### PR TITLE
Provided parameter to add custom annotation for service account

### DIFF
--- a/stable/appmesh-controller/templates/account.yaml
+++ b/stable/appmesh-controller/templates/account.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "appmesh-controller.serviceAccountName" . }}
   labels:
 {{ include "appmesh-controller.labels" . | indent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -34,6 +34,9 @@ serviceAccount:
   create: true
   # serviceAccount.name: The name of the service account to create or use
   name: ""
+  # serviceAccount.annotations: Annotations to be added to ServiceAccount
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
 
 rbac:
   # rbac.create: `true` if rbac resources should be created


### PR DESCRIPTION
Description of changes:

According to the [tutorial](https://docs.aws.amazon.com/eks/latest/userguide/mesh-k8s-integration.html). I should create manually a ServiceAccount with my IAM as annotations and then specify it to the appmesh-controller


```
    --set serviceAccount.create=false \
    --set serviceAccount.name=appmesh-controller
```

I would like to manage everything with the same helm chart, by provide the annotation as a parameter

```
# my-values.yaml
serviceAccount:
  name: appmesh-controller
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::111111:role/Role


helm ... -f my-values.yaml
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
