### PR TITLE
Update aws-calico RBAC permissions for typha-cpha

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.2.1
+version: 0.2.2
 appVersion: 3.8.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/rbac.yaml
+++ b/stable/aws-calico/templates/rbac.yaml
@@ -146,7 +146,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 
 ---
 
@@ -160,7 +160,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions", "apps"]
     resources: ["deployments/scale"]
     verbs: ["get", "update"]
 


### PR DESCRIPTION
Updates the ClusterRole and Role for aws-calico in order to grant permissions appropriately
to the typha-cpha Pod.

Fixes #108 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
