### PR TITLE
Allow users to set log verbosity (level) for appmesh-controller

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -74,6 +74,7 @@ Parameter | Description | Default
 `image.repository` | image repository | ` 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/app-mesh-controller`
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
+`log.level` | controller log level, possible values are `info` and `debug`  | `info`
 `resources.requests/cpu` | pod CPU request | `100m`
 `resources.requests/memory` | pod memory request | `64Mi`
 `resources.limits/cpu` | pod CPU limit | `2000m`

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -32,8 +32,10 @@ spec:
             {{- if .Values.region }}
             - --aws-region={{ .Values.region }}
             {{- end }}
-            {{- if .Values.logging.verbosity }}
-            - --v={{ .Values.logging.verbosity  }}
+            {{- if eq .Values.log.level "debug" }}
+            - --v=4
+            {{- else if eq .Values.log.level "info" }}
+            - --v=0
             {{- end }}
           livenessProbe:
             exec:

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
             {{- if .Values.region }}
             - --aws-region={{ .Values.region }}
             {{- end }}
+            {{- if .Values.logging.verbosity }}
+            - --v={{ .Values.logging.verbosity  }}
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -40,3 +40,7 @@ rbac:
   create: true
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
+
+logging:
+  #logging.verbosity: <=3 (INFO), >=4 (DEBUG)
+  verbosity: 0

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -41,6 +41,6 @@ rbac:
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
 
-logging:
-  #logging.verbosity: <=3 (INFO), >=4 (DEBUG)
-  verbosity: 0
+log:
+  #log.level: info (default), debug
+  level: "info"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Tested with debug and info level
```
helm upgrade -i appmesh-controller ./stable/appmesh-controller \
--namespace appmesh-system \
--set logging.verbosity=4
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
