### PR TITLE
[aws-node-termination-handler] Add PodMonitor

### DIFF
--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -94,12 +94,16 @@ Parameter | Description | Default
 `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`
 `procUptimeFile` | (Used for Testing) Specify the uptime file | `/proc/uptime`
 `securityContext.runAsUserID` | User ID to run the container | `1000`
-`securityContext.runAsGroupID` | Group ID to run the container | `1000` 
+`securityContext.runAsGroupID` | Group ID to run the container | `1000`
 `nodeSelectorTermsOs` | Operating System Node Selector Key | >=1.14: `kubernetes.io/os`, <1.14: `beta.kubernetes.io/os`
 `nodeSelectorTermsArch` | CPU Architecture Node Selector Key | >=1.14: `kubernetes.io/arch`, <1.14: `beta.kubernetes.io/arch`
 `targetNodeOs | Space separated list of node OS's to target, e.g. "linux", "windows", "linux windows".  Note: Windows support is experimental. | `"linux"`
 `enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`
 `prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
+`podMonitor.create` | if `true`, create a PodMonitor | `false`
+`podMonitor.interval` | Prometheus scrape interval | `30s`
+`podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
+`podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
 
 ## Metrics endpoint consideration
 If prometheus server is enabled and since NTH is a daemonset with `host_networking=true`, nothing else will be able to bind to `:9092` (or the port configured) in the root network namespace

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -151,6 +151,13 @@ spec:
             value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.enablePrometheusServer }}
+          ports:
+          - containerPort: {{ .Values.prometheusServerPort | quote }}
+            hostPort: {{ .Values.prometheusServerPort | quote }}
+            name: http-metrics
+            protocol: TCP
+          {{- end }}
       nodeSelector:
         {{ include "aws-node-termination-handler.nodeSelectorTermsOs" . }}: linux
         {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -123,6 +123,13 @@ spec:
             value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.enablePrometheusServer }}
+          ports:
+          - containerPort: {{ .Values.prometheusServerPort | quote }}
+            hostPort: {{ .Values.prometheusServerPort | quote }}
+            name: http-metrics
+            protocol: TCP
+          {{- end }}
       nodeSelector:
         {{ include "aws-node-termination-handler.nodeSelectorTermsOs" . }}: windows
         {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/templates/podmonitor.yaml
+++ b/stable/aws-node-termination-handler/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "aws-node-termination-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-node-termination-handler.labels" . | indent 4 }}
+{{- with .Values.podMonitor.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+ spec:
+  jobLabel: {{ include "aws-node-termination-handler.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - interval: {{ .Values.podMonitor.interval }}
+    path: /metrics
+    port: http-metrics
+  sampleLimit: {{ .Values.podMonitor.sampleLimit }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+{{- end }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -117,3 +117,13 @@ rbac:
   pspEnabled: true
 
 dnsPolicy: ""
+
+podMonitor:
+   # Specifies whether PodMonitor should be created
+   create: false
+   # The Prometheus scrape interval
+   interval: 30s
+   # The number of scraped samples that will be accepted
+   sampleLimit: 5000
+   # Additional labels to add to the metadata
+   labels: {}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -119,11 +119,11 @@ rbac:
 dnsPolicy: ""
 
 podMonitor:
-   # Specifies whether PodMonitor should be created
-   create: false
+  # Specifies whether PodMonitor should be created
+  create: false
    # The Prometheus scrape interval
-   interval: 30s
-   # The number of scraped samples that will be accepted
-   sampleLimit: 5000
+  interval: 30s
+  # The number of scraped samples that will be accepted
+  sampleLimit: 5000
    # Additional labels to add to the metadata
-   labels: {}
+  labels: {}


### PR DESCRIPTION
## Description of changes:
Since Prometheus metrics are now available, we want to be able to scrape those metrics. This PR adds a container port for the prometheus metrics and creates a `PodMonitor` to scrape the `/metrics` endpoint.

By adding the following values

```
podMonitor:
  # Specifies whether PodMonitor should be created
  create: true
   # The Prometheus scrape interval
  interval: 30s
  # The number of scraped samples that will be accepted
  sampleLimit: 5000
   # Additional labels to add to the metadata
  labels:
    prometheus: kube-prometheus
```

Generates the following PodMonitor

```
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: release-name-aws-node-termination-handler
  namespace: default
  labels:
    app.kubernetes.io/name: aws-node-termination-handler
    helm.sh/chart: aws-node-termination-handler-0.9.1
    app.kubernetes.io/instance: release-name
    k8s-app: aws-node-termination-handler
    app.kubernetes.io/version: "1.6.1"
    app.kubernetes.io/managed-by: Tiller
    prometheus: kube-prometheus
    
 spec:
  jobLabel: aws-node-termination-handler
  namespaceSelector:
    matchNames:
    - default
  podMetricsEndpoints:
  - interval: 30s
    path: /metrics
    port: http-metrics
  sampleLimit: 5000
  selector:
    matchLabels:
      app.kubernetes.io/name: aws-node-termination-handler
```
Ports
```
apiVersion: apps/v1
kind: DaemonSet
          ports:
          - containerPort: "9092"
            hostPort: "9092"
            name: http-metrics
            protocol: TCP
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
