### PR TITLE
Bump CNI version to v1.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/
 _tmp/
 
 .idea
+*.iml

--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.3
-appVersion: "v1.6.0"
+version: 1.0.4
+appVersion: "v1.6.1"
 description: A Helm chart for the AWS VPC CNI
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s
 sources:
   - https://github.com/aws/amazon-vpc-cni-k8s
-description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
-icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 keywords:
   - eks
   - cni

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -35,10 +35,10 @@ The following table lists the configurable parameters for this chart and their d
 | Parameter               | Description                                             | Default                             |
 | ------------------------|---------------------------------------------------------|-------------------------------------|
 | `affinity`              | Map of node/pod affinities                              | `{}`                                |
-|  `env`                  | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG, AWS_VPC_K8S_CNI_VETHPREFIX: eni, AWS_VPC_ENI_MTU: "9001"]` |
+| `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG, AWS_VPC_K8S_CNI_VETHPREFIX: eni, AWS_VPC_ENI_MTU: "9001"]` |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.6.0`                            |
+| `image.tag`             | Image tag                                               | `v1.6.1`                            |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `securityContext`       | Container Security context                              | `privileged: true`                  |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
-| `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                              |
+| `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
 | `tolerations`           | Optional deployment tolerations                         | `[]`                                |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
 

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -30,15 +30,15 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
+                  - key: "kubernetes.io/os"
                     operator: In
                     values:
                       - linux
-                  - key: "beta.kubernetes.io/arch"
+                  - key: "kubernetes.io/arch"
                     operator: In
                     values:
                       - amd64
-                  - key: eks.amazonaws.com/compute-type
+                  - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
                       - fargate

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 image:
   region: us-west-2
-  tag: v1.6.0
+  tag: v1.6.1
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"


### PR DESCRIPTION
Description of changes:
* Bump CNI to v1.6.1
* Update config to not use the deprecated beta node selectors for `os` and `arch`
* Removed duplicated `description` in `Chart.yaml`
* Fixed indentation in `README.md`
* Added `*.iml` to `.gitignore`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
