### PR TITLE
aws-for-fluent-bit: service account fix

### DIFF
--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -2,17 +2,17 @@
 
 A helm chart for [AWS-for-fluent-bit](https://github.com/aws/aws-for-fluent-bit)
 
-# Installing the Chart
+## Installing the Chart
 
 Add the EKS repository to Helm:
 
-```
+```bash
 helm repo add eks https://aws.github.io/eks-charts
 ```
 
 Install or upgrading the AWS for fluent bit chart with default configuration:
 
-```
+```bash
 helm upgrade --install aws-for-fluent-bit --namespace kube-system eks/aws-for-fluent-bit
 ```
 
@@ -20,26 +20,26 @@ helm upgrade --install aws-for-fluent-bit --namespace kube-system eks/aws-for-fl
 
 To uninstall/delete the `aws-for-fluent-bit` release:
 
-```
+```bash
 helm delete aws-for-fluent-bit --namespace kube-system
 ```
-
 
 ## Configuration
 
 | Parameter | Description | Default | Required |
 | - | - | - | -
-| `global.namespaceOverride` | Override the deployment namespace	| Not set (`Release.Namespace`) |
+| `global.namespaceOverride` | Override the deployment namespace | Not set (`Release.Namespace`) |
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
 | `image.tag` | Image tag to deploy | `2.2.0`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
-| `serviceAccount.create` | Whether a new service account should be created | `true` | 
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
+| `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
 | `service.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
 | `extraInputs` | Adding more inputs with this value | `""` |
 | `filter.*` | Values for kubernetes filter | |
-| `extraFilters` | Adding more filters with value | 
+| `extraFilters` | Adding more filters with value |
 | `cloudWatch.enabled` | Whether this plugin should be enabled or not [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) | `true` | ✔
 | `cloudWatch.match` | The log filter | `*` | ✔
 | `cloudWatch.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔

--- a/stable/aws-for-fluent-bit/templates/_helpers.tpl
+++ b/stable/aws-for-fluent-bit/templates/_helpers.tpl
@@ -55,11 +55,7 @@ app.kubernetes.io/instance: {{ include "aws-for-fluent-bit.namespace" . }}
 Create the name of the service account to use
 */}}
 {{- define "aws-for-fluent-bit.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "aws-for-fluent-bit.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "aws-for-fluent-bit" .Values.serviceAccount.name }}
-{{- end -}}
+  {{ default (include "aws-for-fluent-bit.fullname" .) .Values.serviceAccount.name }}
 {{- end -}}
 
 {{/*

--- a/stable/aws-for-fluent-bit/templates/_helpers.tpl
+++ b/stable/aws-for-fluent-bit/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Create the name of the service account to use
 {{- if .Values.serviceAccount.create -}}
     {{ default (include "aws-for-fluent-bit.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "aws-for-fluent-bit" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Issue #, if available:
* When deploying with `Values.serviceAccount.create=false` the `serviceaccount.name` value == default.
* `Value.serviceaccount.name` was not in the documentation.

Description of changes:
* Remove dependency between namespace creation and `serviceaccount` name
* update the default value of serviceaccount name to `aws-for-fluent-bit.fullname`
* add `Values.serviceAccount.name` to the documentation
* minor tweaks of README based on MK linter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
