### PR TITLE
Add App Mesh Gateway chart

### DIFF
--- a/stable/appmesh-gateway/.helmignore
+++ b/stable/appmesh-gateway/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+crds/kustomization.yaml

--- a/stable/appmesh-gateway/Chart.yaml
+++ b/stable/appmesh-gateway/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+name: appmesh-gateway
+description: App Mesh Gateway Helm chart for Kubernetes
+version: 0.1.0
+appVersion: 1.0.0
+home: https://github.com/aws/eks-charts
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/eks-charts
+maintainers:
+  - name: Stefan Prodan
+    url: https://github.com/stefanprodan
+    email: stefanprodan@users.noreply.github.com
+keywords:
+  - eks
+  - appmesh
+  - ingress
+  - gateway

--- a/stable/appmesh-gateway/README.md
+++ b/stable/appmesh-gateway/README.md
@@ -78,6 +78,7 @@ Parameter | Description | Default
 `image.repository` | image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
+`skipImageOverride` | when enabled the App Mesh injector will not override the Envoy image | `false`
 `service.type` | service type  | `LoadBalancer`
 `service.port` | service port  | `80`
 `service.annotations` | service annotations | NLB load balancer type

--- a/stable/appmesh-gateway/README.md
+++ b/stable/appmesh-gateway/README.md
@@ -1,11 +1,28 @@
 # App Mesh Gateway
 
-App Mesh Gateway Helm chart for Kubernetes
+App Mesh Gateway Helm chart for Kubernetes. 
 
 ## Prerequisites
 
 * App Mesh CRDs
 * App Mesh Manager >= 1.0.0
+
+**Note** App Mesh Gateway is a release candidate and can be used by
+enabling App Mesh preview features (available only in us-west-2 region).
+
+To enable the preview features:
+
+* When configuring IAM policies, use `appmesh-preview` as the service name instead of `appmesh`
+* Install the App Mesh CRDs with:
+```sh
+kubectl apply -k github.com/aws/eks-charts/stable/appmesh-controller//crds?ref=preview
+```
+* Install the App Mesh Controller chart from the preview branch
+* When configuring pods, add the following annotation so Envoy sidecars point to the preview as well:
+```yaml
+annotations:
+  appmesh.k8s.aws/preview: enabled
+```
 
 ## Installing the Chart
 

--- a/stable/appmesh-gateway/README.md
+++ b/stable/appmesh-gateway/README.md
@@ -1,0 +1,73 @@
+# App Mesh Gateway
+
+App Mesh Gateway Helm chart for Kubernetes
+
+## Prerequisites
+
+* App Mesh CRDs
+* App Mesh Manager >= 1.0.0
+
+## Installing the Chart
+
+Add the EKS repository to Helm:
+
+```sh
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+Create a namespace with injection enabled:
+
+```sh
+kubectl create ns appmesh-ingress
+kubectl label namespace appmesh-ingress appmesh.k8s.aws/sidecarInjectorWebhook=enabled
+```
+
+Deploy the App Mesh Gateway in the `appmesh-ingress` namespace:
+
+```sh
+helm upgrade -i appmesh-gateway eks/appmesh-gateway \
+--namespace appmesh-ingress
+```
+
+Find the NLB address:
+
+```sh
+kubectl get svc appmesh-gateway -n appmesh-ingress
+```
+
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `appmesh-gateway` deployment:
+
+```console
+$ helm delete appmesh-gateway -n appmesh-ingress
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`image.repository` | image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
+`image.tag` | image tag | `<VERSION>`
+`image.pullPolicy` | image pull policy | `IfNotPresent`
+`service.type` | service type  | `LoadBalancer`
+`service.port` | service port  | `80`
+`service.annotations` | service annotations | NLB load balancer type
+`service.externalTrafficPolicy` | when set to `Local` it preserves the client source IP  | `Cluster`
+`appmesh.gateway` | create a `VirtualGateway` object  | `true`
+`appmesh.preview` | enable App Mesh Preview (us-west-2 only)  | `false`
+`resources.requests/cpu` | pod CPU request | `100m`
+`resources.requests/memory` | pod memory request | `64Mi`
+`podAntiAffinity` | soft pod anti-affinity, one replica per node | `true`
+`nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
+`tolerations` | list of node taints to tolerate | `[]`
+`rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
+`serviceAccount.create` | If `true`, create a new service account | `true`
+`serviceAccount.name` | Service account to be used | None

--- a/stable/appmesh-gateway/README.md
+++ b/stable/appmesh-gateway/README.md
@@ -37,6 +37,28 @@ kubectl get svc appmesh-gateway -n appmesh-ingress
 
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+## Configure auto-scaling
+
+Install the Horizontal Pod Autoscaler (HPA) metrics server:
+
+```sh
+helm upgrade -i metrics-server stable/metrics-server \
+--namespace kube-system \
+--set args[0]=--kubelet-preferred-address-types=InternalIP
+```
+
+Configure CPU requests for the gateway pods and enable HPA by setting an average CPU utilization per pod:
+
+```sh
+helm upgrade -i appmesh-gateway eks/appmesh-gateway \
+--namespace appmesh-ingress \
+--set hpa.enabled=true \
+--set hap.minReplicas=2 \
+--set hap.maxReplicas=5 \
+--set hap.averageUtilization=90 \
+--set resources.requests.cpu=1000m
+```
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `appmesh-gateway` deployment:
@@ -64,9 +86,14 @@ Parameter | Description | Default
 `appmesh.preview` | enable App Mesh Preview (us-west-2 only)  | `false`
 `resources.requests/cpu` | pod CPU request | `100m`
 `resources.requests/memory` | pod memory request | `64Mi`
+`hpa.enabled` | enabled CPU based auto-scaling | `false`
+`hpa.minReplicas` | minimum number of replicas | `2`
+`hpa.maxReplicas` | maximum number of replicas | `5`
+`hpa.averageUtilization` | CPU average utilization percentage | `90`
+`hpa.enabled` | enabled CPU based auto-scaling | `false`
 `podAntiAffinity` | soft pod anti-affinity, one replica per node | `true`
-`nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
+`nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `serviceAccount.create` | If `true`, create a new service account | `true`

--- a/stable/appmesh-gateway/ci/values.yaml
+++ b/stable/appmesh-gateway/ci/values.yaml
@@ -1,0 +1,7 @@
+# CI testing values for appmesh-gateway
+
+region: us-west-2
+image:
+  repository: envoyproxy/envoy
+  tag: v1.14.2
+  pullPolicy: IfNotPresent

--- a/stable/appmesh-gateway/templates/NOTES.txt
+++ b/stable/appmesh-gateway/templates/NOTES.txt
@@ -1,0 +1,1 @@
+AWS App Mesh Gateway installed!

--- a/stable/appmesh-gateway/templates/_helpers.tpl
+++ b/stable/appmesh-gateway/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "appmesh-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "appmesh-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "appmesh-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "appmesh-gateway.labels" -}}
+app.kubernetes.io/name: {{ include "appmesh-gateway.name" . }}
+helm.sh/chart: {{ include "appmesh-gateway.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "appmesh-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "appmesh-gateway.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+

--- a/stable/appmesh-gateway/templates/deployment.yaml
+++ b/stable/appmesh-gateway/templates/deployment.yaml
@@ -54,8 +54,12 @@ spec:
           name: http-admin
           protocol: TCP
         livenessProbe:
-          tcpSocket:
-            port: http-admin
+          exec:
+            command:
+              - sh
+              - -c
+              - >-
+                curl -s http://localhost:9901/server_info | grep state | grep -q LIVE
         readinessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/stable/appmesh-gateway/templates/deployment.yaml
+++ b/stable/appmesh-gateway/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "appmesh-gateway.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "appmesh-gateway.fullname" . }}
+      annotations:
+        {{- if .Values.appmesh.preview }}
+        appmesh.k8s.aws/preview: "enabled"
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "appmesh-gateway.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 30
+      {{- if .Values.podAntiAffinity }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: {{ include "appmesh-gateway.name" . }}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      {{- end }}
+      containers:
+      - name: envoy
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 8088
+          name: http
+          protocol: TCP
+        - containerPort: 9901
+          name: http-prom
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: http-prom
+        readinessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: http-prom
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
+    {{- end }}

--- a/stable/appmesh-gateway/templates/deployment.yaml
+++ b/stable/appmesh-gateway/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ template "appmesh-gateway.fullname" . }}
+        app.kubernetes.io/component: "appmesh-gateway"
       annotations:
         {{- if .Values.appmesh.preview }}
         appmesh.k8s.aws/preview: "enabled"

--- a/stable/appmesh-gateway/templates/deployment.yaml
+++ b/stable/appmesh-gateway/templates/deployment.yaml
@@ -22,8 +22,11 @@ spec:
         {{- if .Values.appmesh.preview }}
         appmesh.k8s.aws/preview: "enabled"
         {{- end }}
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- if .Values.image.skipImageOverride }}
+        appmesh.k8s.aws/virtualGatewaySkipImageOverride: "enabled"
+        {{- end }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "appmesh-gateway.serviceAccountName" . }}
@@ -48,15 +51,15 @@ spec:
           name: http
           protocol: TCP
         - containerPort: 9901
-          name: http-prom
+          name: http-admin
           protocol: TCP
         livenessProbe:
           tcpSocket:
-            port: http-prom
+            port: http-admin
         readinessProbe:
           initialDelaySeconds: 5
           tcpSocket:
-            port: http-prom
+            port: http-admin
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}

--- a/stable/appmesh-gateway/templates/gateway.yaml
+++ b/stable/appmesh-gateway/templates/gateway.yaml
@@ -17,4 +17,8 @@ spec:
     - portMapping:
         port: 8088
         protocol: http
+      logging:
+        accessLog:
+          file:
+            path: "/dev/stdout"
 {{- end }}

--- a/stable/appmesh-gateway/templates/gateway.yaml
+++ b/stable/appmesh-gateway/templates/gateway.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.appmesh.gateway }}
+apiVersion: appmesh.k8s.aws/v1beta2
+kind: VirtualGateway
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+spec:
+  namespaceSelector:
+    matchLabels:
+      appmesh.k8s.aws/sidecarInjectorWebhook: enabled
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "appmesh-gateway.fullname" . }}
+  listeners:
+    - portMapping:
+        port: 8088
+        protocol: http
+{{- end }}

--- a/stable/appmesh-gateway/templates/hpa.yaml
+++ b/stable/appmesh-gateway/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "appmesh-gateway.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageUtilization }}
+{{- end }}

--- a/stable/appmesh-gateway/templates/psp.yaml
+++ b/stable/appmesh-gateway/templates/psp.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+    - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}-psp
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - {{ template "appmesh-gateway.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}-psp
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "appmesh-gateway.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "appmesh-gateway.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/appmesh-gateway/templates/service.yaml
+++ b/stable/appmesh-gateway/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "appmesh-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-gateway.labels" . | indent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    name: http
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ template "appmesh-gateway.fullname" . }}

--- a/stable/appmesh-gateway/templates/serviceaccount.yaml
+++ b/stable/appmesh-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "appmesh-gateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "appmesh-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/appmesh-gateway/templates/serviceaccount.yaml
+++ b/stable/appmesh-gateway/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "appmesh-gateway.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "appmesh-gateway.labels" . | nindent 4 }}
+{{- include "appmesh-gateway.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/appmesh-gateway/values.yaml
+++ b/stable/appmesh-gateway/values.yaml
@@ -34,6 +34,14 @@ resources:
     cpu: 100m
     memory: 64Mi
 
+# hpa: CPU based auto-scaling
+hpa:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  # CPU average utilization percentage
+  averageUtilization: 90
+
 # podAnnotations: Prometheus scraping is enabled by default
 podAnnotations:
   prometheus.io/scrape: "true"

--- a/stable/appmesh-gateway/values.yaml
+++ b/stable/appmesh-gateway/values.yaml
@@ -9,6 +9,8 @@ image:
   repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
   tag: v1.12.3.0-prod
   pullPolicy: IfNotPresent
+  # skipImageOverride: when enabled the App Mesh injector will not override the Envoy image
+  skipImageOverride: false
 
 service:
   type: LoadBalancer

--- a/stable/appmesh-gateway/values.yaml
+++ b/stable/appmesh-gateway/values.yaml
@@ -42,12 +42,6 @@ hpa:
   # CPU average utilization percentage
   averageUtilization: 90
 
-# podAnnotations: Prometheus scraping is enabled by default
-podAnnotations:
-  prometheus.io/scrape: "true"
-  prometheus.io/port: "9901"
-  prometheus.io/path: "/stats/prometheus"
-
 # podAntiAffinity: the scheduler should prefer to not schedule
 # two replica pods onto the same node but no guarantee is provided.
 podAntiAffinity:
@@ -59,6 +53,8 @@ affinity: {}
 nodeSelector: {}
 
 tolerations: []
+
+podAnnotations: {}
 
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not

--- a/stable/appmesh-gateway/values.yaml
+++ b/stable/appmesh-gateway/values.yaml
@@ -1,0 +1,64 @@
+# Default values for appmesh-gateway.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
+  tag: v1.12.3.0-prod
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+  port: 80
+  # externalTrafficPolicy: when set to Local it preserves the client source IP
+  externalTrafficPolicy: Cluster
+  # annotations: NLB as default load balancer type
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+appmesh:
+  # appmesh.gateway: Whether to create a VirtualGateway or not
+  gateway: true
+  # appmesh.preview: Whether to enable App Mesh Preview (us-west-2 only) or not
+  preview: false
+
+# resources: requests are set by default to enable HPA
+resources:
+#  limits:
+#    cpu: 2000m
+#    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 64Mi
+
+# podAnnotations: Prometheus scraping is enabled by default
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9901"
+  prometheus.io/path: "/stats/prometheus"
+
+# podAntiAffinity: the scheduler should prefer to not schedule
+# two replica pods onto the same node but no guarantee is provided.
+podAntiAffinity:
+  enabled: true
+
+# affinity: node/pod affinity (disable podAntiAffinity to use this)
+affinity: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
+  create: true
+  # serviceAccount.name: The name of the service account to create or use
+  name: ""
+  annotations: {}
+
+rbac:
+  # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
+  pspEnabled: false


### PR DESCRIPTION
Fix: #165 

Tested on EKS 1.16 with App Mesh preview enabled (App Mesh Manager RC4).

The chart sets the label `app.kubernetes.io/component: "appmesh-gateway"` on all gateway pods, this label should be used to build a dedicated Grafana dashboard for monitoring the gateway instances running on a cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
