### PR TITLE
Add CRD for VirtualGateway podSelector

### DIFF
--- a/stable/appmesh-manager/crds/crds.yaml
+++ b/stable/appmesh-manager/crds/crds.yaml
@@ -808,6 +808,52 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            podSelector:
+              description: "PodSelector selects Pods using labels to designate VirtualGateway
+                membership. This field follows standard label selector semantics:
+                \tif present but empty, it selects all pods within namespace. \tif
+                absent, it selects no pod."
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
           type: object
         status:
           description: VirtualGatewayStatus defines the observed state of VirtualGateway


### PR DESCRIPTION
Description of changes:
App Mesh manager now supports [1] selecting pod for config injection based on virtual gateway podSelector. This change adds the CRD changes for VirtualGateway podSelector

[1] https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/262

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
