### PR TITLE
aws-node-termination-handler v1.1.0 release w/ nodeTerminationGracePeriod config

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.3.1
-appVersion: 1.0.0
+version: 0.4.0
+appVersion: 1.1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -53,8 +53,11 @@ Parameter | Description | Default
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
 `deleteLocalData` | Tells kubectl to continue even if there are pods using emptyDir (local data that will be deleted when the node is drained). | `false`
-`gracePeriod` | The time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used. | `30`
+`gracePeriod` | (DEPRECATED: Renamed to podTerminationGracePeriod) The time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used. | `30`
+`podTerminationGracePeriod` | The time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used. | `30`
+`nodeTerminationGracePeriod` | Period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event. | `120`
 `ignoreDaemonsSets` | Causes kubectl to skip daemon set managed pods | `true`
+`instanceMetadataURL` | The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing. | `http://169.254.169.254:80`
 `affinity` | node/pod affinities | None
 `podSecurityContext` | Pod Security Context | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -68,6 +68,12 @@ spec:
             value: {{ .Values.ignoreDaemonSets | quote }}
           - name: GRACE_PERIOD
             value: {{ .Values.gracePeriod | quote }}
+          - name: POD_TERMINATION_GRACE_PERIOD
+            value: {{ .Values.podTerminationGracePeriod | quote }}
+          - name: INSTANCE_METADATA_URL
+            value: {{ .Values.instanceMetadataURL | quote }}
+          - name: NODE_TERMINATION_GRACE_PERIOD
+            value: {{ .Values.nodeTerminationGracePeriod | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.0.0
+  tag: v1.1.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -34,9 +34,16 @@ deleteLocalData: false
 # ignoreDaemonSets causes kubectl to skip Daemon Set managed pods.
 ignoreDaemonSets: true
 
-# gracePeriod is time in seconds given to each pod to terminate gracefully.
+# gracePeriod (DEPRECATED - use podTerminationGracePeriod instead) is time in seconds given to each pod to terminate gracefully.
 # If negative, the default value specified in the pod will be used.
-gracePeriod: 30
+gracePeriod: ""
+podTerminationGracePeriod: ""
+
+# nodeTerminationGracePeriod specifies the period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event.
+nodeTerminationGracePeriod: ""
+
+# instanceMetadataURL is used to override the default metadata URL (default: http://169.254.169.254:80)
+instanceMetadataURL: ""
 
 # nodeSelector tells the daemonset where to place the node-termination-handler
 # pods. By default, this value is empty and every node will receive a pod.


### PR DESCRIPTION
aws-node-termination-handler: add nodeTerminationGracePeriod config and update versions for 1.1.0 release

*Issue #, if available:*

*Description of changes:*

- Add nodeTerminationGracePeriod Configuration value for daemonset
- Add new config key for podTerminationGracePeriod and put gracePeriod config on deprecation path
- Set values file to empty string for env vars to pickup CLI defaults 
- up chart version and app version



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
