### PR TITLE
Fix service account name for ClusterRoleBinding in AWS for Fluent Bit

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   name: {{ include "aws-for-fluent-bit.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "aws-for-fluent-bit.fullname" . }}
+    name: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
     namespace: {{ include "aws-for-fluent-bit.namespace" . }}
 {{- end -}}


### PR DESCRIPTION
In `aws-for-fluent-bit`, the service account name is configurable but `clusterrolebinding.yaml` incorrectly assumes `fullname` rather than `serviceAccountName`.  This pull request fixes this small error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
