### PR TITLE
aws-node-termination-handler: sync patches for v1.6.1

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.9.0
-appVersion: 1.6.0
+version: 0.9.1
+appVersion: 1.6.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/templates/_helpers.tpl
+++ b/stable/aws-node-termination-handler/templates/_helpers.tpl
@@ -71,7 +71,7 @@ In 1.14 "beta.kubernetes.io" was deprecated and is scheduled for removal in 1.18
 See https://v1-14.docs.kubernetes.io/docs/setup/release/notes/#deprecations
 */}}
 {{- define "aws-node-termination-handler.defaultNodeSelectorTermsPrefix" -}}
-    {{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+    {{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor | replace "+" "" -}}
     {{- semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io" "kubernetes.io" -}}
 {{- end -}}
 

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -58,6 +58,10 @@ spec:
                     - amd64
                     - arm64
                     - arm
+                - key: "eks.amazonaws.com/compute-type"
+                  operator: NotIn
+                  values:
+                    - fargate
         {{- with .Values.affinity }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.6.0
+  tag: v1.6.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
## aws-node-termination-handler

Issue #, if available:
https://github.com/aws/eks-charts/issues/198
https://github.com/aws/aws-node-termination-handler/issues/193

Description of changes:
Syncing patches for v1.6.1 
 - Don't schedule to fargate
 - Fix k8s semver comparison in helm chart. It was failing because EKS minor version has a `+` on the end.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
