### PR TITLE
upgrade chart to support helm 3

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.1.0
+version: 1.0.0
 appVersion: 3.8.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -5,6 +5,7 @@ This chart installs Calico on AWS: https://docs.aws.amazon.com/eks/latest/usergu
 ## Prerequisites
 
 - Kubernetes 1.11+ running on AWS
+- Helm 3
 
 ## Installing the Chart
 
@@ -12,12 +13,6 @@ First add the EKS repository to Helm:
 
 ```shell
 helm repo add eks https://aws.github.io/eks-charts
-```
-
-Install the Calico CRDs:
-
-```shell
-kubectl apply -k github.com/aws/eks-charts/stable/aws-calico//crds?ref=master
 ```
 
 To install the chart with the release name `aws-calico` and default configuration:

--- a/stable/aws-calico/crds/kustomization.yaml
+++ b/stable/aws-calico/crds/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- crds.yaml


### PR DESCRIPTION
This upgrades the chart to support helm3. This in turn means that you don't have to run any manual steps before helm apply to create CRDs.
