### PR TITLE
Add support for app mesh egress filter configuration

### DIFF
--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-inject
 description: App Mesh Inject Helm chart for Kubernetes
-version: 0.13.0
+version: 0.14.0
 appVersion: 0.5.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-inject/README.md
+++ b/stable/appmesh-inject/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default
 `mesh.create` | If `true`, create mesh custom resource | `false`
 `mesh.name` | The name of the mesh to use | `global`
 `mesh.discovery` | The service discovery type to use, can be dns or cloudmap | `dns`
+`mesh.egressFilter` | The egress filter used by Mesh, can be DROP_ALL or ALLOW_ALL | `DROP_ALL`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`

--- a/stable/appmesh-inject/templates/mesh.yaml
+++ b/stable/appmesh-inject/templates/mesh.yaml
@@ -9,4 +9,6 @@ metadata:
 {{ include "appmesh-inject.labels" . | indent 4 }}
 spec:
     serviceDiscoveryType: {{ .Values.mesh.discovery }}
+    egressFilter:
+        type: {{ .Values.mesh.egressFilter }}
 {{- end }}

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -64,6 +64,8 @@ mesh:
   name: "global"
   # mesh.discovery: The service discovery type to use, can be dns or cloudmap
   discovery: dns
+  # mesh.egressFilter: The mesh Egress Filter, can be ALLOW_ALL or DROP_ALL
+  egressFilter: DROP_ALL
 
 tracing:
   # tracing.enabled: `true` if Envoy should be configured tracing


### PR DESCRIPTION
Issue:
#113 
- Currently is not possible to change the Egress Filter on the mesh created by the injector.
- Tried to change it manually after the helm deployment, but it gets overwritten after a couple of seconds.

Description of changes:
- Add new argument variable, `mesh.egressFilter` in order to support changing the Egress Filter on the mesh created by the injector.
- The value by default will be `DROP_ALL`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
