### PR TITLE
[aws-vpc-cni] Update to v1.6.2

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.0.7
-appVersion: "v1.6.1"
+version: 1.0.8
+appVersion: "v1.6.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters for this chart and their d
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options     | `[AWS_VPC_K8S_CNI_LOGLEVEL: DEBUG, AWS_VPC_K8S_CNI_VETHPREFIX: eni, AWS_VPC_ENI_MTU: "9001"]` |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.6.1`                            |
+| `image.tag`             | Image tag                                               | `v1.6.2`                            |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 image:
   region: us-west-2
-  tag: v1.6.1
+  tag: v1.6.2
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"
@@ -61,4 +61,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-


### PR DESCRIPTION
Would be good to merge this before updating to `v1.6.3` so that this version is available.

As far as I can see there's no other required changes apart from the image tag: https://github.com/aws/amazon-vpc-cni-k8s/commits/master/config/v1.6/aws-k8s-cni.yaml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
