### PR TITLE
Update App Mesh controller to v0.2.0

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: appmesh-controller
 description: The AWS App Mesh controller Helm chart for Kubernetes
 type: application
-version: 0.1.0
-appVersion: 0.1.2
+version: 0.2.0
+appVersion: 0.2.0

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/app-mesh-controller
-  tag: v0.1.2
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/appmesh-prometheus/Chart.yaml
+++ b/stable/appmesh-prometheus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: appmesh-prometheus
 description: AWS App Mesh Prometheus Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 2.12.0


### PR DESCRIPTION
This PR updates the App Mesh controller image to v0.2.0 and bumps the chart version for App Mesh controller and Prometheus.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
