### PR TITLE
Added simple parameter to pass environment

### DIFF
--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             {{- else if eq .Values.log.level "info" }}
             - --v=0
             {{- end }}
+          {{- if .Values.stsRegional }}
+          env:
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+          {{- end }}            
           livenessProbe:
             exec:
               command:

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 region: ""
+stsRegional: false
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/app-mesh-controller

--- a/stable/appmesh-inject/templates/deployment.yaml
+++ b/stable/appmesh-inject/templates/deployment.yaml
@@ -64,6 +64,11 @@ spec:
             {{- if .Values.region }}
             - -region={{ .Values.region }}
             {{- end }}
+          {{- if .Values.stsRegional }}
+          env:
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+          {{- end }}              
           ports:
             - name: https
               containerPort: 8080

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 region: ""
+stsRegional: false
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-app-mesh-inject


### PR DESCRIPTION
AWS_STS_REGIONAL_ENDPOINTS to the Go SDK

Issue #125 

Description of changes:

For the usage of VPC Endpoints, in particular STS Endpoints, it's required to specify an environment variable to the AWS Go SDK (reference https://github.com/aws/aws-sdk-go/pull/2779).

If this is not specified, the default behaviour will be to use global endpoints even if STS Endpoint is declared for other usages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
