### PR TITLE
Allow for fluentbit to specify update strategy

### DIFF
--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -73,3 +73,4 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.timeKeyFormat` |  strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
 | `extraOutputs` | Adding more outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
+| `updateStrategy` | Optional update strategy | `type: RollingUpdate` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
 spec:
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
   selector:
     matchLabels:
       {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -107,3 +107,6 @@ resources:
 
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: system-node-critical
+
+updateStrategy:
+  type: RollingUpdate


### PR DESCRIPTION
## What
It'd be nice to have the ability to specify an update strategy for the fluentbit daemonset. For example we usually update the pods in 1/3rds by setting `maxUnavailable` to `33%`. This helps with faster rollouts/rollbacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
