### PR TITLE
Update aws-vpc-cni to 1.6.0

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.2
-appVersion: "v1.5.5"
+version: 1.0.3
+appVersion: "v1.6.0"
 description: A Helm chart for the AWS VPC CNI
 home: https://github.com/aws/amazon-vpc-cni-k8s
 sources:

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -35,10 +35,10 @@ The following table lists the configurable parameters for this chart and their d
 | Parameter               | Description                                             | Default                             |
 | ------------------------|---------------------------------------------------------|-------------------------------------|
 | `affinity`              | Map of node/pod affinities                              | `{}`                                |
-|  `env`                  | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG]` |
+|  `env`                  | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG, AWS_VPC_K8S_CNI_VETHPREFIX: eni, AWS_VPC_ENI_MTU: "9001"]` |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.5.3`                            |
+| `image.tag`             | Image tag                                               | `v1.6.0`                            |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -38,6 +38,10 @@ spec:
                     operator: In
                     values:
                       - amd64
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
       serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}
       automountServiceAccountToken: true
       hostNetwork: true
@@ -56,6 +60,14 @@ spec:
           ports:
             - containerPort: 61678
               name: metrics
+          readinessProbe:
+            exec:
+              command: ["/app/grpc-health-probe", "-addr=:50051"]
+            initialDelaySeconds: 35
+          livenessProbe:
+            exec:
+              command: ["/app/grpc-health-probe", "-addr=:50051"]
+            initialDelaySeconds: 35
           env:
 {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -78,6 +90,8 @@ spec:
               name: log-dir
             - mountPath: /var/run/docker.sock
               name: dockersock
+            - mountPath: /var/run/dockershim.sock
+              name: dockershim
       volumes:
         - name: cni-bin-dir
           hostPath:
@@ -91,6 +105,9 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
+        - name: dockershim
+          hostPath:
+            path: /var/run/dockershim.sock
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 image:
   region: us-west-2
-  tag: v1.5.5
+  tag: v1.6.0
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"
@@ -17,6 +17,8 @@ image:
 # See https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables
 env:
   AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG
+  AWS_VPC_K8S_CNI_VETHPREFIX: eni
+  AWS_VPC_ENI_MTU: "9001"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
Issue #, if available:  This resolves the comments in PR #72 

Description of changes:
AWS announced that the aws-vpc-cni plugin has been updated
to 1.6.0 and will be provided by default in EKS hosts. We
should update this chart so that it runs 1.6.0 by default.
I know there is already an open PR for this, but the author
has not addressed any of the input for weeks now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
