### PR TITLE
NTH - Prune replicaset and daemonset permissions

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.3
+version: 0.7.4
 appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/templates/clusterrole.yaml
+++ b/stable/aws-node-termination-handler/templates/clusterrole.yaml
@@ -26,7 +26,6 @@ rules:
 - apiGroups:
     - extensions
   resources:
-    - replicasets
     - daemonsets
   verbs:
     - get
@@ -36,4 +35,3 @@ rules:
     - daemonsets
   verbs:
     - get
-    - delete


### PR DESCRIPTION
Issue #, if available:

Description of changes: Remove unnecessary permissions on replicaset and daemonset resource types from the cluster role of node termination handler. This matches the corresponding change in NTH: https://github.com/aws/aws-node-termination-handler/pull/140

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
