### PR TITLE
aws-node-termination-handler: default rbac to true

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.5.1
+version: 0.6.0
 appVersion: 1.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -80,4 +80,4 @@ serviceAccount:
 
 rbac:
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
-  pspEnabled: false
+  pspEnabled: true


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This change sets pspEnabled as default true so that rbac resources can be generated. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
