### PR TITLE
Fixes for App Mesh inject and Node termination charts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,13 @@ jobs:
             curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar xz && sudo mv kubeval /bin/kubeval
       - run:
           name: Install helm
-          command: curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.16.0-linux-amd64.tar.gz | tar xz && sudo mv linux-amd64/helm /bin/helm && sudo rm -rf linux-amd64
+          command: curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.16.1-linux-amd64.tar.gz | tar xz && sudo mv linux-amd64/helm /bin/helm && sudo rm -rf linux-amd64
       - run:
           name: Initialize helm
           command:  helm init --client-only --kubeconfig=$HOME/.kube/kubeconfig
       - run:
           name: Install helmv3
-          command: curl -sSL https://get.helm.sh/helm-v3.0.0-rc.3-linux-amd64.tar.gz | tar xz && sudo mv linux-amd64/helm /bin/helmv3 && sudo rm -rf linux-amd64
+          command: curl -sSL https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz | tar xz && sudo mv linux-amd64/helm /bin/helmv3 && sudo rm -rf linux-amd64
       - run:
           name: Lint stable charts
           command: |

--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-inject
 description: App Mesh Inject Helm chart for Kubernetes
-version: 0.6.0
-appVersion: 0.3.0
+version: 0.7.0
+appVersion: 0.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -7,7 +7,7 @@ region: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject
-  tag: v0.3.0
+  tag: v0.3.1
   pullPolicy: IfNotPresent
 
 sidecar:

--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.2.0
+version: 0.3.0
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/templates/clusterrolebinding.yaml
+++ b/stable/aws-node-termination-handler/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "aws-node-termination-handler.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "aws-node-termination-handler.fullname" . }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: 1.0.0
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/test/lib/kind.sh
+++ b/test/lib/kind.sh
@@ -7,8 +7,8 @@ set -o errexit
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KIND_VERSION=v0.5.1
 HELM_MODE="${HELM_MODE:-v2}"
-HELM2_VERSION=v2.16.0
-HELM3_VERSION=v3.0.0-rc.3
+HELM2_VERSION=v2.16.1
+HELM3_VERSION=v3.0.0
 
 function installKubernetes() {
   echo ">>> Installing kubectl"


### PR DESCRIPTION
- fix Jaeger tracing injection by updating App Mesh inject to v0.3.1
- fix #43 by using the release namespace in cluster role binding and by setting the image tag to v1.0.0
- update Helm e2e to latest stable versions (v2.16.1 and v3.0.0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
