### PR TITLE
up appmesh-controller chart version

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 0.5.0
+version: 0.6.0
 appVersion: 0.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
Issue #, if available:

Description of changes:
increment appmesh-controller chart version. 
 - It was modified here https://github.com/aws/eks-charts/pull/103 without a chart version bump before the new version check test was merged.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
