### PR TITLE
update envoy version to v1.13.1.1-prod

### DIFF
--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-inject
 description: App Mesh Inject Helm chart for Kubernetes
-version: 0.11.0
+version: 0.12.0
 appVersion: 0.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -13,7 +13,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.12.2.1-prod
+    tag: v1.13.1.1-prod
   # sidecar.logLevel: Envoy log level can be info, warn or error
   logLevel: info
   resources:


### PR DESCRIPTION
Issue #, if available:
aws/aws-app-mesh-roadmap#168

Description of changes:
Updates AppMesh Envoy image version to v1.13.1.1-prod
Note that v1.13.1.0 was recalled (https://github.com/aws/eks-charts/pull/78)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
