### PR TITLE
Delete Release.Namespace for Helm v3 for aws-node-termination-handler

### DIFF
--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -16,7 +16,7 @@ Install AWS Node Termination Handler:
 To install the chart with the release name aws-node-termination-handler and default configuration:
 
 ```sh
-helm install --name aws-node-termination-handler \
+helm install aws-node-termination-handler \
   --namespace kube-system eks/aws-node-termination-handler
 ```
 

--- a/stable/aws-node-termination-handler/templates/clusterrolebinding.yaml
+++ b/stable/aws-node-termination-handler/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "aws-node-termination-handler.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: {{ include "aws-node-termination-handler.fullname" . }}

--- a/stable/aws-node-termination-handler/templates/psp.yaml
+++ b/stable/aws-node-termination-handler/templates/psp.yaml
@@ -53,5 +53,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "aws-node-termination-handler.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: default
 {{- end }}


### PR DESCRIPTION
*Description of changes:*

Current chart no longer works on helm version3, since `Release.Namespace` and `Release.Time` deleted on Helm v3.

Running current chart in Helm v3 fails with following message.

```bash
$ helm install aws-node-termination-handler --namespace kube-system eks/aws-node-termination-handler

Error: ClusterRoleBinding.rbac.authorization.k8s.io "aws-node-termination-handler" is invalid: subjects[0].namespace: Required value
```

