### PR TITLE
Adding chart for the AWS CNI

### DIFF
--- a/stable/aws-vpc-cni/.helmignore
+++ b/stable/aws-vpc-cni/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
   - name: Nicholas Turner
     url: https://github.com/nckturner
     email: nckturner@users.noreply.github.com
-  - name: Stefan Prodan
-    url: https://github.com/stefanprodan
-    email: stefanprodan@users.noreply.github.com
+  - name: Claes Mogren
+    url: https://github.com/mogren
+    email: mogren@users.noreply.github.com
 engine: gotpl

--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+name: aws-vpc-cni
+version: 1.0.0
+appVersion: "v1.5.3"
+description: A Helm chart for the AWS VPC CNI
+home: https://github.com/aws/amazon-vpc-cni-k8s
+sources:
+  - https://github.com/aws/amazon-vpc-cni-k8s
+description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+keywords:
+  - eks
+  - cni
+  - networking
+  - vpc
+maintainers:
+  - name: Nicholas Turner
+    url: https://github.com/nckturner
+    email: nckturner@users.noreply.github.com
+  - name: Stefan Prodan
+    url: https://github.com/stefanprodan
+    email: stefanprodan@users.noreply.github.com
+engine: gotpl

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -1,0 +1,62 @@
+# AWS VPC CNI
+
+This chart installs the AWS CNI Daemonset: https://github.com/aws/amazon-vpc-cni-k8s
+
+## Prerequisites
+
+- Kubernetes 1.11+ running on AWS
+
+## Installing the Chart
+
+First add the EKS repository to Helm:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+To install the chart with the release name `aws-node` and default configuration:
+
+```shell
+$ helm install --name aws-node --namespace kube-system stable/aws-vpc-cni
+```
+
+To install into an EKS cluster where the CNI is already installed, you can run:
+
+```shell
+helm upgrade --install --recreate-pods --force aws-node --namespace kube-system stable/aws-vpc-cni
+```
+
+If you receive an error similar to `Error: release aws-node failed: <resource> "aws-node" already exists`, simply rerun the above command.
+
+## Configuration
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter               | Description                                             | Default                             |
+| ------------------------|---------------------------------------------------------|-------------------------------------|
+| `affinity`              | Map of node/pod affinities                              | `{}`                                |
+|  `env`                  | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG]` |
+| `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
+| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
+| `image.tag`             | Image tag                                               | `v1.5.3`                            |
+| `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
+| `image.override`        | A custom docker image to use                            | `nil`                               |
+| `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
+| `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
+| `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |
+| `podSecurityContext`    | Pod Security Context                                    | `{}`                                |
+| `podAnnotations`        | annotations to add to each pod                          | `{}`                                |
+| `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
+| `probesEnabled`         | Enable liveness and readiness probes                    | `false`                             |
+| `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
+| `securityContext`       | Container Security context                              | `privileged: true`                  |
+| `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
+| `tolerations`           | Optional deployment tolerations                         | `[]`                                |
+| `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```shell
+$ helm install --name aws-node --namespace kube-system stable/aws-vpc-cni --values values.yaml
+```

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -14,19 +14,19 @@ First add the EKS repository to Helm:
 helm repo add eks https://aws.github.io/eks-charts
 ```
 
-To install the chart with the release name `aws-node` and default configuration:
+To install the chart with the release name `aws-vpc-cni` and default configuration:
 
 ```shell
-$ helm install --name aws-node --namespace kube-system stable/aws-vpc-cni
+$ helm install --name aws-vpc-cni --namespace kube-system stable/aws-vpc-cni
 ```
 
 To install into an EKS cluster where the CNI is already installed, you can run:
 
 ```shell
-helm upgrade --install --recreate-pods --force aws-node --namespace kube-system stable/aws-vpc-cni
+helm upgrade --install --recreate-pods --force aws-vpc-cni --namespace kube-system stable/aws-vpc-cni
 ```
 
-If you receive an error similar to `Error: release aws-node failed: <resource> "aws-node" already exists`, simply rerun the above command.
+If you receive an error similar to `Error: release aws-vpc-cni failed: <resource> "aws-node" already exists`, simply rerun the above command.
 
 ## Configuration
 
@@ -58,5 +58,5 @@ The following table lists the configurable parameters for this chart and their d
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 
 ```shell
-$ helm install --name aws-node --namespace kube-system stable/aws-vpc-cni --values values.yaml
+$ helm install --name aws-vpc-cni --namespace kube-system stable/aws-vpc-cni --values values.yaml
 ```

--- a/stable/aws-vpc-cni/templates/NOTES.txt
+++ b/stable/aws-vpc-cni/templates/NOTES.txt
@@ -1,0 +1,4 @@
+
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+
+kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "aws-vpc-cni.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/aws-vpc-cni/templates/_helpers.tpl
+++ b/stable/aws-vpc-cni/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-vpc-cni.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-vpc-cni.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-vpc-cni.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-vpc-cni.labels" -}}
+app.kubernetes.io/name: {{ include "aws-vpc-cni.name" . }}
+helm.sh/chart: {{ include "aws-vpc-cni.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+k8s-app: aws-node
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-vpc-cni.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "aws-vpc-cni.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/aws-vpc-cni/templates/clusterrole.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "aws-vpc-cni.fullname" . }}
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+      - crd.k8s.amazonaws.com
+    resources:
+      - "*"
+      - namespaces
+    verbs:
+      - "*"
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+    verbs: ["list", "watch"]

--- a/stable/aws-vpc-cni/templates/clusterrolebinding.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "aws-vpc-cni.fullname" . }}
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aws-vpc-cni.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "aws-vpc-cni.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
+++ b/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -1,0 +1,115 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ include "aws-vpc-cni.fullname" . }}
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+spec:
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-vpc-cni.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "aws-vpc-cni.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        k8s-app: aws-node
+    spec:
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "beta.kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "beta.kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+      serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}
+      hostNetwork: true
+      tolerations:
+        - operator: Exists
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: aws-node
+          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.image.region }}.amazonaws.com/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 61678
+              name: metrics
+{{- if .Values.probesEnabled }}
+          readinessProbe:
+            initialDelaySeconds: 25
+            exec:
+              command: ["/app/grpc_health_probe", "-addr=:50051"]
+          livenessProbe:
+            initialDelaySeconds: 25
+            exec:
+              command: ["/app/grpc_health_probe", "-addr=:50051"]
+{{- end }}
+          env:
+{{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /host/var/log
+              name: log-dir
+            - mountPath: /var/run/docker.sock
+              name: dockersock
+      volumes:
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: log-dir
+          hostPath:
+            path: /var/log
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/aws-vpc-cni/templates/serviceaccount.yaml
+++ b/stable/aws-vpc-cni/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "aws-vpc-cni.serviceAccountName" . }}
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+{{- end -}}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -1,0 +1,54 @@
+# Default values for aws-vpc-cni.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This default name override is to maintain backwards compatability with
+# existing naming
+nameOverride: aws-node
+
+image:
+  region: us-west-2
+  tag: v1.5.3
+  pullPolicy: Always
+  # Set to use custom image
+  # override: "repo/org/image:tag"
+
+# The CNI supports a number of environment variable settings
+# See https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables
+env:
+  AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG
+
+imagePullSecrets: []
+
+fullnameOverride: "aws-node"
+
+probesEnabled: false
+
+priorityClassName: system-node-critical
+
+podSecurityContext: {}
+
+podAnnotations: {}
+
+securityContext:
+  privileged: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+resources:
+  requests:
+    cpu: 10m
+
+updateStrategy:
+  type: RollingUpdate
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This is essentially a copy of [v1.5.3](https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.5.3/config/v1.5/aws-k8s-cni.yaml) release YAML but with the standard Helm labels and options added.

I tested it and it works for me. I did a YAML diff of a pod and the daemonset between what this chart produces and what's in an EKS cluster by default and there's no major differences apart from labels and `securityContext.procMount: Default` but this isn't in the release YAML so I guess it's not required.

Some notes....

1. **Naming**: `amazon-vpc-cni-k8s` is not a good name for a chart and neither is `aws-node` so I've chosen `aws-vpc-cni` and set the default name override options to `aws-node` so as to be compatible with current EKS design.

2. **Installation**:  To install it over the top of the existing `aws-node` resources is super easy. Helm just overwrites them. See the README 😃

3. **Resource labels**: These are the default Helm labels for any change but I also added `k8s-app: aws-node` for backwards compatibility.

Related issues:
https://github.com/aws/amazon-vpc-cni-k8s/issues/336
https://github.com/aws/amazon-vpc-cni-k8s/issues/679

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.