### PR TITLE
NTH: parameterize os and arch node selector key

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
 version: 0.7.5
-appVersion: 1.3.1
+appVersion: 1.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.4
+version: 0.7.5
 appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -60,6 +60,7 @@ Parameter | Description | Default
 `ignoreDaemonsSets` | Causes kubectl to skip daemon set managed pods | `true`
 `instanceMetadataURL` | The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing. | `http://169.254.169.254:80`
 `webhookURL` | Posts event data to URL upon instance interruption action | ``
+`webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | `` 
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
 `dryRun` | If true, only log if a node would be drained | `false`
@@ -67,6 +68,7 @@ Parameter | Description | Default
 `enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
 `metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
+`jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
 `affinity` | node/pod affinities | None
 `podAnnotations` | annotations to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`
@@ -82,4 +84,5 @@ Parameter | Description | Default
 `procUptimeFile` | (Used for Testing) Specify the uptime file | `/proc/uptime`
 `securityContext.runAsUserID` | User ID to run the container | `1000`
 `securityContext.runAsGroupID` | Group ID to run the container | `1000` 
-
+`nodeSelectorTermsOs` | Operating System Node Selector Key | `beta.kubernetes.io/os`
+`nodeSelectorTermsArch` | CPU Architecture Node Selector Key | `beta.kubernetes.io/arch`

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -62,6 +62,11 @@ Parameter | Description | Default
 `webhookURL` | Posts event data to URL upon instance interruption action | ``
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+`dryRun` | If true, only log if a node would be drained | `false`
+`enableScheduledEventDraining` | [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event | `false`
+`enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
+`metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
+`cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
 `affinity` | node/pod affinities | None
 `podAnnotations` | annotations to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -109,6 +109,10 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
+          - name: JSON_LOGGING
+            value: {{ .Values.jsonLogging | quote }}
+          - name: WEBHOOK_PROXY
+            value: {{ .Values.webhookProxy | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -37,11 +37,11 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
+                  - key: {{ .Values.nodeSelectorTermsOs | default "beta.kubernetes.io/os" | quote }}
                     operator: In
                     values:
                       - linux
-                  - key: "beta.kubernetes.io/arch"
+                  - key: {{ .Values.nodeSelectorTermsArch | default "beta.kubernetes.io/arch" | quote }}
                     operator: In
                     values:
                       - amd64
@@ -105,6 +105,10 @@ spec:
             value: {{ .Values.enableSpotInterruptionDraining | quote }}
           - name: ENABLE_SCHEDULED_EVENT_DRAINING
             value: {{ .Values.enableScheduledEventDraining | quote }}
+          - name: METADATA_TRIES
+            value: {{ .Values.metadataTries | quote }}
+          - name: CORDON_ONLY
+            value: {{ .Values.cordonOnly | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -70,6 +70,9 @@ procUptimeFile: "/proc/uptime"
 # pods. By default, this value is empty and every node will receive a pod.
 nodeSelector: {}
 
+nodeSelectorTermsOs: ""
+nodeSelectorTermsArch: ""
+
 tolerations: 
   - operator: "Exists"
 

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -54,6 +54,9 @@ nodeTerminationGracePeriod: ""
 # webhookURL if specified, posts event data to URL upon instance interruption action.
 webhookURL: ""
 
+# webhookProxy if specified, uses this HTTP(S) proxy configuration.
+webhookProxy: ""
+
 # webhookHeaders if specified, replaces the default webhook headers.
 webhookHeaders: ""
 

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.3.1
+  tag: v1.4.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/pull/149

Description of changes:
 - The OS and Arch node selector keys are moving out of beta. In order to not break users on older kubernetes versions, the node selector keys have been parameterized w/ the default being the beta keys since it still works on K8s 1.11 - 1.18 . 

- Add CORDON_ONLY parameter 

- Add METADATA_TRIES parameter which was added to NTH a while ago but missed putting in the helm chart

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
