### PR TITLE
aws-node-termination-handler: tolerate all taints so that nth runs on all nodes

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.2
+version: 0.7.3
 appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -68,7 +68,7 @@ Parameter | Description | Default
 `resources` | Resources for the pods | `requests.cpu: 50m, requests.memory: 64Mi, limits.cpu: 100m, limits.memory: 128Mi`
 `dnsPolicy` | DaemonSet DNS policy | `ClusterFirstWithHostNet`
 `nodeSelector` | Tells the daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
-`tolerations` | list of node taints to tolerate | `[]`
+`tolerations` | list of node taints to tolerate | `[ {"operator": "Exists"} ]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `serviceAccount.create` | If `true`, create a new service account | `true`

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -66,7 +66,8 @@ procUptimeFile: "/proc/uptime"
 # pods. By default, this value is empty and every node will receive a pod.
 nodeSelector: {}
 
-tolerations: []
+tolerations: 
+  - operator: "Exists"
 
 affinity: {}
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/127

Description of changes:
 - aws-node-termination-handler: Tolerate all taints so that NTH runs on all nodes (PR in NTH repo: https://github.com/aws/aws-node-termination-handler/pull/128)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
