### PR TITLE
aws-node-termination-handler: restrict filesystem to readonly and runas non-root 

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.1
-appVersion: 1.3.0
+version: 0.7.3
+appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -75,4 +75,6 @@ Parameter | Description | Default
 `serviceAccount.name` | Service account to be used | None
 `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`
 `procUptimeFile` | (Used for Testing) Specify the uptime file | `/proc/uptime`
+`securityContext.runAsUserID` | User ID to run the container | `1000`
+`securityContext.runAsGroupID` | Group ID to run the container | `1000` 
 

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -52,9 +52,16 @@ spec:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: {{ .Values.securityContext.runAsUserID }}
+            runAsGroup: {{ .Values.securityContext.runAsGroupID }}
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: "uptime"
               mountPath: "/proc/uptime"
+              readOnly: true
           env:
           - name: NODE_NAME
             valueFrom:

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,9 +4,13 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.3.0
+  tag: v1.3.1
   pullPolicy: IfNotPresent
   pullSecrets: []
+
+securityContext:
+  runAsUserID: 1000
+  runAsGroupID: 1000
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Issue #, if available:
N/A

## Description of changes:
Locks down some access from NTH:

 - Makes the root container filesystem read only
- Runs as non-root
- Disallow privilege escalation explicitly
- change uptime volume mount to readonly


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.