### PR TITLE
Add PodSecurityPolicy to AWS for Fluent Bit

### DIFF
--- a/stable/aws-for-fluent-bit/templates/clusterrole.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrole.yaml
@@ -9,4 +9,9 @@ rules:
       - namespaces
       - pods
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+      - {{ include "aws-for-fluent-bit.fullname" . }}
 {{- end -}}

--- a/stable/aws-for-fluent-bit/templates/psp.yaml
+++ b/stable/aws-for-fluent-bit/templates/psp.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'hostPath'
+    - 'projected'
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false


### PR DESCRIPTION
The Helm chart for AWS for Fluent Bit assumes an environment with a permissive default PodSecurityPolicy, which works for out-of-the-box EKS clusters due to the default `eks.privileged` policy, but not when things are tightened up with a restrictive default PSP.  This Helm chart should include a tailored PSP to support AWS for Fluent Bit.

This pull request adds such a PSP and updates the ClusterRole to grant permission to use it.  The assumption of `policy` API group rather than `extensions` does mean that K8s 1.14 is required, however since that's the earliest version supported by EKS as of this writing, the assumption seemed reasonable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.