### PR TITLE
Update appmesh-manager tag to rc4 preview

### DIFF
--- a/stable/appmesh-manager/Chart.yaml
+++ b/stable/appmesh-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-manager
 description: App Mesh manager Helm chart for Kubernetes
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-manager/values.yaml
+++ b/stable/appmesh-manager/values.yaml
@@ -7,7 +7,7 @@ region: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-manager
-  tag: v1.0.0-rc3
+  tag: v1.0.0-rc4-preview
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
Description of changes:
Update appmesh-manager image to rc4 preview tag.

The the new tag includes
- support for podSelector in Virtual Gateway
- support to reference resources outside cluster using ARNs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
