### PR TITLE
make vpc cni crd install optional

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.5
+version: 1.0.6
 appVersion: "v1.6.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters for this chart and their d
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
+| `crd.create`            | Specifies whether to create the VPC-CNI CRD             | `true`                              |
 | `tolerations`           | Optional deployment tolerations                         | `[]`                                |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
 

--- a/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
+++ b/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd.create -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -15,3 +16,4 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
+{{- end -}}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -33,6 +33,9 @@ podAnnotations: {}
 securityContext:
   privileged: true
 
+crd:
+  create: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
If multiple copies of this chart are installed in the same cluster (different node networking setups) the charts fight for ownership of the CRDs. 

This adds a parameter to disable to install of the CRD

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
