### PR TITLE
NTH - Add image.pullSecrets variable for private docker registries

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.6.0
-appVersion: 1.2.0
+version: 0.7.0
+appVersion: 1.3.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -52,6 +52,7 @@ Parameter | Description | Default
 `image.repository` | image repository | `amazon/aws-node-termination-handler`
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
+`image.pullSecrets` | image pull secrets (for private docker registries) | `[]`
 `deleteLocalData` | Tells kubectl to continue even if there are pods using emptyDir (local data that will be deleted when the node is drained). | `false`
 `gracePeriod` | (DEPRECATED: Renamed to podTerminationGracePeriod) The time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used. | `30`
 `podTerminationGracePeriod` | The time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used. | `30`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -101,6 +101,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.2.0
+  tag: v1.3.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -6,6 +6,7 @@ image:
   repository: amazon/aws-node-termination-handler
   tag: v1.2.0
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Merging this PR from NTH repo https://github.com/aws/aws-node-termination-handler/pull/105 providing the ability to use private docker registries

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
