### PR TITLE
Appmesh controller/svc acct annotation updates

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -274,6 +274,7 @@ Parameter | Description | Default
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
+`serviceAccount.annotations` | optional annotations to add to service account | None
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
 `sidecar.image.repository` | Envoy image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -50,6 +50,8 @@ serviceAccount:
   create: true
   # serviceAccount.name: The name of the service account to create or use
   name: ""
+  # serviceAccount.annotations: optional annotations to be applied to service account
+  annotations: ""
 
 rbac:
   # rbac.create: `true` if rbac resources should be created


### PR DESCRIPTION
Description of changes:
Update to `README.md` and default `values.yaml` of appmesh-controller to reflect the availability of `serviceAccount.annotations` as defined at https://github.com/aws/eks-charts/blob/master/stable/appmesh-controller/templates/serviceaccount.yaml#L9-L12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
