### PR TITLE
Update aws-node-termination-handler to v1.3.1

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.1
-appVersion: 1.3.0
+version: 0.7.2
+appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.3.0
+  tag: v1.3.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Description of changes:
Updating versions to correspond to https://github.com/aws/aws-node-termination-handler/commit/6cb1cff578ae0128a4eeffb2928e52ff5186e64f


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
