### PR TITLE
[WIP]Helm chart for appmesh-controller for 1.0

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 0.6.1
-appVersion: 0.5.0
+version: 1.0.0
+appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -167,3 +167,14 @@ Parameter | Description | Default
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
+`sidecar.image.repository` | Envoy image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
+`sidecar.image.tag` | Envoy image tag | `<VERSION>`
+`sidecar.logLevel` | Envoy log level | `info`
+`sidecar.resources` | Envoy container resources | `requests: cpu 10m memory 32Mi`
+`init.image.repository` | Route manager image repository | `111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager`
+`init.image.tag` | Route manager image tag | `<VERSION>`
+`tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
+`tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
+`tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`
+`tracing.port` |  Jaeger or Datadog agent port (ignored for X-Ray) | `9411`
+`enableCertManager` |  Enable Cert-Manager | `false`

--- a/stable/appmesh-controller/crds/crds.yaml
+++ b/stable/appmesh-controller/crds/crds.yaml
@@ -1,673 +1,2348 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: gatewayroutes.appmesh.k8s.aws
+spec:
+  group: appmesh.k8s.aws
+  names:
+    kind: GatewayRoute
+    listKind: GatewayRouteList
+    plural: gatewayroutes
+    singular: gatewayroute
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: GatewayRoute is the Schema for the gatewayroutes API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GatewayRouteSpec defines the desired state of GatewayRoute
+            refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+          properties:
+            awsName:
+              description: AWSName is the AppMesh GatewayRoute object's name. If unspecified
+                or empty, it defaults to be "${name}_${namespace}" of k8s GatewayRoute
+              type: string
+            grpcRoute:
+              description: An object that represents the specification of a gRPC gatewayRoute.
+              properties:
+                action:
+                  description: An object that represents the action to take if a match
+                    is determined.
+                  properties:
+                    target:
+                      description: An object that represents the target that traffic
+                        is routed to when a request matches the route.
+                      properties:
+                        virtualService:
+                          description: The virtual service to associate with the gateway
+                            route target.
+                          properties:
+                            virtualServiceRef:
+                              description: The virtual service reference to associate
+                                with the gateway route virtual service target.
+                              properties:
+                                name:
+                                  description: Name is the name of VirtualService
+                                    CR
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of VirtualService
+                                    CR. If unspecified, defaults to the referencing
+                                    object's namespace
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - virtualServiceRef
+                          type: object
+                      required:
+                      - virtualService
+                      type: object
+                  required:
+                  - target
+                  type: object
+                match:
+                  description: An object that represents the criteria for determining
+                    a request match.
+                  properties:
+                    serviceName:
+                      description: The fully qualified domain name for the service
+                        to match from the request.
+                      type: string
+                  type: object
+              required:
+              - action
+              - match
+              type: object
+            http2Route:
+              description: An object that represents the specification of an HTTP/2
+                gatewayRoute.
+              properties:
+                action:
+                  description: An object that represents the action to take if a match
+                    is determined.
+                  properties:
+                    target:
+                      description: An object that represents the target that traffic
+                        is routed to when a request matches the route.
+                      properties:
+                        virtualService:
+                          description: The virtual service to associate with the gateway
+                            route target.
+                          properties:
+                            virtualServiceRef:
+                              description: The virtual service reference to associate
+                                with the gateway route virtual service target.
+                              properties:
+                                name:
+                                  description: Name is the name of VirtualService
+                                    CR
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of VirtualService
+                                    CR. If unspecified, defaults to the referencing
+                                    object's namespace
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - virtualServiceRef
+                          type: object
+                      required:
+                      - virtualService
+                      type: object
+                  required:
+                  - target
+                  type: object
+                match:
+                  description: An object that represents the criteria for determining
+                    a request match.
+                  properties:
+                    prefix:
+                      description: Specifies the path to match requests with
+                      type: string
+                  required:
+                  - prefix
+                  type: object
+              required:
+              - action
+              - match
+              type: object
+            httpRoute:
+              description: An object that represents the specification of an HTTP
+                gatewayRoute.
+              properties:
+                action:
+                  description: An object that represents the action to take if a match
+                    is determined.
+                  properties:
+                    target:
+                      description: An object that represents the target that traffic
+                        is routed to when a request matches the route.
+                      properties:
+                        virtualService:
+                          description: The virtual service to associate with the gateway
+                            route target.
+                          properties:
+                            virtualServiceRef:
+                              description: The virtual service reference to associate
+                                with the gateway route virtual service target.
+                              properties:
+                                name:
+                                  description: Name is the name of VirtualService
+                                    CR
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of VirtualService
+                                    CR. If unspecified, defaults to the referencing
+                                    object's namespace
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - virtualServiceRef
+                          type: object
+                      required:
+                      - virtualService
+                      type: object
+                  required:
+                  - target
+                  type: object
+                match:
+                  description: An object that represents the criteria for determining
+                    a request match.
+                  properties:
+                    prefix:
+                      description: Specifies the path to match requests with
+                      type: string
+                  required:
+                  - prefix
+                  type: object
+              required:
+              - action
+              - match
+              type: object
+            meshRef:
+              description: "A reference to k8s Mesh CR that this GatewayRoute belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+            virtualGatewayRef:
+              description: "A reference to k8s VirtualGateway CR that this GatewayRoute
+                belongs to. The admission controller populates it using VirtualGateway's
+                selector, and prevents users from setting this field. \n Populated
+                by the system. Read-only."
+              properties:
+                name:
+                  description: Name is the name of VirtualGateway CR
+                  type: string
+                namespace:
+                  description: Namespace is the namespace of VirtualGateway CR. If
+                    unspecified, defaults to the referencing object's namespace
+                  type: string
+                uid:
+                  description: UID is the UID of VirtualGateway CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+          type: object
+        status:
+          description: GatewayRouteStatus defines the observed state of GatewayRoute
+          properties:
+            conditions:
+              description: The current GatewayRoute status.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of GatewayRoute condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            gatewayRouteARN:
+              description: GatewayRouteARNs is a map of AppMesh GatewayRoute objects'
+                Amazon Resource Names, indexed by gatewayRoute name.
+              type: string
+          type: object
+      type: object
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
   name: meshes.appmesh.k8s.aws
 spec:
   group: appmesh.k8s.aws
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-    - name: v1alpha1
-      served: true
-      storage: false
-  version: v1beta1
-  scope: Cluster
   names:
+    kind: Mesh
+    listKind: MeshList
     plural: meshes
     singular: mesh
-    kind: Mesh
-    categories:
-      - all
-      - appmesh
-  subresources:
-    status: {}
+  scope: Cluster
   validation:
     openAPIV3Schema:
+      description: Mesh is the Schema for the meshes API
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         spec:
+          description: MeshSpec defines the desired state of Mesh refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_MeshSpec.html
           properties:
+            awsName:
+              description: AWSName is the AppMesh Mesh object's name. If unspecified
+                or empty, it defaults to be "${name}" of k8s Mesh
+              type: string
             egressFilter:
-              type: object
-              required:
-                - type
+              description: The egress filter rules for the service mesh. If unspecified,
+                default settings from AWS API will be applied. Refer to AWS Docs for
+                default settings.
               properties:
                 type:
-                  type: string
+                  description: The egress filter type.
                   enum:
-                    - ALLOW_ALL
-                    - DROP_ALL
-            serviceDiscoveryType:
+                  - ALLOW_ALL
+                  - DROP_ALL
+                  type: string
+              required:
+              - type
+              type: object
+            meshOwner:
+              description: The AWS IAM account ID of the service mesh owner. Required
+                if the account ID is not your own.
               type: string
-              enum:
-                - dns
+            namespaceSelector:
+              description: NamespaceSelector selects Namespaces using labels to designate
+                mesh membership. This field follows standard label selector semantics;
+                if present but empty, it selects all namespaces.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          type: object
         status:
+          description: MeshStatus defines the observed state of Mesh
           properties:
-            meshArn:
-              type: string
             conditions:
-              type: array
+              description: The current Mesh status.
               items:
-                type: object
-                required:
-                  - type
                 properties:
-                  type:
-                    type: string
-                    enum:
-                      - MeshActive
-                  status:
-                    type: string
-                    enum:
-                      - "True"
-                      - "False"
-                      - Unknown
                   lastTransitionTime:
-                    type: string
-                  reason:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
                     type: string
                   message:
+                    description: A human readable message indicating details about
+                      the transition.
                     type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of mesh condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            meshARN:
+              description: MeshARN is the AppMesh Mesh object's Amazon Resource Name
+              type: string
+          type: object
+      type: object
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: virtualgateways.appmesh.k8s.aws
+spec:
+  group: appmesh.k8s.aws
+  names:
+    kind: VirtualGateway
+    listKind: VirtualGatewayList
+    plural: virtualgateways
+    singular: virtualgateway
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: VirtualGateway is the Schema for the virtualgateways API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VirtualGatewaySpec defines the desired state of VirtualGateway
+            refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+          properties:
+            awsName:
+              description: AWSName is the AppMesh VirtualGateway object's name. If
+                unspecified or empty, it defaults to be "${name}_${namespace}" of
+                k8s VirtualGateway
+              type: string
+            backendDefaults:
+              description: A reference to an object that represents the defaults for
+                backend GatewayRoutes.
+              properties:
+                clientPolicy:
+                  description: A reference to an object that represents a client policy.
+                  properties:
+                    tls:
+                      description: A reference to an object that represents a Transport
+                        Layer Security (TLS) client policy.
+                      properties:
+                        enforce:
+                          description: Whether the policy is enforced. If unspecified,
+                            default settings from AWS API will be applied. Refer to
+                            AWS Docs for default settings.
+                          type: boolean
+                        ports:
+                          description: The range of ports that the policy is enforced
+                            for.
+                          items:
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          type: array
+                        validation:
+                          description: A reference to an object that represents a
+                            TLS validation context.
+                          properties:
+                            trust:
+                              description: A reference to an object that represents
+                                a TLS validation context trust
+                              properties:
+                                acm:
+                                  description: A reference to an object that represents
+                                    a TLS validation context trust for an AWS Certicate
+                                    Manager (ACM) certificate.
+                                  properties:
+                                    certificateAuthorityARNs:
+                                      description: One or more ACM Amazon Resource
+                                        Name (ARN)s.
+                                      items:
+                                        type: string
+                                      maxItems: 3
+                                      minItems: 1
+                                      type: array
+                                  required:
+                                  - certificateAuthorityARNs
+                                  type: object
+                                file:
+                                  description: An object that represents a TLS validation
+                                    context trust for a local file.
+                                  properties:
+                                    certificateChain:
+                                      description: The certificate trust chain for
+                                        a certificate stored on the file system of
+                                        the virtual Gateway.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - certificateChain
+                                  type: object
+                              type: object
+                          required:
+                          - trust
+                          type: object
+                      required:
+                      - validation
+                      type: object
+                  type: object
+              type: object
+            listeners:
+              description: The listener that the virtual gateway is expected to receive
+                inbound traffic from
+              items:
+                description: VirtualGatewayListener refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+                properties:
+                  healthCheck:
+                    description: The health check information for the listener.
+                    properties:
+                      healthyThreshold:
+                        description: The number of consecutive successful health checks
+                          that must occur before declaring listener healthy. If unspecified,
+                          defaults to be 10
+                        format: int64
+                        maximum: 10
+                        minimum: 2
+                        type: integer
+                      intervalMillis:
+                        description: The time period in milliseconds between each
+                          health check execution. If unspecified, defaults to be 30000
+                        format: int64
+                        maximum: 300000
+                        minimum: 5000
+                        type: integer
+                      path:
+                        description: The destination path for the health check request.
+                          This value is only used if the specified protocol is http
+                          or http2. For any other protocol, this value is ignored.
+                        type: string
+                      port:
+                        description: The destination port for the health check request.
+                          If unspecified, defaults to be same as port defined in the
+                          PortMapping for the listener.
+                        format: int64
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: The protocol for the health check request If
+                          unspecified, defaults to be same as protocol defined in
+                          the PortMapping for the listener.
+                        enum:
+                        - grpc
+                        - http
+                        - http2
+                        type: string
+                      timeoutMillis:
+                        description: The amount of time to wait when receiving a response
+                          from the health check, in milliseconds. If unspecified,
+                          defaults to be 5000
+                        format: int64
+                        maximum: 60000
+                        minimum: 2000
+                        type: integer
+                      unhealthyThreshold:
+                        description: The number of consecutive failed health checks
+                          that must occur before declaring a virtual Gateway unhealthy.
+                          If unspecified, defaults to be 2
+                        format: int64
+                        maximum: 10
+                        minimum: 2
+                        type: integer
+                    type: object
+                  logging:
+                    description: The inbound and outbound access logging information
+                      for the virtual gateway.
+                    properties:
+                      accessLog:
+                        description: The access log configuration for a virtual Gateway.
+                        properties:
+                          file:
+                            description: The file object to send virtual gateway access
+                              logs to.
+                            properties:
+                              path:
+                                description: The file path to write access logs to.
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                    type: object
+                  portMapping:
+                    description: The port mapping information for the listener.
+                    properties:
+                      port:
+                        description: The port used for the port mapping.
+                        format: int64
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: The protocol used for the port mapping.
+                        enum:
+                        - grpc
+                        - http
+                        - http2
+                        type: string
+                    required:
+                    - port
+                    - protocol
+                    type: object
+                  tls:
+                    description: A reference to an object that represents the Transport
+                      Layer Security (TLS) properties for a listener.
+                    properties:
+                      certificate:
+                        description: A reference to an object that represents a listener's
+                          TLS certificate.
+                        properties:
+                          acm:
+                            description: A reference to an object that represents
+                              an AWS Certificate Manager (ACM) certificate.
+                            properties:
+                              certificateARN:
+                                description: The Amazon Resource Name (ARN) for the
+                                  certificate.
+                                type: string
+                            required:
+                            - certificateARN
+                            type: object
+                          file:
+                            description: A reference to an object that represents
+                              a local file certificate.
+                            properties:
+                              certificateChain:
+                                description: The certificate chain for the certificate.
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                              privateKey:
+                                description: The private key for a certificate stored
+                                  on the file system of the virtual Gateway.
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            required:
+                            - certificateChain
+                            - privateKey
+                            type: object
+                        type: object
+                      mode:
+                        description: ListenerTLS mode
+                        enum:
+                        - DISABLED
+                        - PERMISSIVE
+                        - STRICT
+                        type: string
+                    required:
+                    - certificate
+                    - mode
+                    type: object
+                required:
+                - portMapping
+                type: object
+              maxItems: 1
+              minItems: 0
+              type: array
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualGateway belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+            namespaceSelector:
+              description: NamespaceSelector selects Namespaces using labels to designate
+                GatewayRoute membership. This field follows standard label selector
+                semantics; if present but empty, it selects all namespaces.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            podSelector:
+              description: PodSelector selects Pods using labels to designate VirtualGateway
+                membership. if unspecified or empty, it selects no pods.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          type: object
+        status:
+          description: VirtualGatewayStatus defines the observed state of VirtualGateway
+          properties:
+            conditions:
+              description: The current VirtualGateway status.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of VirtualGateway condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            virtualGatewayARN:
+              description: VirtualGatewayARN is the AppMesh VirtualGateway object's
+                Amazon Resource Name
+              type: string
+          type: object
+      type: object
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
   name: virtualnodes.appmesh.k8s.aws
 spec:
   group: appmesh.k8s.aws
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-    - name: v1alpha1
-      served: true
-      storage: false
-  version: v1beta1
-  scope: Namespaced
   names:
+    kind: VirtualNode
+    listKind: VirtualNodeList
     plural: virtualnodes
     singular: virtualnode
-    kind: VirtualNode
-    categories:
-      - all
-      - appmesh
-  subresources:
-    status: {}
+  scope: Namespaced
   validation:
     openAPIV3Schema:
-      required:
-        - spec
+      description: VirtualNode is the Schema for the virtualnodes API
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         spec:
-          required:
-            - meshName
+          description: VirtualNodeSpec defines the desired state of VirtualNode refers
+            to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
           properties:
-            meshName:
+            awsName:
+              description: AWSName is the AppMesh VirtualNode object's name. If unspecified
+                or empty, it defaults to be "${name}_${namespace}" of k8s VirtualNode
               type: string
-            listeners:
-              type: array
-              items:
-                type: object
-                required:
-                  - portMapping
-                properties:
-                  portMapping:
-                    required:
-                      - port
-                      - protocol
-                    properties:
-                      port:
-                        type: integer
-                      protocol:
-                        type: string
-                        enum:
-                          - tcp
-                          - http
-                          - grpc
-                          - http2
-                          - https
-                  healthCheck:
-                    properties:
-                      healthyThreshold:
-                        type: integer
-                      intervalMillis:
-                        type: integer
-                      path:
-                        type: string
-                      port:
-                        type: integer
-                      protocol:
-                        type: string
-                        enum:
-                          - tcp
-                          - http
-                          - http2
-                          - grpc
-                      timeoutMillis:
-                        type: integer
-                      unhealthyThreshold:
-                        type: integer
-                  tls:
-                    type: object
-                    required:
-                      - mode
-                      - certificate
-                    properties:
-                      mode:
-                        type: string
-                        enum:
-                          - 'DISABLED'
-                          - 'PERMISSIVE'
-                          - 'STRICT'
-                      certificate:
-                        type: object
-                        properties:
-                          acm:
-                            type: object
-                            required:
-                              - certificateArn
-                            properties:
-                              certificateArn:
-                                type: string
-                          file:
-                            type: object
-                            required:
-                              - certificateChain
-                              - privateKey
-                            properties:
-                              certificateChain:
-                                type: string
-                              privateKey:
-                                type: string
-            serviceDiscovery:
-              type: object
-              properties:
-                cloudMap:
-                  type: object
-                  properties:
-                    serviceName:
-                      type: string
-                    namespaceName:
-                      type: string
-                dns:
-                  type: object
-                  properties:
-                    hostName:
-                      type: string
-            backends:
-              type: array
-              items:
-                oneOf:
-                  - type: object
-                    properties:
-                      backendService:
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                          clientPolicy:
-                            type: object
-                            properties:
-                              tls:
-                                type: object
-                                required:
-                                  - validation
-                                properties:
-                                  enforce:
-                                    type: boolean
-                                  ports:
-                                    type: array
-                                    items:
-                                      type: integer
-                                  validation:
-                                    type: object
-                                    required:
-                                      - trust
-                                    properties:
-                                      trust:
-                                        type: object
-                                        properties:
-                                          acm:
-                                            type: object
-                                            required:
-                                              - certificateAuthorityArns
-                                            properties:
-                                              certificateAuthorityArns:
-                                                type: array
-                                                items:
-                                                  type: string
-                                          file:
-                                            type: object
-                                            required:
-                                              - certificateChain
-                                            properties:
-                                              certificateChain:
-                                                type: string
             backendDefaults:
-              type: object
+              description: A reference to an object that represents the defaults for
+                backends.
               properties:
                 clientPolicy:
-                  type: object
+                  description: A reference to an object that represents a client policy.
                   properties:
                     tls:
-                      type: object
-                      required:
-                        - validation
+                      description: A reference to an object that represents a Transport
+                        Layer Security (TLS) client policy.
                       properties:
                         enforce:
+                          description: Whether the policy is enforced. If unspecified,
+                            default settings from AWS API will be applied. Refer to
+                            AWS Docs for default settings.
                           type: boolean
                         ports:
-                          type: array
+                          description: The range of ports that the policy is enforced
+                            for.
                           items:
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
                             type: integer
+                          type: array
                         validation:
-                          type: object
-                          required:
-                            - trust
+                          description: A reference to an object that represents a
+                            TLS validation context.
                           properties:
                             trust:
-                              type: object
+                              description: A reference to an object that represents
+                                a TLS validation context trust
                               properties:
                                 acm:
-                                  type: object
-                                  required:
-                                    - certificateAuthorityArns
+                                  description: A reference to an object that represents
+                                    a TLS validation context trust for an AWS Certicate
+                                    Manager (ACM) certificate.
                                   properties:
-                                    certificateAuthorityArns:
-                                      type: array
+                                    certificateAuthorityARNs:
+                                      description: One or more ACM Amazon Resource
+                                        Name (ARN)s.
                                       items:
                                         type: string
-                                file:
-                                  type: object
+                                      maxItems: 3
+                                      minItems: 1
+                                      type: array
                                   required:
-                                    - certificateChain
+                                  - certificateAuthorityARNs
+                                  type: object
+                                file:
+                                  description: An object that represents a TLS validation
+                                    context trust for a local file.
                                   properties:
                                     certificateChain:
+                                      description: The certificate trust chain for
+                                        a certificate stored on the file system of
+                                        the virtual node that the proxy is running
+                                        on.
+                                      maxLength: 255
+                                      minLength: 1
                                       type: string
-            logging:
+                                  required:
+                                  - certificateChain
+                                  type: object
+                              type: object
+                          required:
+                          - trust
+                          type: object
+                      required:
+                      - validation
+                      type: object
+                  type: object
               type: object
+            backends:
+              description: The backends that the virtual node is expected to send
+                outbound traffic to.
+              items:
+                description: Backend refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Backend.html
+                properties:
+                  virtualService:
+                    description: Specifies a virtual service to use as a backend for
+                      a virtual node.
+                    properties:
+                      clientPolicy:
+                        description: A reference to an object that represents the
+                          client policy for a backend.
+                        properties:
+                          tls:
+                            description: A reference to an object that represents
+                              a Transport Layer Security (TLS) client policy.
+                            properties:
+                              enforce:
+                                description: Whether the policy is enforced. If unspecified,
+                                  default settings from AWS API will be applied. Refer
+                                  to AWS Docs for default settings.
+                                type: boolean
+                              ports:
+                                description: The range of ports that the policy is
+                                  enforced for.
+                                items:
+                                  format: int64
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                type: array
+                              validation:
+                                description: A reference to an object that represents
+                                  a TLS validation context.
+                                properties:
+                                  trust:
+                                    description: A reference to an object that represents
+                                      a TLS validation context trust
+                                    properties:
+                                      acm:
+                                        description: A reference to an object that
+                                          represents a TLS validation context trust
+                                          for an AWS Certicate Manager (ACM) certificate.
+                                        properties:
+                                          certificateAuthorityARNs:
+                                            description: One or more ACM Amazon Resource
+                                              Name (ARN)s.
+                                            items:
+                                              type: string
+                                            maxItems: 3
+                                            minItems: 1
+                                            type: array
+                                        required:
+                                        - certificateAuthorityARNs
+                                        type: object
+                                      file:
+                                        description: An object that represents a TLS
+                                          validation context trust for a local file.
+                                        properties:
+                                          certificateChain:
+                                            description: The certificate trust chain
+                                              for a certificate stored on the file
+                                              system of the virtual node that the
+                                              proxy is running on.
+                                            maxLength: 255
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - certificateChain
+                                        type: object
+                                    type: object
+                                required:
+                                - trust
+                                type: object
+                            required:
+                            - validation
+                            type: object
+                        type: object
+                      virtualServiceRef:
+                        description: The VirtualService that is acting as a virtual
+                          node backend.
+                        properties:
+                          name:
+                            description: Name is the name of VirtualService CR
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of VirtualService
+                              CR. If unspecified, defaults to the referencing object's
+                              namespace
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - virtualServiceRef
+                    type: object
+                required:
+                - virtualService
+                type: object
+              type: array
+            listeners:
+              description: The listener that the virtual node is expected to receive
+                inbound traffic from
+              items:
+                description: Listener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Listener.html
+                properties:
+                  healthCheck:
+                    description: The health check information for the listener.
+                    properties:
+                      healthyThreshold:
+                        description: The number of consecutive successful health checks
+                          that must occur before declaring listener healthy. If unspecified,
+                          defaults to be 10
+                        format: int64
+                        maximum: 10
+                        minimum: 2
+                        type: integer
+                      intervalMillis:
+                        description: The time period in milliseconds between each
+                          health check execution. If unspecified, defaults to be 30000
+                        format: int64
+                        maximum: 300000
+                        minimum: 5000
+                        type: integer
+                      path:
+                        description: The destination path for the health check request.
+                          This value is only used if the specified protocol is http
+                          or http2. For any other protocol, this value is ignored.
+                        type: string
+                      port:
+                        description: The destination port for the health check request.
+                          If unspecified, defaults to be same as port defined in the
+                          PortMapping for the listener.
+                        format: int64
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: The protocol for the health check request If
+                          unspecified, defaults to be same as protocol defined in
+                          the PortMapping for the listener.
+                        enum:
+                        - grpc
+                        - http
+                        - http2
+                        - tcp
+                        type: string
+                      timeoutMillis:
+                        description: The amount of time to wait when receiving a response
+                          from the health check, in milliseconds. If unspecified,
+                          defaults to be 5000
+                        format: int64
+                        maximum: 60000
+                        minimum: 2000
+                        type: integer
+                      unhealthyThreshold:
+                        description: The number of consecutive failed health checks
+                          that must occur before declaring a virtual node unhealthy.
+                          If unspecified, defaults to be 2
+                        format: int64
+                        maximum: 10
+                        minimum: 2
+                        type: integer
+                    type: object
+                  portMapping:
+                    description: The port mapping information for the listener.
+                    properties:
+                      port:
+                        description: The port used for the port mapping.
+                        format: int64
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: The protocol used for the port mapping.
+                        enum:
+                        - grpc
+                        - http
+                        - http2
+                        - tcp
+                        type: string
+                    required:
+                    - port
+                    - protocol
+                    type: object
+                  tls:
+                    description: A reference to an object that represents the Transport
+                      Layer Security (TLS) properties for a listener.
+                    properties:
+                      certificate:
+                        description: A reference to an object that represents a listener's
+                          TLS certificate.
+                        properties:
+                          acm:
+                            description: A reference to an object that represents
+                              an AWS Certificate Manager (ACM) certificate.
+                            properties:
+                              certificateARN:
+                                description: The Amazon Resource Name (ARN) for the
+                                  certificate.
+                                type: string
+                            required:
+                            - certificateARN
+                            type: object
+                          file:
+                            description: A reference to an object that represents
+                              a local file certificate.
+                            properties:
+                              certificateChain:
+                                description: The certificate chain for the certificate.
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                              privateKey:
+                                description: The private key for a certificate stored
+                                  on the file system of the virtual node that the
+                                  proxy is running on.
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            required:
+                            - certificateChain
+                            - privateKey
+                            type: object
+                        type: object
+                      mode:
+                        description: ListenerTLS mode
+                        enum:
+                        - DISABLED
+                        - PERMISSIVE
+                        - STRICT
+                        type: string
+                    required:
+                    - certificate
+                    - mode
+                    type: object
+                required:
+                - portMapping
+                type: object
+              maxItems: 1
+              minItems: 0
+              type: array
+            logging:
+              description: The inbound and outbound access logging information for
+                the virtual node.
               properties:
                 accessLog:
-                  type: object
+                  description: The access log configuration for a virtual node.
                   properties:
                     file:
-                      type: object
+                      description: The file object to send virtual node access logs
+                        to.
                       properties:
                         path:
+                          description: The file path to write access logs to.
+                          maxLength: 255
+                          minLength: 1
                           type: string
+                      required:
+                      - path
+                      type: object
+                  type: object
+              type: object
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualNode belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+            podSelector:
+              description: PodSelector selects Pods using labels to designate VirtualNode
+                membership. if unspecified or empty, it selects no pods.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            serviceDiscovery:
+              description: The service discovery information for the virtual node.
+              properties:
+                awsCloudMap:
+                  description: Specifies any AWS Cloud Map information for the virtual
+                    node.
+                  properties:
+                    attributes:
+                      description: A string map that contains attributes with values
+                        that you can use to filter instances by any custom attribute
+                        that you specified when you registered the instance
+                      items:
+                        description: AWSCloudMapInstanceAttribute refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_AwsCloudMapInstanceAttribute.html
+                        properties:
+                          key:
+                            description: The name of an AWS Cloud Map service instance
+                              attribute key.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          value:
+                            description: The value of an AWS Cloud Map service instance
+                              attribute key.
+                            maxLength: 1024
+                            minLength: 1
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                    namespaceName:
+                      description: The name of the AWS Cloud Map namespace to use.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    serviceName:
+                      description: The name of the AWS Cloud Map service to use.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                  required:
+                  - namespaceName
+                  - serviceName
+                  type: object
+                dns:
+                  description: Specifies the DNS information for the virtual node.
+                  properties:
+                    hostname:
+                      description: Specifies the DNS service discovery hostname for
+                        the virtual node.
+                      type: string
+                  required:
+                  - hostname
+                  type: object
+              type: object
+          type: object
         status:
+          description: VirtualNodeStatus defines the observed state of VirtualNode
           properties:
-            meshArn:
-              type: string
-            virtualNodeArn:
-              type: string
+            awsCloudMapServiceStatus:
+              description: AWSCloudMapServiceStatus is AWS CloudMap Service object's
+                info
+              properties:
+                namespaceID:
+                  description: NamespaceID is AWS CloudMap Service object's namespace
+                    Id
+                  type: string
+                serviceID:
+                  description: ServiceID is AWS CloudMap Service object's Id
+                  type: string
+              type: object
             conditions:
-              type: array
+              description: The current VirtualNode status.
               items:
-                type: object
-                required:
-                  - type
                 properties:
-                  type:
-                    type: string
-                    enum:
-                      - VirtualNodeActive
-                      - MeshMarkedForDeletion
-                  status:
-                    type: string
-                    enum:
-                      - "True"
-                      - "False"
-                      - Unknown
                   lastTransitionTime:
-                    type: string
-                  reason:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
                     type: string
                   message:
+                    description: A human readable message indicating details about
+                      the transition.
                     type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of VirtualNode condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            virtualNodeARN:
+              description: VirtualNodeARN is the AppMesh VirtualNode object's Amazon
+                Resource Name
+              type: string
+          type: object
+      type: object
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: virtualrouters.appmesh.k8s.aws
+spec:
+  group: appmesh.k8s.aws
+  names:
+    kind: VirtualRouter
+    listKind: VirtualRouterList
+    plural: virtualrouters
+    singular: virtualrouter
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: VirtualRouter is the Schema for the virtualrouters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VirtualRouterSpec defines the desired state of VirtualRouter
+            refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterSpec.html
+          properties:
+            awsName:
+              description: AWSName is the AppMesh VirtualRouter object's name. If
+                unspecified or empty, it defaults to be "${name}_${namespace}" of
+                k8s VirtualRouter
+              type: string
+            listeners:
+              description: The listeners that the virtual router is expected to receive
+                inbound traffic from
+              items:
+                description: VirtualRouterListener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterListener.html
+                properties:
+                  portMapping:
+                    description: The port mapping information for the listener.
+                    properties:
+                      port:
+                        description: The port used for the port mapping.
+                        format: int64
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: The protocol used for the port mapping.
+                        enum:
+                        - grpc
+                        - http
+                        - http2
+                        - tcp
+                        type: string
+                    required:
+                    - port
+                    - protocol
+                    type: object
+                required:
+                - portMapping
+                type: object
+              maxItems: 1
+              minItems: 1
+              type: array
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualRouter belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+            routes:
+              description: The routes associated with VirtualRouter
+              items:
+                description: Route refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteSpec.html
+                properties:
+                  grpcRoute:
+                    description: An object that represents the specification of a
+                      gRPC route.
+                    properties:
+                      action:
+                        description: An object that represents the action to take
+                          if a match is determined.
+                        properties:
+                          weightedTargets:
+                            description: An object that represents the targets that
+                              traffic is routed to when a request matches the route.
+                            items:
+                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                              properties:
+                                virtualNodeRef:
+                                  description: The virtual node to associate with
+                                    the weighted target.
+                                  properties:
+                                    name:
+                                      description: Name is the name of VirtualNode
+                                        CR
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of VirtualNode
+                                        CR. If unspecified, defaults to the referencing
+                                        object's namespace
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                weight:
+                                  description: The relative weight of the weighted
+                                    target.
+                                  format: int64
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - virtualNodeRef
+                              - weight
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                        required:
+                        - weightedTargets
+                        type: object
+                      match:
+                        description: An object that represents the criteria for determining
+                          a request match.
+                        properties:
+                          metadata:
+                            description: An object that represents the data to match
+                              from the request.
+                            items:
+                              description: GRPCRouteMetadata refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcRouteMetadata.html
+                              properties:
+                                invert:
+                                  description: Specify True to match anything except
+                                    the match criteria. The default value is False.
+                                  type: boolean
+                                match:
+                                  description: An object that represents the data
+                                    to match from the request.
+                                  properties:
+                                    exact:
+                                      description: The value sent by the client must
+                                        match the specified value exactly.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    prefix:
+                                      description: The value sent by the client must
+                                        begin with the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    range:
+                                      description: An object that represents the range
+                                        of values to match on
+                                      properties:
+                                        end:
+                                          description: The end of the range.
+                                          format: int64
+                                          type: integer
+                                        start:
+                                          description: The start of the range.
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    regex:
+                                      description: The value sent by the client must
+                                        include the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    suffix:
+                                      description: The value sent by the client must
+                                        end with the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                name:
+                                  description: The name of the route.
+                                  maxLength: 50
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                          methodName:
+                            description: The method name to match from the request.
+                              If you specify a name, you must also specify a serviceName.
+                            maxLength: 50
+                            minLength: 1
+                            type: string
+                          serviceName:
+                            description: The fully qualified domain name for the service
+                              to match from the request.
+                            type: string
+                        type: object
+                      retryPolicy:
+                        description: An object that represents a retry policy.
+                        properties:
+                          grpcRetryEvents:
+                            items:
+                              enum:
+                              - cancelled
+                              - deadline-exceeded
+                              - internal
+                              - resource-exhausted
+                              - unavailable
+                              type: string
+                            maxItems: 5
+                            minItems: 1
+                            type: array
+                          httpRetryEvents:
+                            items:
+                              enum:
+                              - server-error
+                              - gateway-error
+                              - client-error
+                              - stream-error
+                              type: string
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                          maxRetries:
+                            description: The maximum number of retry attempts.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          perRetryTimeout:
+                            description: An object that represents a duration of time.
+                            properties:
+                              unit:
+                                description: A unit of time.
+                                enum:
+                                - s
+                                - ms
+                                type: string
+                              value:
+                                description: A number of time units.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                            required:
+                            - unit
+                            - value
+                            type: object
+                          tcpRetryEvents:
+                            items:
+                              enum:
+                              - connection-error
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                        - maxRetries
+                        - perRetryTimeout
+                        type: object
+                    required:
+                    - action
+                    - match
+                    type: object
+                  http2Route:
+                    description: An object that represents the specification of an
+                      HTTP/2 route.
+                    properties:
+                      action:
+                        description: An object that represents the action to take
+                          if a match is determined.
+                        properties:
+                          weightedTargets:
+                            description: An object that represents the targets that
+                              traffic is routed to when a request matches the route.
+                            items:
+                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                              properties:
+                                virtualNodeRef:
+                                  description: The virtual node to associate with
+                                    the weighted target.
+                                  properties:
+                                    name:
+                                      description: Name is the name of VirtualNode
+                                        CR
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of VirtualNode
+                                        CR. If unspecified, defaults to the referencing
+                                        object's namespace
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                weight:
+                                  description: The relative weight of the weighted
+                                    target.
+                                  format: int64
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - virtualNodeRef
+                              - weight
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                        required:
+                        - weightedTargets
+                        type: object
+                      match:
+                        description: An object that represents the criteria for determining
+                          a request match.
+                        properties:
+                          headers:
+                            description: An object that represents the client request
+                              headers to match on.
+                            items:
+                              description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
+                              properties:
+                                invert:
+                                  description: Specify True to match anything except
+                                    the match criteria. The default value is False.
+                                  type: boolean
+                                match:
+                                  description: The HeaderMatchMethod object.
+                                  properties:
+                                    exact:
+                                      description: The value sent by the client must
+                                        match the specified value exactly.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    prefix:
+                                      description: The value sent by the client must
+                                        begin with the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    range:
+                                      description: An object that represents the range
+                                        of values to match on.
+                                      properties:
+                                        end:
+                                          description: The end of the range.
+                                          format: int64
+                                          type: integer
+                                        start:
+                                          description: The start of the range.
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    regex:
+                                      description: The value sent by the client must
+                                        include the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    suffix:
+                                      description: The value sent by the client must
+                                        end with the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                name:
+                                  description: A name for the HTTP header in the client
+                                    request that will be matched on.
+                                  maxLength: 50
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                          method:
+                            description: The client request method to match on.
+                            enum:
+                            - CONNECT
+                            - DELETE
+                            - GET
+                            - HEAD
+                            - OPTIONS
+                            - PATCH
+                            - POST
+                            - PUT
+                            - TRACE
+                            type: string
+                          prefix:
+                            description: Specifies the path to match requests with
+                            type: string
+                          scheme:
+                            description: The client request scheme to match on
+                            enum:
+                            - http
+                            - https
+                            type: string
+                        required:
+                        - prefix
+                        type: object
+                      retryPolicy:
+                        description: An object that represents a retry policy.
+                        properties:
+                          httpRetryEvents:
+                            items:
+                              enum:
+                              - server-error
+                              - gateway-error
+                              - client-error
+                              - stream-error
+                              type: string
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                          maxRetries:
+                            description: The maximum number of retry attempts.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          perRetryTimeout:
+                            description: An object that represents a duration of time
+                            properties:
+                              unit:
+                                description: A unit of time.
+                                enum:
+                                - s
+                                - ms
+                                type: string
+                              value:
+                                description: A number of time units.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                            required:
+                            - unit
+                            - value
+                            type: object
+                          tcpRetryEvents:
+                            items:
+                              enum:
+                              - connection-error
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                        - maxRetries
+                        - perRetryTimeout
+                        type: object
+                    required:
+                    - action
+                    - match
+                    type: object
+                  httpRoute:
+                    description: An object that represents the specification of an
+                      HTTP route.
+                    properties:
+                      action:
+                        description: An object that represents the action to take
+                          if a match is determined.
+                        properties:
+                          weightedTargets:
+                            description: An object that represents the targets that
+                              traffic is routed to when a request matches the route.
+                            items:
+                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                              properties:
+                                virtualNodeRef:
+                                  description: The virtual node to associate with
+                                    the weighted target.
+                                  properties:
+                                    name:
+                                      description: Name is the name of VirtualNode
+                                        CR
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of VirtualNode
+                                        CR. If unspecified, defaults to the referencing
+                                        object's namespace
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                weight:
+                                  description: The relative weight of the weighted
+                                    target.
+                                  format: int64
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - virtualNodeRef
+                              - weight
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                        required:
+                        - weightedTargets
+                        type: object
+                      match:
+                        description: An object that represents the criteria for determining
+                          a request match.
+                        properties:
+                          headers:
+                            description: An object that represents the client request
+                              headers to match on.
+                            items:
+                              description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
+                              properties:
+                                invert:
+                                  description: Specify True to match anything except
+                                    the match criteria. The default value is False.
+                                  type: boolean
+                                match:
+                                  description: The HeaderMatchMethod object.
+                                  properties:
+                                    exact:
+                                      description: The value sent by the client must
+                                        match the specified value exactly.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    prefix:
+                                      description: The value sent by the client must
+                                        begin with the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    range:
+                                      description: An object that represents the range
+                                        of values to match on.
+                                      properties:
+                                        end:
+                                          description: The end of the range.
+                                          format: int64
+                                          type: integer
+                                        start:
+                                          description: The start of the range.
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    regex:
+                                      description: The value sent by the client must
+                                        include the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    suffix:
+                                      description: The value sent by the client must
+                                        end with the specified characters.
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                name:
+                                  description: A name for the HTTP header in the client
+                                    request that will be matched on.
+                                  maxLength: 50
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                          method:
+                            description: The client request method to match on.
+                            enum:
+                            - CONNECT
+                            - DELETE
+                            - GET
+                            - HEAD
+                            - OPTIONS
+                            - PATCH
+                            - POST
+                            - PUT
+                            - TRACE
+                            type: string
+                          prefix:
+                            description: Specifies the path to match requests with
+                            type: string
+                          scheme:
+                            description: The client request scheme to match on
+                            enum:
+                            - http
+                            - https
+                            type: string
+                        required:
+                        - prefix
+                        type: object
+                      retryPolicy:
+                        description: An object that represents a retry policy.
+                        properties:
+                          httpRetryEvents:
+                            items:
+                              enum:
+                              - server-error
+                              - gateway-error
+                              - client-error
+                              - stream-error
+                              type: string
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                          maxRetries:
+                            description: The maximum number of retry attempts.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          perRetryTimeout:
+                            description: An object that represents a duration of time
+                            properties:
+                              unit:
+                                description: A unit of time.
+                                enum:
+                                - s
+                                - ms
+                                type: string
+                              value:
+                                description: A number of time units.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                            required:
+                            - unit
+                            - value
+                            type: object
+                          tcpRetryEvents:
+                            items:
+                              enum:
+                              - connection-error
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                        - maxRetries
+                        - perRetryTimeout
+                        type: object
+                    required:
+                    - action
+                    - match
+                    type: object
+                  name:
+                    description: Route's name
+                    type: string
+                  priority:
+                    description: The priority for the route.
+                    format: int64
+                    maximum: 1000
+                    minimum: 0
+                    type: integer
+                  tcpRoute:
+                    description: An object that represents the specification of a
+                      TCP route.
+                    properties:
+                      action:
+                        description: The action to take if a match is determined.
+                        properties:
+                          weightedTargets:
+                            description: An object that represents the targets that
+                              traffic is routed to when a request matches the route.
+                            items:
+                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                              properties:
+                                virtualNodeRef:
+                                  description: The virtual node to associate with
+                                    the weighted target.
+                                  properties:
+                                    name:
+                                      description: Name is the name of VirtualNode
+                                        CR
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of VirtualNode
+                                        CR. If unspecified, defaults to the referencing
+                                        object's namespace
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                weight:
+                                  description: The relative weight of the weighted
+                                    target.
+                                  format: int64
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - virtualNodeRef
+                              - weight
+                              type: object
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                        required:
+                        - weightedTargets
+                        type: object
+                    required:
+                    - action
+                    type: object
+                type: object
+              type: array
+          type: object
+        status:
+          description: VirtualRouterStatus defines the observed state of VirtualRouter
+          properties:
+            conditions:
+              description: The current VirtualRouter status.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of VirtualRouter condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            routeARNs:
+              additionalProperties:
+                type: string
+              description: RouteARNs is a map of AppMesh Route objects' Amazon Resource
+                Names, indexed by route name.
+              type: object
+            virtualRouterARN:
+              description: VirtualRouterARN is the AppMesh VirtualRouter object's
+                Amazon Resource Name.
+              type: string
+          type: object
+      type: object
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
   name: virtualservices.appmesh.k8s.aws
 spec:
   group: appmesh.k8s.aws
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-    - name: v1alpha1
-      served: true
-      storage: false
-  version: v1beta1
-  scope: Namespaced
   names:
+    kind: VirtualService
+    listKind: VirtualServiceList
     plural: virtualservices
     singular: virtualservice
-    kind: VirtualService
-    categories:
-      - all
-      - appmesh
-  subresources:
-    status: {}
+  scope: Namespaced
   validation:
     openAPIV3Schema:
-      required:
-        - spec
+      description: VirtualService is the Schema for the virtualservices API
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         spec:
+          description: VirtualServiceSpec defines the desired state of VirtualService
           properties:
-            meshName:
+            awsName:
+              description: AWSName is the AppMesh VirtualService object's name. If
+                unspecified or empty, it defaults to be "${name}.${namespace}" of
+                k8s VirtualService
               type: string
-            virtualRouter:
-              type: object
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualService belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
               properties:
                 name:
+                  description: Name is the name of Mesh CR
                   type: string
-                listeners:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      portMapping:
-                        properties:
-                          port:
-                            type: integer
-                          protocol:
-                            type: string
-                            enum:
-                              - tcp
-                              - http
-                              - grpc
-                              - http2
-                              - https
-            routes:
-              type: array
-              items:
-                type: object
-                properties:
-                  http:
-                    type: object
-                    properties:
-                      priority:
-                        type: integer
-                      match:
-                        type: object
-                        properties:
-                          prefix:
-                            type: string
-                          method:
-                            type: string
-                          scheme:
-                            type: string
-                          headers:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                invert:
-                                  type: boolean
-                                match:
-                                  type: object
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                    regex:
-                                      type: string
-                                    suffix:
-                                      type: string
-                                    range:
-                                      type: object
-                                      properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
-                      action:
-                        type: object
-                        properties:
-                          weightedTargets:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                virtualNodeName:
-                                  type: string
-                                weight:
-                                  type: integer
-                      retryPolicy:
-                        type: object
-                        properties:
-                          perRetryTimeoutMillis:
-                            type: integer
-                          maxRetries:
-                            type: integer
-                          httpRetryEvents:
-                            type: array
-                            items:
-                              type: string
-                              enum:
-                                - 'server-error' # HTTP status codes 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, and 511
-                                - 'gateway-error' # HTTP status codes 502, 503, and 504
-                                - 'client-error' # HTTP status code 409
-                                - 'stream-error' # Retry on refused stream
-                          tcpRetryEvents:
-                            type: array
-                            items:
-                              type: string
-                              enum:
-                                - 'connection-error'
-                  tcp:
-                    type: object
-                    properties:
-                      action:
-                        type: object
-                        properties:
-                          weightedTargets:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                virtualNodeName:
-                                  type: string
-                                weight:
-                                  type: integer
-                  http2:
-                    type: object
-                    properties:
-                      priority:
-                        type: integer
-                      match:
-                        type: object
-                        properties:
-                          prefix:
-                            type: string
-                          method:
-                            type: string
-                          scheme:
-                            type: string
-                          headers:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                invert:
-                                  type: boolean
-                                match:
-                                  type: object
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                    regex:
-                                      type: string
-                                    suffix:
-                                      type: string
-                                    range:
-                                      type: object
-                                      properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
-                      action:
-                        type: object
-                        properties:
-                          weightedTargets:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                virtualNodeName:
-                                  type: string
-                                weight:
-                                  type: integer
-                      retryPolicy:
-                        type: object
-                        properties:
-                          perRetryTimeoutMillis:
-                            type: integer
-                          maxRetries:
-                            type: integer
-                          httpRetryEvents:
-                            type: array
-                            items:
-                              type: string
-                              enum:
-                                - 'server-error' # HTTP status codes 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, and 511
-                                - 'gateway-error' # HTTP status codes 502, 503, and 504
-                                - 'client-error' # HTTP status code 409
-                                - 'stream-error' # Retry on refused stream
-                          tcpRetryEvents:
-                            type: array
-                            items:
-                              type: string
-                              enum:
-                                - 'connection-error'
-                  grpc: 
-                    type: object
-                    properties:
-                      priority:
-                        type: integer
-                      match:
-                        type: object
-                        properties:
-                          serviceName:
-                            type: string
-                          methodName:
-                            type: string
-                          metadata:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                invert:
-                                  type: boolean
-                                match:
-                                  type: object
-                                  properties:
-                                    exact:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                    regex:
-                                      type: string
-                                    suffix:
-                                      type: string
-                                    range:
-                                      type: object
-                                      properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
-                      action:
-                        type: object
-                        properties:
-                          weightedTargets: 
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                virtualNodeName:
-                                  type: string
-                                weight:
-                                  type: integer 
-                      retryPolicy:
-                        type: object
-                        properties:
-                          perRetryTimeoutMillis:
-                            type: integer                        
-                          maxRetries:
-                            type: integer                         
-                          httpRetryEvents:
-                            type: array
-                            items:
-                              type: string   
-                              enum:
-                                - 'server-error' # HTTP status codes 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, and 511
-                                - 'gateway-error' # HTTP status codes 502, 503, and 504
-                                - 'client-error' # HTTP status code 409
-                                - 'stream-error' # Retry on refused stream
-                          tcpRetryEvents:
-                            type: array
-                            items:
-                              type: string
-                              enum:
-                                - 'connection-error'                          
-                          grpcRetryEvents:
-                            type: array
-                            items:
-                              type: string
-                              enum: 
-                                - 'cancelled'
-                                - 'deadline-exceeded'
-                                - 'internal'
-                                - 'resource-exhausted'
-                                - 'unavailable'
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+            provider:
+              description: The provider for virtual services. You can specify a single
+                virtual node or virtual router.
+              properties:
+                virtualNode:
+                  description: The virtual node associated with a virtual service.
+                  properties:
+                    virtualNodeRef:
+                      description: The virtual node that is acting as a service provider.
+                      properties:
+                        name:
+                          description: Name is the name of VirtualNode CR
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of VirtualNode CR.
+                            If unspecified, defaults to the referencing object's namespace
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - virtualNodeRef
+                  type: object
+                virtualRouter:
+                  description: The virtual router associated with a virtual service.
+                  properties:
+                    virtualRouterRef:
+                      description: The virtual router that is acting as a service
+                        provider.
+                      properties:
+                        name:
+                          description: Name is the name of VirtualRouter CR
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of VirtualRouter
+                            CR. If unspecified, defaults to the referencing object's
+                            namespace
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - virtualRouterRef
+                  type: object
+              type: object
+          required:
+          - provider
+          type: object
         status:
+          description: VirtualServiceStatus defines the observed state of VirtualService
           properties:
-            virtualServiceArn:
-              type: string
-            virtualRouterArn:
-              type: string
-            routeArns:
-              type: array
-              items:
-                type: string
             conditions:
-              type: array
+              description: The current VirtualService status.
               items:
-                type: object
-                required:
-                  - type
                 properties:
-                  type:
-                    type: string
-                    enum:
-                      - VirtualServiceActive
-                      - VirtualRouterActive
-                      - RoutesActive
-                      - MeshMarkedForDeletion
-                  status:
-                    type: string
-                    enum:
-                      - "True"
-                      - "False"
-                      - Unknown
                   lastTransitionTime:
-                    type: string
-                  reason:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
                     type: string
                   message:
+                    description: A human readable message indicating details about
+                      the transition.
                     type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of VirtualService condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            virtualServiceARN:
+              description: VirtualServiceARN is the AppMesh VirtualService object's
+                Amazon Resource Name.
+              type: string
+          type: object
+      type: object
+  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/appmesh-controller/templates/_helpers.tpl
+++ b/stable/appmesh-controller/templates/_helpers.tpl
@@ -54,3 +54,15 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate certificates for webhook
+*/}}
+{{- define "appmesh-controller.gen-certs" -}}
+{{- $altNames := list ( printf "%s.%s" "appmesh-webhook-service" .Release.Namespace ) ( printf "%s.%s.svc" "appmesh-webhook-service" .Release.Namespace ) -}}
+{{- $ca := genCA "appmesh-controller-ca" 3650 -}}
+{{- $cert := genSignedCert ( include "appmesh-controller.fullname" . ) nil $altNames 3650 $ca -}}
+caCert: {{ $ca.Cert | b64enc }}
+clientCert: {{ $cert.Cert | b64enc }}
+clientKey: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -1,21 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "appmesh-controller.fullname" . }}
+  name: appmesh-controller-manager
   labels:
+    control-plane: controller-manager
 {{ include "appmesh-controller.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "appmesh-controller.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      control-plane: controller-manager
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "appmesh-controller.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/part-of: appmesh
+        control-plane: controller-manager
       annotations:
         prometheus.io/scrape: "true"
         {{- if .Values.podAnnotations }}
@@ -23,46 +21,71 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "appmesh-controller.serviceAccountName" . }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 10555
-          command:
-            - /bin/app-mesh-controller
-            {{- if .Values.region }}
-            - --aws-region={{ .Values.region }}
-            {{- end }}
-            {{- if eq .Values.log.level "debug" }}
-            - --v=4
-            {{- else if eq .Values.log.level "info" }}
-            - --v=0
-            {{- end }}
-          livenessProbe:
-            exec:
-              command:
-                - curl
-                - -s
-                - http://localhost:10555/healthz
-          readinessProbe:
-            exec:
-              command:
-                - curl
-                - -s
-                - http://localhost:10555/healthz
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        command:
+        - /manager
+        args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --sidecar-image={{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}
+        - --sidecar-cpu-requests={{ .Values.sidecar.resources.requests.cpu }}
+        - --sidecar-memory-requests={{ .Values.sidecar.resources.requests.memory }}
+        - --init-image={{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
+        - --enable-stats-tags={{ .Values.stats.tagsEnabled }}
+        - --enable-statsd={{ .Values.stats.statsdEnabled }}
+        {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "x-ray" ) }}
+        - --enable-xray-tracing=true
+        {{- end }}
+        {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "jaeger" ) }}
+        - --enable-jaeger-tracing=true
+        - --jaeger-address={{ .Values.tracing.address }}
+        - --jaeger-port={{ .Values.tracing.port }}
+        {{- end }}
+        {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "datadog" ) }}
+        - --enable-datadog-tracing=true
+        - --datadog-address={{ .Values.tracing.address }}
+        - --datadog-port={{ .Values.tracing.port }}
+        {{- end }}
+        {{- if .Values.region }}
+        - --aws-region={{ .Values.region }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 6 }}
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 6 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 6 }}
     {{- end }}

--- a/stable/appmesh-controller/templates/rbac.yaml
+++ b/stable/appmesh-controller/templates/rbac.yaml
@@ -1,35 +1,106 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  name: {{ template "appmesh-controller.fullname" . }}
+  name: appmesh-leader-election-role
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "appmesh-controller.labels" . | indent 4 }}
 rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["*"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["app-mesh-controller-leader"]
-    verbs: ["*"]
-  - apiGroups: ["appmesh.k8s.aws"]
-    resources: ["meshes", "virtualnodes", "virtualservices", "meshes/status", "virtualnodes/status", "virtualservices/status"]
-    verbs: ["*"]
+- apiGroups: [""]
+  resources: [configmaps]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [configmaps/status]
+  verbs: [get, update, patch]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appmesh-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appmesh-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "appmesh-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appmesh-manager-role
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+rules:
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+- apiGroups: [appmesh.k8s.aws]
+  resources: [meshes, virtualgateways, virtualnodes, virtualrouters, virtualservices]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [appmesh.k8s.aws]
+  resources: [meshes/status, virtualgateways/status, virtualnodes/status, virtualrouters/status, virtualservices/status]
+  verbs: [get, patch, update]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appmesh-proxy-role
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+rules:
+- apiGroups: [authentication.k8s.io]
+  resources: [tokenreviews]
+  verbs: [create]
+- apiGroups: [authorization.k8s.io]
+  resources: [subjectaccessreviews]
+  verbs: [create]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: appmesh-metrics-reader
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "appmesh-controller.fullname" . }}
+  name: appmesh-manager-rolebinding
   labels:
 {{ include "appmesh-controller.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "appmesh-controller.fullname" . }}
+  name: appmesh-manager-role
+subjects:
+- name: {{ template "appmesh-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appmesh-proxy-rolebinding
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appmesh-proxy-role
 subjects:
 - name: {{ template "appmesh-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/stable/appmesh-controller/templates/service.yaml
+++ b/stable/appmesh-controller/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: appmesh-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+{{ include "appmesh-controller.labels" . | indent 4 }}
+spec:
+  ports:
+   - name: https
+     port: 8443
+     targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: appmesh-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/stable/appmesh-controller/templates/webhook.yaml
+++ b/stable/appmesh-controller/templates/webhook.yaml
@@ -1,0 +1,122 @@
+{{ $tls := fromYaml ( include "appmesh-controller.gen-certs" . ) }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+{{- if $.Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: appmesh-system/appmesh-serving-cert
+{{- end }}
+  name: appmesh-mutating-webhook-configuration
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+webhooks:
+{{- range $res := .Values.customResourceNames }}
+- clientConfig:
+    service:
+      name: appmesh-webhook-service
+      namespace: {{ $.Release.Namespace }}
+      path: /mutate-appmesh-k8s-aws-v1beta2-{{ $res.name }}
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+  failurePolicy: Fail
+  name: m{{ $res.name }}.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - {{ $res.plural }}
+{{- end }}
+- clientConfig:
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+    service:
+      name: appmesh-webhook-service
+      namespace: appmesh-system
+      path: /mutate-v1-pod
+  failurePolicy: Ignore
+  name: mpod.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+{{- if $.Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: appmesh-system/appmesh-serving-cert
+{{- end }}
+  name: appmesh-validating-webhook-configuration
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+webhooks:
+{{- range $res := .Values.customResourceNames }}
+- clientConfig:
+    service:
+      name: appmesh-webhook-service
+      namespace: {{ $.Release.Namespace }}
+      path: /validate-appmesh-k8s-aws-v1beta2-{{ $res.name }}
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+  failurePolicy: Fail
+  name: v{{ $res.name }}.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - {{ $res.plural }}
+{{- end }}
+---
+{{- if not $.Values.enableCertManager }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-cert
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $tls.caCert }}
+  tls.crt: {{ $tls.clientCert }}
+  tls.key: {{ $tls.clientKey }}
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: appmesh-serving-cert
+  namespace: appmesh-system
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+spec:
+  dnsNames:
+  - appmesh-webhook-service.appmesh-system.svc
+  - appmesh-webhook-service.appmesh-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: appmesh-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: appmesh-selfsigned-issuer
+  namespace: appmesh-system
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -10,6 +10,22 @@ image:
   tag: v0.5.0
   pullPolicy: IfNotPresent
 
+sidecar:
+  image:
+    repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
+    tag: v1.12.3.0-prod
+    # sidecar.logLevel: Envoy log level can be info, warn or error
+  logLevel: info
+  resources:
+    # sidecar.resources.requests: Envoy CPU and memory requests
+    requests:
+      cpu: 10m
+      memory: 32Mi
+init:
+  image:
+    repository: 111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
+    tag: v2
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -44,3 +60,33 @@ rbac:
 log:
   #log.level: info (default), debug
   level: "info"
+
+tracing:
+  # tracing.enabled: `true` if Envoy should be configured tracing
+  enabled: false
+  # tracing.provider: can be x-ray, jaeger or datadog
+  provider: x-ray
+  # tracing.address: Jaeger or Datadog agent server address (ignored for X-Ray)
+  address: appmesh-jaeger.appmesh-system
+  # tracing.address: Jaeger or Datadog agent server port (ignored for X-Ray)
+  port: 9411
+
+stats:
+  # stats.tagsEnabled: `true` if Envoy should include app-mesh tags
+  tagsEnabled: false
+  # stats.statsdEnabled: `true` if Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125
+  statsdEnabled: false
+
+# Enable cert-manager
+enableCertManager: false
+
+# Custom resource names for the webhooks
+customResourceNames:
+  - name: mesh
+    plural: meshes
+  - name: virtualnode
+    plural: virtualnodes
+  - name: virtualrouter
+    plural: virtualrouters
+  - name: virtualservice
+    plural: virtualservices

--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -17,3 +17,4 @@ maintainers:
 keywords:
   - eks
   - appmesh
+deprecated: true


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Helm chart changes for the AppMesh controller GA. The appmesh-inject chart has been deprecated and the feature will now be included in the appmesh-controller. Support added for enabling cert-manager.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
