### PR TITLE
Expose the kubernetes service host/port arguments in the Helm chart for aws-node-termination-handler

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.5
+version: 0.7.6
 appVersion: 1.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -89,6 +89,10 @@ spec:
             value: {{ .Values.gracePeriod | quote }}
           - name: POD_TERMINATION_GRACE_PERIOD
             value: {{ .Values.podTerminationGracePeriod | quote }}
+          - name: KUBERNETES_SERVICE_HOST
+            value: {{ .Values.kubernetesServiceHost | quote }}
+          - name: KUBERNETES_SERVICE_PORT
+            value: {{ .Values.kubernetesServicePort | quote }}
           - name: INSTANCE_METADATA_URL
             value: {{ .Values.instanceMetadataURL | quote }}
           - name: NODE_TERMINATION_GRACE_PERIOD

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -63,6 +63,12 @@ webhookHeaders: ""
 # webhookTemplate if specified, replaces the default webhook message template.
 webhookTemplate: ""
 
+# kubernetesServiceHost if specified, overrides the k8s service host to send api calls to
+kubernetesServiceHost: ""
+
+# kubernetesServiceHost if specified, overrides the k8s service port to send api calls to
+kubernetesServicePort: ""
+
 # instanceMetadataURL is used to override the default metadata URL (default: http://169.254.169.254:80)
 instanceMetadataURL: ""
 


### PR DESCRIPTION
Description of changes:

- added the kubernetesServiceHost Helm value, that sets the KUBERNETES_SERVICE_HOST environment variable (default to "")
- added the kubernetesServicePort Helm value, that sets the KUBERNETES_SERVICE_PORT environment variable (default to "")

These arguments were already available in the
aws-node-termination-handler source code, as environment variables, but
it was not possible to override them in the Helm Chart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
