### PR TITLE
Add X-Ray, Jaeger and Datadog tracing to App Mesh Inject

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ you can proceed with the Helm installation as described above.
 
 ### App Mesh add-ons
 
-#### Prometheus
+#### Prometheus monitoring
 
 Install App Mesh Prometheus:
 
@@ -120,7 +120,7 @@ helm upgrade -i appmesh-inject eks/appmesh-inject \
 The above configuration will inject the AWS X-Ray daemon sidecar in each pod scheduled to run on the mesh.
 **Note** that you should restart all pods running inside the mesh after enabling tracing.
 
-#### Jaeger
+#### Jaeger tracing
 
 Install App Mesh Jaeger:
 
@@ -147,6 +147,21 @@ helm upgrade -i appmesh-inject eks/appmesh-inject \
 --set tracing.provider=jaeger \
 --set tracing.address=appmesh-jaeger.appmesh-system \
 --set tracing.port=9411
+```
+
+**Note** that you should restart all pods running inside the mesh after enabling tracing.
+
+#### Datadog tracing
+
+Install the Datadog agent in the `appmesh-system` namespace and enable tracing for the App Mesh data plane:
+
+```sh
+helm upgrade -i appmesh-inject eks/appmesh-inject \
+--namespace appmesh-system \
+--set tracing.enabled=true \
+--set tracing.provider=datadog \
+--set tracing.address=datadog.appmesh-system \
+--set tracing.port=8126
 ```
 
 **Note** that you should restart all pods running inside the mesh after enabling tracing.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ helm upgrade -i appmesh-prometheus eks/appmesh-prometheus \
 --set persistentVolumeClaim.claimName=prometheus
 ```
 
+#### AWS X-Ray 
+
+Enable X-Ray tracing for the App Mesh data plane:
+
+```sh
+helm upgrade -i appmesh-inject eks/appmesh-inject \
+--namespace appmesh-system \
+--set tracing.enabled=true \
+--set tracing.provider=x-ray
+```
+
+The above configuration will inject the AWS X-Ray daemon sidecar in each pod scheduled to run on the mesh.
+**Note** that you should restart all pods running inside the mesh after enabling tracing.
+
 #### Jaeger
 
 Install App Mesh Jaeger:
@@ -129,8 +143,13 @@ Enable Jaeger tracing for the App Mesh data plane:
 ```sh
 helm upgrade -i appmesh-inject eks/appmesh-inject \
 --namespace appmesh-system \
---set tracing.jaeger.enabled=true
+--set tracing.enabled=true \
+--set tracing.provider=jaeger \
+--set tracing.address=appmesh-jaeger.appmesh-system \
+--set tracing.port=9411
 ```
+
+**Note** that you should restart all pods running inside the mesh after enabling tracing.
 
 ## License
 

--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: appmesh-inject
 description: AWS App Mesh Inject Helm chart for Kubernetes
 type: application
-version: 0.1.0
-appVersion: 0.1.6
+version: 0.2.0
+appVersion: 0.2.0

--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -42,10 +42,13 @@ spec:
             - -sidecar-cpu-requests={{ .Values.sidecar.resources.requests.cpu }}
             - -sidecar-memory-requests={{ .Values.sidecar.resources.requests.memory }}
             - -init-image={{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
-            {{- if .Values.tracing.jaeger.enabled }}
+            {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "x-ray" ) }}
+            - -inject-xray-sidecar=true
+            {{- end }}
+            {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "jaeger" ) }}
             - -enable-jaeger-tracing=true
-            - -jaeger-address={{ .Values.tracing.jaeger.address }}
-            - -jaeger-port={{ .Values.tracing.jaeger.port }}
+            - -jaeger-address={{ .Values.tracing.address }}
+            - -jaeger-port={{ .Values.tracing.port }}
             {{- end }}
           ports:
             - name: https

--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
             - -sidecar-cpu-requests={{ .Values.sidecar.resources.requests.cpu }}
             - -sidecar-memory-requests={{ .Values.sidecar.resources.requests.memory }}
             - -init-image={{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
+            {{- if .Values.tracing.jaeger.enabled }}
+            - -enable-jaeger-tracing=true
+            - -jaeger-address={{ .Values.tracing.jaeger.address }}
+            - -jaeger-port={{ .Values.tracing.jaeger.port }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 8080

--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -50,6 +50,11 @@ spec:
             - -jaeger-address={{ .Values.tracing.address }}
             - -jaeger-port={{ .Values.tracing.port }}
             {{- end }}
+            {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "datadog" ) }}
+            - -enable-datadog-tracing=true
+            - -datadog-address={{ .Values.tracing.address }}
+            - -datadog-port={{ .Values.tracing.port }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 8080

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: 602401143452.dkr.ecr.REGION.amazonaws.com/amazon/aws-app-mesh-inject
+  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject
   tag: v0.2.0
   pullPolicy: IfNotPresent
 
@@ -65,9 +65,9 @@ mesh:
 tracing:
   # tracing.enabled: `true` if Envoy should be configured tracing
   enabled: false
-  # tracing.provider: can be x-ray or jaeger
+  # tracing.provider: can be x-ray, jaeger or datadog
   provider: x-ray
-  # tracing.address: Jaeger server address (ignored for X-Ray)
+  # tracing.address: Jaeger or Datadog agent server address (ignored for X-Ray)
   address: appmesh-jaeger.appmesh-system
-  # tracing.address: Jaeger Zipkin port (ignored for X-Ray)
+  # tracing.address: Jaeger or Datadog agent server port (ignored for X-Ray)
   port: 9411

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject
-  tag: v0.1.6
+  repository: stefanprodan/aws-app-mesh-inject
+  tag: jaeger.9
   pullPolicy: IfNotPresent
 
 sidecar:
@@ -61,3 +61,12 @@ mesh:
   name: "global"
   # mesh.discovery: The service discovery type to use, can be dns or cloudmap
   discovery: dns
+
+tracing:
+  jaeger:
+    # tracing.jaeger.enabled: `true` if the Envoy sidecar should be configured with Jaeger tracing
+    enabled: false
+    # tracing.jaeger.address: Jaeger server address
+    address: appmesh-jaeger.appmesh-system
+    # tracing.jaeger.port: Jaeger Zipkin port
+    port: 9411

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: 602401143452.dkr.ecr.REGION.amazonaws.com/amazon/aws-app-mesh-inject
-  tag: v0.1.7
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 sidecar:

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -5,14 +5,14 @@
 replicaCount: 1
 
 image:
-  repository: stefanprodan/aws-app-mesh-inject
-  tag: jaeger.9
+  repository: 602401143452.dkr.ecr.REGION.amazonaws.com/amazon/aws-app-mesh-inject
+  tag: v0.1.7
   pullPolicy: IfNotPresent
 
 sidecar:
   image:
-    repository: 111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.11.1.0-prod
+    repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
+    tag: v1.11.2.0-prod
   # sidecar.logLevel: Envoy log level can be info, warn or error
   logLevel: info
   resources:

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -63,10 +63,11 @@ mesh:
   discovery: dns
 
 tracing:
-  jaeger:
-    # tracing.jaeger.enabled: `true` if the Envoy sidecar should be configured with Jaeger tracing
-    enabled: false
-    # tracing.jaeger.address: Jaeger server address
-    address: appmesh-jaeger.appmesh-system
-    # tracing.jaeger.port: Jaeger Zipkin port
-    port: 9411
+  # tracing.enabled: `true` if Envoy should be configured tracing
+  enabled: false
+  # tracing.provider: can be x-ray or jaeger
+  provider: x-ray
+  # tracing.address: Jaeger server address (ignored for X-Ray)
+  address: appmesh-jaeger.appmesh-system
+  # tracing.address: Jaeger Zipkin port (ignored for X-Ray)
+  port: 9411

--- a/stable/appmesh-jaeger/.helmignore
+++ b/stable/appmesh-jaeger/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/appmesh-jaeger/Chart.yaml
+++ b/stable/appmesh-jaeger/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: appmesh-jaeger
+description: AWS App Mesh Jaeger Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 1.14.0

--- a/stable/appmesh-jaeger/templates/NOTES.txt
+++ b/stable/appmesh-jaeger/templates/NOTES.txt
@@ -1,0 +1,3 @@
+AWS App Mesh Jaeger installed!
+Jaeger UI port: 16686
+Jaeger Zipkin port: 9411

--- a/stable/appmesh-jaeger/templates/_helpers.tpl
+++ b/stable/appmesh-jaeger/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "appmesh-jaeger.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "appmesh-jaeger.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "appmesh-jaeger.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "appmesh-jaeger.labels" -}}
+app.kubernetes.io/name: {{ include "appmesh-jaeger.name" . }}
+helm.sh/chart: {{ include "appmesh-jaeger.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "appmesh-jaeger.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "appmesh-jaeger.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/appmesh-jaeger/templates/account.yaml
+++ b/stable/appmesh-jaeger/templates/account.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "appmesh-jaeger.serviceAccountName" . }}
+  labels:
+{{ include "appmesh-jaeger.labels" . | indent 4 }}
+{{- end }}

--- a/stable/appmesh-jaeger/templates/deployment.yaml
+++ b/stable/appmesh-jaeger/templates/deployment.yaml
@@ -35,22 +35,28 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
+            # agent: accept zipkin.thrift over compact thrift protocol (deprecated, used by legacy clients only)
             - containerPort: 5775
               protocol: UDP
+            # agent: accept jaeger.thrift over compact thrift protocol
             - containerPort: 6831
               protocol: UDP
+            # agent: accept jaeger.thrift over binary thrift protocol
             - containerPort: 6832
               protocol: UDP
+            # collector: Zipkin compatible endpoint
             - containerPort: 9411
               protocol: TCP
+            # query: serve frontend
             - containerPort: 16686
               protocol: TCP
-            - containerPort: 14250
+            # agent: serve configs
+            - containerPort: 5778
               protocol: TCP
-            - containerPort: 14267
-              protocol: TCP
+            # collector: accept jaeger.thrift directly from clients
             - containerPort: 14268
               protocol: TCP
+            # collector: Health Check server
             - containerPort: 14269
               protocol: TCP
           env:

--- a/stable/appmesh-jaeger/templates/deployment.yaml
+++ b/stable/appmesh-jaeger/templates/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "appmesh-jaeger.fullname" . }}
+  labels:
+{{ include "appmesh-jaeger.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "appmesh-jaeger.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "appmesh-jaeger.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "14269"
+    spec:
+      serviceAccountName: {{ include "appmesh-jaeger.serviceAccountName" . }}
+      volumes:
+      - name: data
+        {{- if .Values.persistentVolumeClaim.claimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistentVolumeClaim.claimName }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 5775
+              protocol: UDP
+            - containerPort: 6831
+              protocol: UDP
+            - containerPort: 6832
+              protocol: UDP
+            - containerPort: 9411
+              protocol: TCP
+            - containerPort: 16686
+              protocol: TCP
+            - containerPort: 14250
+              protocol: TCP
+            - containerPort: 14267
+              protocol: TCP
+            - containerPort: 14268
+              protocol: TCP
+            - containerPort: 14269
+              protocol: TCP
+          env:
+            - name: MEMORY_MAX_TRACES
+              value: "{{ .Values.memory.maxTraces }}"
+            - name: COLLECTOR_ZIPKIN_HTTP_PORT
+              value: "9411"
+            - name: BADGER_EPHEMERAL
+              value: "false"
+            - name: SPAN_STORAGE_TYPE
+              value: "badger"
+            - name: BADGER_DIRECTORY_VALUE
+              value: "/badger/data"
+            - name: BADGER_DIRECTORY_KEY
+              value: "/badger/key"
+            - name: QUERY_BASE_PATH
+              value:  /jaeger
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 14269
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 14269
+          volumeMounts:
+            - name: data
+              mountPath: /badger
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/appmesh-jaeger/templates/psp.yaml
+++ b/stable/appmesh-jaeger/templates/psp.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "appmesh-jaeger.fullname" . }}
+  labels:
+{{ include "appmesh-jaeger.labels" . | indent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+    - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "appmesh-jaeger.fullname" . }}-psp
+  labels:
+{{ include "appmesh-jaeger.labels" . | indent 4 }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - {{ template "appmesh-jaeger.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "appmesh-jaeger.fullname" . }}-psp
+  labels:
+{{ include "appmesh-jaeger.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "appmesh-jaeger.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "appmesh-jaeger.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/appmesh-jaeger/templates/service.yaml
+++ b/stable/appmesh-jaeger/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "appmesh-jaeger.fullname" . }}
+  labels:
+{{ include "appmesh-jaeger.labels" . | indent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9411
+      targetPort: 9411
+      protocol: TCP
+      name: http-zipkin
+    - port: 16686
+      targetPort: 16686
+      protocol: TCP
+      name: http-ui
+  selector:
+    app.kubernetes.io/name: {{ include "appmesh-jaeger.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/appmesh-jaeger/values.yaml
+++ b/stable/appmesh-jaeger/values.yaml
@@ -1,0 +1,45 @@
+# Default values for appmesh-jaeger.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: jaegertracing/all-in-one
+  tag: 1.14
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
+  create: true
+  # serviceAccount.name: The name of the service account to create or use
+  name: ""
+
+rbac:
+  # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
+  pspEnabled: false
+
+memory:
+  # memory.maxTraces: The amount of traces stored in memory
+  maxTraces: 40000
+
+persistentVolumeClaim:
+  # persistentVolumeClaim.claimName: Specify an existing volume claim to be used for Badger data
+  claimName: ""


### PR DESCRIPTION
* update images to Envoy v1.11.2 and Inject v0.2.0 - resolves #15 
* add X-Ray tracing option to App Mesh Inject - resolves #14
* add Datadog tracing option to App Mesh Inject - resolves #18
* add App Mesh Jaeger chart - resolves #9
* add Jaeger tracing option to App Mesh Inject
* add tracing documentation to readme


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
