### PR TITLE
Point the root README to use last stable tag for CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kubectl create ns appmesh-system
 Apply the App Mesh CRDs:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/aws/eks-charts/master/stable/appmesh-controller/crds/crds.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/eks-charts/v0.0.19/stable/appmesh-controller/crds/crds.yaml
 ```
 
 Install the App Mesh CRD controller:


### PR DESCRIPTION
Description of changes:
Point the root README to use last stable tag (not master) for CRDs until v1.0.0 is published

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
