### PR TITLE
release appMeshController helm chart for v0.4.0

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 0.4.0
-appVersion: 0.3.0
+version: 0.5.0
+appVersion: 0.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:


### PR DESCRIPTION
release appMeshController helm chart for v0.4.0 controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
