### PR TITLE
upgrade appMesh controller default version to v0.4.0

### DIFF
--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -7,7 +7,7 @@ region: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/app-mesh-controller
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
upgrade appMesh controller default version to v0.4.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
