### PR TITLE
[aws-calico] Add kustomization.yaml to .helmignore

### DIFF
--- a/stable/aws-calico/.helmignore
+++ b/stable/aws-calico/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+crds/kustomization.yaml

--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.8.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png


### PR DESCRIPTION
For compatibility with Helm 3, this PR takes the suggestion from https://github.com/aws/eks-charts/pull/82 and adds crds/kustomization.yaml to the .helmignore file. This avoids the error when installing this Helm chart `no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"`. This ignoring of the .helmignore is the same strategy as taken in appmesh-controller in https://github.com/aws/eks-charts/commit/b727affcb575f5a270b2e0099662b89daf3ac553.

I understand that CRDs would need to be installed manually anyways if they are upgraded as noted in https://github.com/aws/eks-charts/pull/75 but this at least makes the non CRD parts actually installable via Helm 3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
