### PR TITLE
Add option to set up pod annotations for appmesh controller

### DIFF
--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -38,3 +38,6 @@ rbac:
   create: true
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
+
+# kiam-role name in case you want to annotate the pods to use kiam to get the AWS role
+kiam-role: ""

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -27,6 +27,8 @@ tolerations: []
 
 affinity: {}
 
+podAnnotations: {}
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true
@@ -38,6 +40,3 @@ rbac:
   create: true
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
-
-# kiam-role name in case you want to annotate the pods to use kiam to get the AWS role
-kiam-role: ""

--- a/stable/appmesh-inject/README.md
+++ b/stable/appmesh-inject/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `resources.limits/memory` | pod memory limit | `1Gi`
 `affinity` | node/pod affinities | None
 `nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
@@ -82,4 +83,3 @@ Parameter | Description | Default
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`
 `tracing.port` |  Jaeger or Datadog agent port (ignored for X-Ray) | `9411`
-`kiam-role` |  The role name in case your cluster set AWS permissions using kiam  |  `""`

--- a/stable/appmesh-inject/README.md
+++ b/stable/appmesh-inject/README.md
@@ -82,3 +82,4 @@ Parameter | Description | Default
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`
 `tracing.port` |  Jaeger or Datadog agent port (ignored for X-Ray) | `9411`
+`kiam-role` |  The role name in case your cluster set AWS permissions using kiam  |  `""`

--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/part-of: appmesh
       annotations:
         prometheus.io/scrape: "false"
+        {{- if index .Values "kiam-role" }}
+        iam.amazonaws.com/role: {{ index .Values "kiam-role" }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "appmesh-inject.serviceAccountName" . }}
       volumes:

--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
         app.kubernetes.io/part-of: appmesh
       annotations:
         prometheus.io/scrape: "false"
-        {{- if index .Values "kiam-role" }}
-        iam.amazonaws.com/role: {{ index .Values "kiam-role" }}
+        {{- if .Values.podAnnotations }}
+        {{- range $key, $value := .Values.podAnnotations }}
+          {{ $key }}: {{ $value | quote }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "appmesh-inject.serviceAccountName" . }}


### PR DESCRIPTION
Issue #, if available:
No issue

Description of changes:

Add option in appmesh controller chart to be able to define pod annotations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: pipo02mix <fernando@giantswarm.io>
