### PR TITLE
allow original match label on daemonset to enable helm adoption

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.6
+version: 1.0.7
 appVersion: "v1.6.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -42,6 +42,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
+| `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |
 | `podSecurityContext`    | Pod Security Context                                    | `{}`                                |
@@ -61,3 +62,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```shell
 $ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni --values values.yaml
 ```
+
+## Adopting the existing aws-node resources in an EKS cluster
+
+If you do not want to delete the existing aws-node resources in your cluster that run the aws-vpc-cni and then install this helm chart, you can adopt the resources into a release instead. This process is highlighted in this [PR comment](https://github.com/aws/eks-charts/issues/57#issuecomment-628403245). Once you have annotated and labeled all the resources this chart specifies, enable the `originalMatchLabels` flag on the helm release and run an update. If you have been careful this should not diff and leave all the resources unmodified and now under management of helm.

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -62,6 +62,7 @@ $ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni --valu
 If you do not want to delete the existing aws-node resources in your cluster that run the aws-vpc-cni and then install this helm chart, you can adopt the resources into a release instead. This process is highlighted in this [PR comment](https://github.com/aws/eks-charts/issues/57#issuecomment-628403245). Once you have annotated and labeled all the resources this chart specifies, enable the `originalMatchLabels` flag on the helm release and run an update. If you have been careful this should not diff and leave all the resources unmodified and now under management of helm.
 
 Here is an example script to modify the existing resources:
+
 WARNING: Substitute YOUR_HELM_RELEASE_NAME_HERE with the name of your helm release.
 ```
 #!/usr/bin/env bash

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -70,7 +70,7 @@ set -euo pipefail
 
 # don't import the crd. Helm cant manage the lifecycle of it anyway.
 for kind in daemonSet clusterRole clusterRoleBinding serviceAccount; do
-  echo "setting annotations and labels on $kind"
+  echo "setting annotations and labels on $kind/aws-node"
   kubectl -n kube-system annotate --overwrite $kind aws-node meta.helm.sh/release-name=YOUR_HELM_RELEASE_NAME_HERE
   kubectl -n kube-system annotate --overwrite $kind aws-node meta.helm.sh/release-namespace=kube-system
   kubectl -n kube-system label --overwrite $kind aws-node app.kubernetes.io/managed-by=Helm

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -59,7 +59,7 @@ $ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni --valu
 
 ## Adopting the existing aws-node resources in an EKS cluster
 
-If you do not want to delete the existing aws-node resources in your cluster that run the aws-vpc-cni and then install this helm chart, you can adopt the resources into a release instead. This process is highlighted in this [PR comment](https://github.com/aws/eks-charts/issues/57#issuecomment-628403245). Once you have annotated and labeled all the resources this chart specifies, enable the `originalMatchLabels` flag on the helm release and run an update. If you have been careful this should not diff and leave all the resources unmodified and now under management of helm.
+If you do not want to delete the existing aws-node resources in your cluster that run the aws-vpc-cni and then install this helm chart, you can adopt the resources into a release instead. This process is highlighted in this [PR comment](https://github.com/aws/eks-charts/issues/57#issuecomment-628403245). Once you have annotated and labeled all the resources this chart specifies, enable the `originalMatchLabels` flag, and also set `crd.create` to false on the helm release and run an update. If you have been careful this should not diff and leave all the resources unmodified and now under management of helm.
 
 Here is an example script to modify the existing resources:
 

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -20,7 +20,7 @@ To install the chart with the release name `aws-vpc-cni` and default configurati
 $ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni
 ```
 
-To install into an EKS cluster where the CNI is already installed, see [this section below](##-Adopting-the-existing-aws-node-resources-in-an-EKS-cluster)
+To install into an EKS cluster where the CNI is already installed, see [this section below](#adopting-the-existing-aws-node-resources-in-an-eks-cluster)
 
 ## Configuration
 
@@ -68,7 +68,8 @@ WARNING: Substitute YOUR_HELM_RELEASE_NAME_HERE with the name of your helm relea
 
 set -euo pipefail
 
-for kind in ds clusterRole clusterRoleBinding serviceAccount; do
+# don't import the crd. Helm cant manage the lifecycle of it anyway.
+for kind in daemonSet clusterRole clusterRoleBinding serviceAccount; do
   echo "setting annotations and labels on $kind"
   kubectl -n kube-system annotate --overwrite $kind aws-node meta.helm.sh/release-name=YOUR_HELM_RELEASE_NAME_HERE
   kubectl -n kube-system annotate --overwrite $kind aws-node meta.helm.sh/release-namespace=kube-system

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -9,8 +9,12 @@ spec:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   selector:
     matchLabels:
+{{- if .Values.originalMatchLabels }}
+      k8s-app: aws-node
+{{- else }}
       app.kubernetes.io/name: {{ include "aws-vpc-cni.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
   template:
     metadata:
       {{- if .Values.podAnnotations }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -20,6 +20,10 @@ env:
   AWS_VPC_K8S_CNI_VETHPREFIX: eni
   AWS_VPC_ENI_MTU: "9001"
 
+# this flag enables you to use the match label that was present in the original daemonset deployed by EKS
+# You can then annotate and label the original aws-node resources and 'adopt' them into a helm release
+originalMatchLabels: false
+
 imagePullSecrets: []
 
 fullnameOverride: "aws-node"
@@ -57,3 +61,4 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+


### PR DESCRIPTION
Description of changes:
This PR enables the adoption of the existing aws-node resources by allowing you to retain the original match labels, and results in a successful adoption.

The match label on a daemonset is an immutable field. When trying to adopt the existing aws-node resources for aws-vpc-cni it will diff on these matchLabels and attempt to change them, resulting in an error.

This is somewhat related to issue https://github.com/aws/eks-charts/issues/57.
