### PR TITLE
Roll back Envoy version

### DIFF
--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-inject
 description: App Mesh Inject Helm chart for Kubernetes
-version: 0.8.0
+version: 0.9.0
 appVersion: 0.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -13,7 +13,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.12.2.0-prod
+    tag: v1.12.1.1-prod
   # sidecar.logLevel: Envoy log level can be info, warn or error
   logLevel: info
   resources:


### PR DESCRIPTION
*Issue #, if available:*
We need to roll back the Envoy image due to a reported crash: https://github.com/aws/aws-app-mesh-roadmap/issues/144

*Description of changes:*
Reverting the update to v1.12.2.0-prod. Rolling back to v1.12.1.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
