### PR TITLE
[aws-node-termination-handler] Add new podLabels parameter

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.5
+version: 0.7.6
 appVersion: 1.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
 `affinity` | node/pod affinities | None
 `podAnnotations` | annotations to add to each pod | `{}`
+`podLabels` | labels to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`
 `resources` | Resources for the pods | `requests.cpu: 50m, requests.memory: 64Mi, limits.cpu: 100m, limits.memory: 128Mi`
 `dnsPolicy` | DaemonSet DNS policy | `ClusterFirstWithHostNet`

--- a/stable/aws-node-termination-handler/templates/daemonset.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         k8s-app: aws-node-termination-handler
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
       volumes:
         - name: "uptime"

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -18,6 +18,7 @@ fullnameOverride: ""
 priorityClassName: system-node-critical
 
 podAnnotations: {}
+podLabels: {}
 
 resources:
   requests:


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
This PR adds a new `podLabels` parameter which allows setting extra labels to each pod.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Edit: I've noticed this chart is duplicated on https://github.com/aws/aws-node-termination-handler, where is the correct place to place my PR?