### PR TITLE
Updating aws-node-termination-handler helm template for prometheus configs

### DIFF
--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -87,4 +87,8 @@ Parameter | Description | Default
 `nodeSelectorTermsOs` | Operating System Node Selector Key | `beta.kubernetes.io/os`
 `nodeSelectorTermsArch` | CPU Architecture Node Selector Key | `beta.kubernetes.io/arch`
 `enablePrometheusServer` | If `true`, start an http server exposing `/metrics` endpoint for prometheus. | `false`
-`prometheusPortServer` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
+`prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
+
+## Metrics endpoint consideration
+
+If prometheus server is enabled and since NTH is a daemonset with host_networking=true, nothing else will be able to bind to :9092 (or the port configured) in the root network namespace since it's listening on all interfaces. Therefore, it will need to have a firewall/security group configured on the nodes to block access to the /metrics endpoint.

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -60,7 +60,7 @@ Parameter | Description | Default
 `ignoreDaemonsSets` | Causes kubectl to skip daemon set managed pods | `true`
 `instanceMetadataURL` | The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing. | `http://169.254.169.254:80`
 `webhookURL` | Posts event data to URL upon instance interruption action | ``
-`webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | `` 
+`webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | ``
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
 `dryRun` | If true, only log if a node would be drained | `false`
@@ -83,6 +83,8 @@ Parameter | Description | Default
 `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`
 `procUptimeFile` | (Used for Testing) Specify the uptime file | `/proc/uptime`
 `securityContext.runAsUserID` | User ID to run the container | `1000`
-`securityContext.runAsGroupID` | Group ID to run the container | `1000` 
+`securityContext.runAsGroupID` | Group ID to run the container | `1000`
 `nodeSelectorTermsOs` | Operating System Node Selector Key | `beta.kubernetes.io/os`
 `nodeSelectorTermsArch` | CPU Architecture Node Selector Key | `beta.kubernetes.io/arch`
+`enablePrometheusServer` | If `true`, start an http server exposing `/metrics` endpoint for prometheus. | `false`
+`prometheusPortServer` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
                       - arm64
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
       hostNetwork: true
-      dnsPolicy: {{ .Values.dnsPolicy }}    
+      dnsPolicy: {{ .Values.dnsPolicy }}
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
@@ -113,6 +113,10 @@ spec:
             value: {{ .Values.jsonLogging | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
+          - name: ENABLE_PROMETHEUS_SERVER
+            value: {{ .Values.enablePrometheusServer | quote }}
+          - name: PROMETHEUS_SERVER_PORT
+            value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -77,7 +77,7 @@ nodeSelectorTermsOs: ""
 nodeSelectorTermsArch: ""
 
 enablePrometheusServer: false
-prometheusServerPort: ""
+prometheusServerPort: "9092"
 
 tolerations:
   - operator: "Exists"

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.4.0
+  tag: v1.5.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -76,7 +76,10 @@ nodeSelector: {}
 nodeSelectorTermsOs: ""
 nodeSelectorTermsArch: ""
 
-tolerations: 
+enablePrometheusServer: false
+prometheusServerPort: ""
+
+tolerations:
   - operator: "Exists"
 
 affinity: {}


### PR DESCRIPTION
Issue https://github.com/aws/aws-node-termination-handler/issues/171
PR: https://github.com/aws/aws-node-termination-handler/pull/172

Description of changes:
Updating aws-node-termination-handler helm template for prometheus configs (flag for enabling it and port)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
