### PR TITLE
stable charts version increment test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,38 @@ jobs:
               helmv3 template ${STABLE}/${d} | kubeval --strict --ignore-missing-schemas
             done
       - run:
+          name: Validate stable charts versions
+          command: |
+            EXIT_CODE=0
+            if $(git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"); then
+              LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
+            else 
+              TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
+              LAST_RELEASE_HASH=$(git rev-list -1 $TAG)
+            fi
+            LAST_RELEASE_TAG=$(git describe $LAST_RELEASE_HASH --tags)
+            STABLE="$(git rev-parse --show-toplevel)/stable"
+            cd ${STABLE}
+            echo "📝 Checking for updated Chart versions since the last eks-charts release $LAST_RELEASE_TAG"
+            for d in */; do
+              LAST_COMMIT_HASH=$(git --no-pager log --pretty=tformat:"%H" -- $d | awk 'FNR <= 1')
+              ## If LAST_RELEASE_HASH is NOT an ancestor of LAST_COMMIT_HASH then it has not been modified 
+              if [[ ! -z $LAST_COMMIT_HASH && -z $(git rev-list $LAST_COMMIT_HASH | grep $LAST_RELEASE_HASH) ]]; then
+                echo "✅ Chart $d had no changes since the last eks-charts release"
+                continue
+              fi
+              LAST_RELEASE_CHART_VERSION=$(git --no-pager show $LAST_RELEASE_HASH:stable/"$d"Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
+              LAST_COMMIT_CHART_VERSION=$(git --no-pager show $LAST_COMMIT_HASH:stable/"$d"Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
+              if [[ $LAST_RELEASE_CHART_VERSION == $LAST_COMMIT_CHART_VERSION ]]; then
+                echo "❌ Chart $d has the same Chart version as the last release $LAST_COMMIT_CHART_VERSION"
+                EXIT_CODE=1
+              else 
+                echo "✅ Chart $d has a different version since the last eks-charts release ($LAST_RELEASE_CHART_VERSION -> $LAST_COMMIT_CHART_VERSION)"
+              fi
+            done
+            exit $EXIT_CODE
+
+      - run:
           name: Package stable charts
           command: |
             mkdir $HOME/stable


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/eks-charts/issues/88

Description of changes:
 - Add Circle CI tests that checks stable chart versions have been incremented since the last release
 - Works when evaluating at release time (i.e. CI is run on the commit tagged) or in-between releases.

This is a more lengthy script embedded in the circleci config file directly. It might make more sense to put this in `test/chart` or something and provide a Makefile that executes quick tests like this one, helm lint, and helm v2 and v3 tests. lmk 

## Testing:

Tests were performed on my local mac using circleci CLI:

### Negative Case (went back 1 commit before appmesh-inject version was incremented):

```
====>> Validate stable charts versions
  #!/bin/bash -eo pipefail
EXIT_CODE=0
if $(git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"); then
  LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
else
  TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
  LAST_RELEASE_HASH=$(git rev-list -1 $TAG)
fi
LAST_RELEASE_TAG=$(git describe $LAST_RELEASE_HASH --tags)
STABLE="$(git rev-parse --show-toplevel)/stable"
cd ${STABLE}
echo "📝 Checking for updated Chart versions since the last eks-charts release $LAST_RELEASE_TAG"
for d in */; do
  LAST_COMMIT_HASH=$(git --no-pager log --pretty=tformat:"%H" -- $d | awk 'FNR <= 1')
  ## If LAST_RELEASE_HASH is NOT an ancestor of LAST_COMMIT_HASH then it has not been modified
  if [[ ! -z $LAST_COMMIT_HASH && -z $(git rev-list $LAST_COMMIT_HASH | grep $LAST_RELEASE_HASH) ]]; then
    echo "✅ Chart $d had no changes since the last eks-charts release"
    continue
  fi
  LAST_RELEASE_CHART_VERSION=$(git --no-pager show $LAST_RELEASE_HASH:stable/"$d"Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
  LAST_COMMIT_CHART_VERSION=$(git --no-pager show $LAST_COMMIT_HASH:stable/"$d"Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
  if [[ $LAST_RELEASE_CHART_VERSION == $LAST_COMMIT_CHART_VERSION ]]; then
    echo "❌ Chart $d has the same Chart version as the last release $LAST_COMMIT_CHART_VERSION"
    EXIT_CODE=1
  else
    echo "✅ Chart $d has a different version since the last eks-charts release ($LAST_RELEASE_CHART_VERSION -> $LAST_COMMIT_CHART_VERSION)"
  fi
done
exit $EXIT_CODE

📝 Checking for updated Chart versions since the last eks-charts release v0.0.15
✅ Chart appmesh-controller/ had no changes since the last eks-charts release
✅ Chart appmesh-grafana/ had no changes since the last eks-charts release
❌ Chart appmesh-inject/ has the same Chart version as the last release 0.11.0
✅ Chart appmesh-jaeger/ had no changes since the last eks-charts release
✅ Chart appmesh-prometheus/ had no changes since the last eks-charts release
✅ Chart aws-calico/ has a different version since the last eks-charts release (0.1.0 -> 0.2.0)
✅ Chart aws-node-termination-handler/ has a different version since the last eks-charts release (0.7.0 -> 0.7.1)
✅ Chart aws-vpc-cni/ had no changes since the last eks-charts release
Error:
Exited with code exit status 1

Step failed
```

### Positive Case (at v0.16.0):

```
====>> Validate stable charts versions
  #!/bin/bash -eo pipefail
EXIT_CODE=0
if $(git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"); then
  LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
else
  TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
  LAST_RELEASE_HASH=$(git rev-list -1 $TAG)
fi
LAST_RELEASE_TAG=$(git describe $LAST_RELEASE_HASH --tags)
STABLE="$(git rev-parse --show-toplevel)/stable"
cd ${STABLE}
echo "📝 Checking for updated Chart versions since the last eks-charts release $LAST_RELEASE_TAG"
for d in */; do
  LAST_COMMIT_HASH=$(git --no-pager log --pretty=tformat:"%H" -- $d | awk 'FNR <= 1')
  ## If LAST_RELEASE_HASH is NOT an ancestor of LAST_COMMIT_HASH then it has not been modified
  if [[ ! -z $LAST_COMMIT_HASH && -z $(git rev-list $LAST_COMMIT_HASH | grep $LAST_RELEASE_HASH) ]]; then
    echo "✅ Chart $d had no changes since the last eks-charts release"
    continue
  fi
  LAST_RELEASE_CHART_VERSION=$(git --no-pager show $LAST_RELEASE_HASH:stable/"$d"Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
  LAST_COMMIT_CHART_VERSION=$(git --no-pager show $LAST_COMMIT_HASH:stable/"$d"Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
  if [[ $LAST_RELEASE_CHART_VERSION == $LAST_COMMIT_CHART_VERSION ]]; then
    echo "❌ Chart $d has the same Chart version as the last release $LAST_COMMIT_CHART_VERSION"
    EXIT_CODE=1
  else
    echo "✅ Chart $d has a different version since the last eks-charts release ($LAST_RELEASE_CHART_VERSION -> $LAST_COMMIT_CHART_VERSION)"
  fi
done
exit $EXIT_CODE

📝 Checking for updated Chart versions since the last eks-charts release v0.0.15
✅ Chart appmesh-controller/ had no changes since the last eks-charts release
✅ Chart appmesh-grafana/ had no changes since the last eks-charts release
✅ Chart appmesh-inject/ has a different version since the last eks-charts release (0.11.0 -> 0.12.0)
✅ Chart appmesh-jaeger/ had no changes since the last eks-charts release
✅ Chart appmesh-prometheus/ had no changes since the last eks-charts release
✅ Chart aws-calico/ has a different version since the last eks-charts release (0.1.0 -> 0.2.0)
✅ Chart aws-node-termination-handler/ has a different version since the last eks-charts release (0.7.0 -> 0.7.3)
✅ Chart aws-vpc-cni/ had no changes since the last eks-charts release
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
