### PR TITLE
Add back beta selectors for 1.12 clusters

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.4
+version: 1.0.5
 appVersion: "v1.6.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -30,6 +30,19 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
+                  - key: "beta.kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "beta.kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
+              - matchExpressions:
                   - key: "kubernetes.io/os"
                     operator: In
                     values:


### PR DESCRIPTION
**Description of changes:**

To support 1.12 clusters, we need to keep the `beta.kubernetes.io` tags as well. See https://github.com/aws/amazon-vpc-cni-k8s/pull/959 for details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
