### PR TITLE
Make appmesh-manager image preview non-default

### DIFF
--- a/stable/appmesh-manager/README.md
+++ b/stable/appmesh-manager/README.md
@@ -4,7 +4,9 @@ App Mesh manager Helm chart for Kubernetes
 
 ## Prerequisites
 
-Note: the current release candidate uses App Mesh preview service endpoints. It will be changed to App Mesh service at the time of GA release.
+Note: App Mesh manager is a release candidate. Please use it for testing purpose only as it has backward incompatible changes with v0.5.0. Upgrade instructions will be provided before the final release.
+
+Note: If you wish to use App Mesh preview features, you can add `-preview` to the published imge. e.g. `v1.0.0-rc4-preview`
 Two important things when using App Mesh preview:
 1. When configuring IAM policies, use `appmesh-preview` as the service name instead of `appmesh`. See the example JSON below.
 2. When configuring pods, add the following annotation so Envoy sidecars point to the preview as well:

--- a/stable/appmesh-manager/values.yaml
+++ b/stable/appmesh-manager/values.yaml
@@ -7,7 +7,7 @@ region: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-manager
-  tag: v1.0.0-rc4-preview
+  tag: v1.0.0-rc4
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
Description of changes:
Make appmesh-manager image preview non-default

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
