### PR TITLE
aws-node-termination-handler: v1.2.0 release

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.4.0
-appVersion: 1.1.0
+version: 0.5.0
+appVersion: 1.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -58,6 +58,9 @@ Parameter | Description | Default
 `nodeTerminationGracePeriod` | Period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event. | `120`
 `ignoreDaemonsSets` | Causes kubectl to skip daemon set managed pods | `true`
 `instanceMetadataURL` | The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing. | `http://169.254.169.254:80`
+`webhookURL` | Posts event data to URL upon instance interruption action | ``
+`webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
+`webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
 `affinity` | node/pod affinities | None
 `podSecurityContext` | Pod Security Context | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
@@ -71,3 +74,5 @@ Parameter | Description | Default
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
 `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`
+`procUptimeFile` | (Used for Testing) Specify the uptime file | `/proc/uptime`
+

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "aws-node-termination-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-node-termination-handler.labels" . | indent 4 }}
 spec:
@@ -24,6 +25,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         k8s-app: aws-node-termination-handler
     spec:
+      volumes:
+        - name: "uptime"
+          hostPath:
+            path: "{{ .Values.procUptimeFile }}"
       priorityClassName: "{{ .Values.priorityClassName }}"
       affinity:
         nodeAffinity:
@@ -41,10 +46,14 @@ spec:
                     values:
                       - amd64
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
+      hostNetwork: true
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: "uptime"
+              mountPath: "/proc/uptime"
           env:
           - name: NODE_NAME
             valueFrom:
@@ -74,6 +83,18 @@ spec:
             value: {{ .Values.instanceMetadataURL | quote }}
           - name: NODE_TERMINATION_GRACE_PERIOD
             value: {{ .Values.nodeTerminationGracePeriod | quote }}
+          - name: WEBHOOK_URL
+            value: {{ .Values.webhookURL | quote }}
+          - name: WEBHOOK_HEADERS
+            value: {{ .Values.webhookHeaders | quote }}
+          - name: WEBHOOK_TEMPLATE
+            value: {{ .Values.webhookTemplate | quote }}
+          - name: DRY_RUN
+            value: {{ .Values.dryRun | quote }}
+          - name: ENABLE_SPOT_INTERRUPTION_DRAINING
+            value: {{ .Values.enableSpotInterruptionDraining | quote }}
+          - name: ENABLE_SCHEDULED_EVENT_DRAINING
+            value: {{ .Values.enableScheduledEventDraining | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/stable/aws-node-termination-handler/templates/serviceaccount.yaml
+++ b/stable/aws-node-termination-handler/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aws-node-termination-handler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -27,12 +27,21 @@ resources:
     memory: "128Mi"
     cpu: "100m"
 
+## enableSpotInterruptionDraining If true, drain nodes when the spot interruption termination notice is receieved
+enableSpotInterruptionDraining: ""
+
+## enableScheduledEventDraining [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event
+enableScheduledEventDraining: ""
+
+## dryRun tells node-termination-handler to only log calls to kubernetes control plane
+dryRun: false
+
 # deleteLocalData tells kubectl to continue even if there are pods using
 # emptyDir (local data that will be deleted when the node is drained).
-deleteLocalData: false
+deleteLocalData: ""
 
 # ignoreDaemonSets causes kubectl to skip Daemon Set managed pods.
-ignoreDaemonSets: true
+ignoreDaemonSets: ""
 
 # gracePeriod (DEPRECATED - use podTerminationGracePeriod instead) is time in seconds given to each pod to terminate gracefully.
 # If negative, the default value specified in the pod will be used.
@@ -42,8 +51,20 @@ podTerminationGracePeriod: ""
 # nodeTerminationGracePeriod specifies the period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event.
 nodeTerminationGracePeriod: ""
 
+# webhookURL if specified, posts event data to URL upon instance interruption action.
+webhookURL: ""
+
+# webhookHeaders if specified, replaces the default webhook headers.
+webhookHeaders: ""
+
+# webhookTemplate if specified, replaces the default webhook message template.
+webhookTemplate: ""
+
 # instanceMetadataURL is used to override the default metadata URL (default: http://169.254.169.254:80)
 instanceMetadataURL: ""
+
+# (TESTING USE): Mount path for uptime file
+procUptimeFile: "/proc/uptime"
 
 # nodeSelector tells the daemonset where to place the node-termination-handler
 # pods. By default, this value is empty and every node will receive a pod.


### PR DESCRIPTION
*Issue #, if available:*
N/A

# aws-node-termination-handler v1.2.0 release

*Description of changes:*
This is an updated helm chart for the aws-node-termination-handler v1.2.0 release.

The release includes feature flags on the CLI and chart, a dry-run option, webhook configuration options, and a new volume mount for /proc/uptime. 

This also defaults args to the empty string which will take the CLI defaults. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
