### PR TITLE
new NTH value for dnsPolicy

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.0
+version: 0.7.1
 appVersion: 1.3.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `podAnnotations` | annotations to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`
 `resources` | Resources for the pods | `requests.cpu: 50m, requests.memory: 64Mi, limits.cpu: 100m, limits.memory: 128Mi`
+`dnsPolicy` | DaemonSet DNS policy | `ClusterFirstWithHostNet`
 `nodeSelector` | Tells the daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
                       - amd64
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
       hostNetwork: true
+      dnsPolicy: {{ .Values.dnsPolicy }}    
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -82,3 +82,5 @@ serviceAccount:
 rbac:
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: true
+
+dnsPolicy: "ClusterFirstWithHostNet"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Due to daemonset `hostNetwork` setting is `true` , if I want resolve service dns like elasticsearch inside k8s for webhook post , I need to change `dnsPolicy` from `ClusterFirst` to `ClusterFirstWithHostNet`. so new Helm value for this situation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
