### PR TITLE
stable-chart-version-test: check if last commit and last release are equal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
                 continue
               fi
               ## If LAST_RELEASE_HASH is NOT an ancestor of LAST_COMMIT_HASH then it has not been modified 
-              if [[ ! -z $LAST_COMMIT_HASH && -z $(git rev-list $LAST_COMMIT_HASH | grep $LAST_RELEASE_HASH) ]]; then
+              if [[ ! -z $LAST_COMMIT_HASH && -z $(git rev-list $LAST_COMMIT_HASH | grep $LAST_RELEASE_HASH) || $LAST_COMMIT_HASH == $LAST_RELEASE_HASH ]]; then
                 echo "✅ Chart $d had no changes since the last eks-charts release"
                 continue
               fi


### PR DESCRIPTION
Issue #, if available:

Description of changes:
stable-chart-version-test: check if last commit and last release are equal to fix a bug in the test where it will fail if the chart version was updated in the tagged release commit.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
