### PR TITLE
Update README to fix broken command

### DIFF
--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -17,7 +17,7 @@ To install the chart with the release name aws-node-termination-handler and defa
 
 ```sh
 helm install --name aws-node-termination-handler \
-  --namespace kube-system eks/aws-node-termination-handler
+  --set namespace=kube-system eks/aws-node-termination-handler
 ```
 
 To install into an EKS cluster where the Node Termination Handler is already installed, you can run:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```
helm install --name aws-node-termination-handler \
  --namespace kube-system eks/aws-node-termination-handler
```
Results in the following error:
```
Error: release aws-node-termination-handler failed: ClusterRoleBinding.rbac.authorization.k8s.io "aws-node-termination-handler" is invalid: subjects[0].namespace: Required value
```
Changing to a working command. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
