### PR TITLE
Grafana helm deployment should not be called prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ helm upgrade -i appmesh-prometheus eks/appmesh-prometheus \
 Install App Mesh Grafana:
 
 ```sh
-helm upgrade -i appmesh-prometheus eks/appmesh-grafana \
+helm upgrade -i appmesh-grafana eks/appmesh-grafana \
 --namespace appmesh-system
 ```
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* 

Small README update.

The deployment of the grafana helm chart currently uses the same name as the prometheus deployment (they both use `appmesh-prometheus`). This causes them to overwrite each other, meaning they can't both be installed at the same time. 

This PR resolves that by naming the grafana deployment `appmesh-grafana`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
