### PR TITLE
Add read permissions on nodes for appmesh-manager

### DIFF
--- a/stable/appmesh-manager/templates/rbac.yaml
+++ b/stable/appmesh-manager/templates/rbac.yaml
@@ -44,7 +44,7 @@ rules:
   resources: [events]
   verbs: [create, delete, get, list, patch, update, watch]
 - apiGroups: [""]
-  resources: [namespaces, pods]
+  resources: [namespaces, pods, nodes]
   verbs: [get, list, watch]
 - apiGroups: [""]
   resources: [pods/status]


### PR DESCRIPTION
Issue: https://github.com/aws/eks-charts/issues/158

Description of changes:
The latest appmesh-manager [reads region and availability zone metadata](https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/241) from k8s nodes and adds it as instance attributes in AWS CloudMap. The existing appmesh-manager RBAC does not setup the permission to list nodes. This change adds the read permissions on node resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
