### PR TITLE
Utilize imagePullSecrets for fluentbit chart

### DIFF
--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -33,6 +33,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
 | `image.tag` | Image tag to deploy | `2.2.0`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
+| `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` | 
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
 | `service.extraParsers` | Adding more parsers with this value | `""` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}


### PR DESCRIPTION
## What
`imagePullSecrets` exists in the `aws-for-fluent-bit` chart but is unused in the template.

https://github.com/aws/eks-charts/blob/c028efc3c009786393670bd24131628bf6561887/stable/aws-for-fluent-bit/values.yaml#L10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
