### PR TITLE
bump cni default to 1.6.0

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.2
+version: 1.0.3
 appVersion: "v1.6.0"
 description: A Helm chart for the AWS VPC CNI
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
 version: 1.0.2
-appVersion: "v1.5.5"
+appVersion: "v1.6.0"
 description: A Helm chart for the AWS VPC CNI
 home: https://github.com/aws/amazon-vpc-cni-k8s
 sources:

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -35,7 +35,7 @@ The following table lists the configurable parameters for this chart and their d
 | Parameter               | Description                                             | Default                             |
 | ------------------------|---------------------------------------------------------|-------------------------------------|
 | `affinity`              | Map of node/pod affinities                              | `{}`                                |
-|  `env`                  | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG]` |
+|  `env`                  | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG, AWS_VPC_K8S_CNI_VETHPREFIX: eni, AWS_VPC_ENI_MTU: "9001"]` |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.tag`             | Image tag                                               | `v1.5.3`                            |

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -78,6 +78,8 @@ spec:
               name: log-dir
             - mountPath: /var/run/docker.sock
               name: dockersock
+            - mountPath: /var/run/dockershim.sock
+              name: dockershim
       volumes:
         - name: cni-bin-dir
           hostPath:
@@ -91,6 +93,9 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
+        - name: dockershim
+          hostPath:
+            path: /var/run/dockershim.sock
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -56,6 +56,14 @@ spec:
           ports:
             - containerPort: 61678
               name: metrics
+          readinessProbe:
+            exec:
+              command: ["/app/grpc-health-probe", "-addr=:50051"]
+            initialDelaySeconds: 35
+          livenessProbe:
+            exec:
+              command: ["/app/grpc-health-probe", "-addr=:50051"]
+            initialDelaySeconds: 35
           env:
 {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 image:
   region: us-west-2
-  tag: v1.5.5
+  tag: v1.6.0
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -17,6 +17,8 @@ image:
 # See https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables
 env:
   AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG
+  AWS_VPC_K8S_CNI_VETHPREFIX: eni
+  AWS_VPC_ENI_MTU: "9001"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
Description of changes:

bumping the default version to 1.6.0 and including the dockershim volume mount

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
