### PR TITLE
Removing kustomization.yaml for helmv3 compatibility

### DIFF
--- a/stable/aws-calico/crds/kustomization.yaml
+++ b/stable/aws-calico/crds/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- crds.yaml


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Since Helmv3 goes directly to the CRD file, it no longer needs the kustomization.yaml file as a pointer. 

Helmv3 doesn't know what do with this file and returns the following errors
```
Error: failed to install CRD crds/kustomization.yaml: unable to recognize "": no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"
```

Thank you for reviewing my PR.