### PR TITLE
Add pod annotation to appmesh-controller deployment

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -80,6 +80,7 @@ Parameter | Description | Default
 `resources.limits/memory` | pod memory limit | `1Gi`
 `affinity` | node/pod affinities | None
 `nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -18,6 +18,11 @@ spec:
         app.kubernetes.io/part-of: appmesh
       annotations:
         prometheus.io/scrape: "true"
+        {{- if .Values.podAnnotations }}
+        {{- range $key, $value := .Values.podAnnotations }}
+          {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "appmesh-controller.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
Signed-off-by: pipo02mix <fernando@giantswarm.io>

Issue #, if available:
None

Description of changes:

In previous [PR](https://github.com/aws/eks-charts/pull/64) I added pod annotation to appmesh-inject, but it is needed in appmesh-controller which perform the actions against AWS API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
