### PR TITLE
aws-node-termination-handler: taint nodes and prometheus metrics

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.5
-appVersion: 1.4.0
+version: 0.8.0
+appVersion: 1.5.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -60,7 +60,7 @@ Parameter | Description | Default
 `ignoreDaemonsSets` | Causes kubectl to skip daemon set managed pods | `true`
 `instanceMetadataURL` | The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing. | `http://169.254.169.254:80`
 `webhookURL` | Posts event data to URL upon instance interruption action | ``
-`webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | `` 
+`webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | ``
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
 `dryRun` | If true, only log if a node would be drained | `false`
@@ -68,6 +68,7 @@ Parameter | Description | Default
 `enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
 `metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
+`taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance` and `aws-node-termination-handler/spot-itn` | `false`
 `jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
 `affinity` | node/pod affinities | None
 `podAnnotations` | annotations to add to each pod | `{}`
@@ -83,6 +84,13 @@ Parameter | Description | Default
 `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`
 `procUptimeFile` | (Used for Testing) Specify the uptime file | `/proc/uptime`
 `securityContext.runAsUserID` | User ID to run the container | `1000`
-`securityContext.runAsGroupID` | Group ID to run the container | `1000` 
+`securityContext.runAsGroupID` | Group ID to run the container | `1000`
 `nodeSelectorTermsOs` | Operating System Node Selector Key | `beta.kubernetes.io/os`
 `nodeSelectorTermsArch` | CPU Architecture Node Selector Key | `beta.kubernetes.io/arch`
+`enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`
+`prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
+
+## Metrics endpoint consideration
+If prometheus server is enabled and since NTH is a daemonset with `host_networking=true`, nothing else will be able to bind to `:9092` (or the port configured) in the root network namespace
+since it's listening on all interfaces.
+Therefore, it will need to have a firewall/security group configured on the nodes to block access to the `/metrics` endpoint.

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
                       - arm64
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
       hostNetwork: true
-      dnsPolicy: {{ .Values.dnsPolicy }}    
+      dnsPolicy: {{ .Values.dnsPolicy }}
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
@@ -109,10 +109,16 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
+          - name: TAINT_NODE
+            value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
+          - name: ENABLE_PROMETHEUS_SERVER
+            value: {{ .Values.enablePrometheusServer | quote }}
+          - name: PROMETHEUS_SERVER_PORT
+            value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.4.0
+  tag: v1.5.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -32,6 +32,8 @@ enableSpotInterruptionDraining: ""
 
 ## enableScheduledEventDraining [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event
 enableScheduledEventDraining: ""
+
+taintNode: false
 
 ## dryRun tells node-termination-handler to only log calls to kubernetes control plane
 dryRun: false
@@ -76,7 +78,10 @@ nodeSelector: {}
 nodeSelectorTermsOs: ""
 nodeSelectorTermsArch: ""
 
-tolerations: 
+enablePrometheusServer: false
+prometheusServerPort: "9092"
+
+tolerations:
   - operator: "Exists"
 
 affinity: {}


### PR DESCRIPTION
Syncing aws-node-termination-handler for v1.5.0 release. 

Issue #, if available:
N/A

Description of changes:
 - Taint Nodes upon interruption 
 - Add prometheus metrics endpoint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
