### PR TITLE
Added settings to support statsd and stats-tags

### DIFF
--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             - -sidecar-cpu-requests={{ .Values.sidecar.resources.requests.cpu }}
             - -sidecar-memory-requests={{ .Values.sidecar.resources.requests.memory }}
             - -init-image={{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
+            - -enable-stats-tags={{ .Values.stats.tagsEnabled }}
+            - -enable-statsd={{ .Values.stats.statsdEnabled }}
             {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "x-ray" ) }}
             - -inject-xray-sidecar=true
             {{- end }}

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -72,3 +72,9 @@ tracing:
   address: appmesh-jaeger.appmesh-system
   # tracing.address: Jaeger or Datadog agent server port (ignored for X-Ray)
   port: 9411
+
+stats:
+  # stats.tagsEnabled: `true` if Envoy should include app-mesh tags
+  tagsEnabled: false
+  # stats.statsdEnabled: `true` if Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125
+  statsdEnabled: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will enable stats-tags and statsd integration for appmesh-inject.

Verified by applying the helm chart on my cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
