### PR TITLE
aws-calico: add podSecurityPolicy objects

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.2.2
+version: 0.3.0
 appVersion: 3.8.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `fullnameOverride`      | Override the fullname of the chart                      | `calico`                        |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                           |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                          |
+| `podSecurityPolicy.create` | Specifies whether podSecurityPolicy and related rbac objects should be created    | `false`                          |
 | `autoscaler.image`      | Cluster Proportional Autoscaler Image                   | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
 | `autoscaler.tag`        | Cluster Proportional Autoscaler version                 | `1.1.2`                                            |
 

--- a/stable/aws-calico/templates/podsecuritypolicy.yaml
+++ b/stable/aws-calico/templates/podsecuritypolicy.yaml
@@ -1,0 +1,211 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-node
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-node
+{{ include "aws-calico.labels" . | indent 4 }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: "/lib/modules"
+      readOnly: false
+    - pathPrefix: "/var/run/calico"
+      readOnly: false
+    - pathPrefix: "/var/lib/calico"
+      readOnly: false
+    - pathPrefix: "/run/xtables.lock"
+      readOnly: false
+  runAsUser:
+    rule: 'RunAsAny'
+  runAsGroup:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-typha
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-typha
+{{ include "aws-calico.labels" . | indent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: true
+  hostPorts:
+  - max: 5473
+    min: 5473
+  hostIPC: false
+  hostPID: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-typha-horizontal-autoscaler
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-typha-autoscaler
+{{ include "aws-calico.labels" . | indent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-node-psp
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-node
+{{ include "aws-calico.labels" . | indent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "aws-calico.fullname" . }}-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-typha-psp
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-typha
+{{ include "aws-calico.labels" . | indent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "aws-calico.fullname" . }}-typha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-typha-horizontal-autoscaler-psp
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-typha-autoscaler
+{{ include "aws-calico.labels" . | indent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "aws-calico.fullname" . }}-typha-horizontal-autoscaler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-node-psp
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-node
+{{ include "aws-calico.labels" . | indent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "aws-calico.fullname" . }}-node-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "aws-calico.serviceAccountName" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-typha-psp
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-typha
+{{ include "aws-calico.labels" . | indent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "aws-calico.fullname" . }}-typha-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "aws-calico.serviceAccountName" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aws-calico.fullname" . }}-typha-horizontal-autoscaler-psp
+  labels:
+    app.kubernetes.io/name: {{ include "aws-calico.fullname" . }}-typha-autoscaler
+{{ include "aws-calico.labels" . | indent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "aws-calico.fullname" . }}-typha-horizontal-autoscaler-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "aws-calico.serviceAccountName" . }}-typha-cpha
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -3,6 +3,9 @@ fullnameOverride: calico
 serviceAccount:
   create: true
 
+podSecurityPolicy:
+  create: false
+
 calico:
   tag: v3.8.1
 


### PR DESCRIPTION
add parameters to enable the creation of podsecuritypolicy objects for calico components

Signed-off-by: Yannick Kint <yannickkint@gmail.com>

Issue #, if available:

Description of changes:
The Helm chart for AWS for calico assumes an environment with a permissive default PodSecurityPolicy, which works for out-of-the-box EKS clusters due to the default eks.privileged policy, but not when things are tightened up with a restrictive default PSP. This Helm chart should include a tailored podSecurityPolicy to allow calico to work in all environments.

creation of the objects can be enabled via the values of the helm chart, by default they will not be created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
