### PR TITLE
Fix Prometheus persistent volume mount ownership

### DIFF
--- a/stable/appmesh-prometheus/templates/deployment.yaml
+++ b/stable/appmesh-prometheus/templates/deployment.yaml
@@ -32,6 +32,15 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+      initContainers:
+        - name: chown
+          image: alpine:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - chown 65534:65534 /mount;
+          volumeMounts:
+            - name: data-volume
+              mountPath: /mount
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -51,6 +60,10 @@ spec:
             httpGet:
               path: /-/ready
               port: http
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
           volumeMounts:
             - name: config-volume
               mountPath: /etc/prometheus


### PR DESCRIPTION
Fix: #21 by mounting the PV in an init container that sets the ownership to the UID used by the Prometheus container.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
