### PR TITLE
Fix podAnnotations option of appmesh-inject

### DIFF
--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -18,10 +18,8 @@ spec:
         app.kubernetes.io/part-of: appmesh
       annotations:
         prometheus.io/scrape: "false"
-        {{- if .Values.podAnnotations }}
-        {{- range $key, $value := .Values.podAnnotations }}
-          {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        {{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "appmesh-inject.serviceAccountName" . }}

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -43,6 +43,8 @@ tolerations: []
 
 affinity: {}
 
+podAnnotations: {}
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true


### PR DESCRIPTION
Description of changes:
I faced the error when specified podAnnotations.
```console
$ helm upgrade -i --debug -n appmesh-system appmesh-inject eks/appmesh-inject --set podAnnotations.hoge=fuga
history.go:52: [debug] getting history for release appmesh-inject
Release "appmesh-inject" does not exist. Installing it now.
install.go:158: [debug] Original chart version: ""
install.go:175: [debug] CHART PATH: /Users/pataiji/Library/Caches/helm/repository/appmesh-inject-0.11.0.tgz

Error: YAML parse error on appmesh-inject/templates/deployment.yaml: error converting YAML to JSON: yaml: line 24: did not find expected key
helm.go:75: [debug] error converting YAML to JSON: yaml: line 24: did not find expected key
YAML parse error on appmesh-inject/templates/deployment.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/pkg/action/install.go:489
helm.sh/helm/v3/pkg/action.(*Install).Run
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/pkg/action/install.go:230
main.runInstall
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/cmd/helm/install.go:223
main.newUpgradeCmd.func1
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/cmd/helm/upgrade.go:113
github.com/spf13/cobra.(*Command).execute
        /private/tmp/helm-20200221-95404-1668hu8/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826
github.com/spf13/cobra.(*Command).ExecuteC
        /private/tmp/helm-20200221-95404-1668hu8/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
        /private/tmp/helm-20200221-95404-1668hu8/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main
        /private/tmp/helm-20200221-95404-1668hu8/src/helm.sh/helm/cmd/helm/helm.go:74
runtime.main
        /usr/local/Cellar/go/1.13.8/libexec/src/runtime/proc.go:203
runtime.goexit
        /usr/local/Cellar/go/1.13.8/libexec/src/runtime/asm_amd64.s:1357
```

I wrote a patch based on this code.
https://github.com/aws/eks-charts/blob/74f43c36bd361e91433f704a8208112e97d354aa/stable/aws-vpc-cni/templates/serviceaccount.yaml#L6-L9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
