### PR TITLE
Allow override of cluster-proportional-autoscaler image

### DIFF
--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -46,6 +46,8 @@ The following table lists the configurable parameters for this chart and their d
 | `fullnameOverride`      | Override the fullname of the chart                      | `calico`                        |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                           |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                          |
+| `autoscaler.image`      | Cluster Proportional Autoscaler Image                   | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
+| `autoscaler.tag`        | Cluster Proportional Autoscaler version                 | `1.1.2`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-calico/templates/deployment.yaml
+++ b/stable/aws-calico/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: "{{ .Values.autoscaler.image }}:{{ .Values.autoscaler.tag }}"
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -9,3 +9,7 @@ calico:
     image: quay.io/calico/typha
   node:
     image: quay.io/calico/node
+
+autoscaler:
+  tag: "1.1.2"
+  image: k8s.gcr.io/cluster-proportional-autoscaler-amd64


### PR DESCRIPTION
## Issue #, if available:

N/A

## Description of changes:

When working in an environment where the target k8s clusters have no egress to the internet, it's very handy to be able to override the image locations. That's already being done for both calico images via `calico.typha.image` and `calico.node.image`, which is great.

This PR exposes 2 additional parameters (`autoscaler.image` and `autoscaler.tag`) so that the user can point the deployment to a private registry.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
