### PR TITLE
NTH - Add CORDON_ONLY and METADATA_TRIES to daemonset template

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.4
+version: 0.7.5
 appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -62,6 +62,11 @@ Parameter | Description | Default
 `webhookURL` | Posts event data to URL upon instance interruption action | ``
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+`dryRun` | If true, only log if a node would be drained | `false`
+`enableScheduledEventDraining` | [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event | `false`
+`enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
+`metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
+`cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
 `affinity` | node/pod affinities | None
 `podAnnotations` | annotations to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -105,6 +105,10 @@ spec:
             value: {{ .Values.enableSpotInterruptionDraining | quote }}
           - name: ENABLE_SCHEDULED_EVENT_DRAINING
             value: {{ .Values.enableScheduledEventDraining | quote }}
+          - name: METADATA_TRIES
+            value: {{ .Values.metadataTries | quote }}
+          - name: CORDON_ONLY
+            value: {{ .Values.cordonOnly | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add the options for metadata tries and cordon only to the daemonset helm chart. metadata tries is an option that's been [present in NTH](https://github.com/aws/aws-node-termination-handler/blob/master/pkg/config/config.go#L98) that we forgot to add here. cordon only is a new option related to an upcoming PR for NTH issue https://github.com/aws/aws-node-termination-handler/issues/135

I'll add the related NTH PR here once I create it, shouldn't take much time, I just wanted to create this one first to avoid failing the build in NTH. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
