### PR TITLE
Adding annotation for aws-node-termination-handler service account

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -1,6 +1,6 @@
 # AWS Node Termination Handler
 
-AWS Node Termination Handler Helm chart for Kubernetes. For more information on this project see the project repo at https://github.com/aws/aws-node-termination-handler. 
+AWS Node Termination Handler Helm chart for Kubernetes. For more information on this project see the project repo at https://github.com/aws/aws-node-termination-handler.
 
 ## Prerequisites
 
@@ -67,3 +67,4 @@ Parameter | Description | Default
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
+`serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`

--- a/stable/aws-node-termination-handler/templates/serviceaccount.yaml
+++ b/stable/aws-node-termination-handler/templates/serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aws-node-termination-handler.serviceAccountName" . }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
 {{ include "aws-node-termination-handler.labels" . | indent 4 }}
 {{- end -}}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -52,6 +52,8 @@ serviceAccount:
   # The name of the service account to use. If namenot set and create is true,
   # a name is generated using fullname template
   name:
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
 
 rbac:
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created


### PR DESCRIPTION
In order to be able to assign the related role
https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
