### PR TITLE
Point to managed policies for required app mesh controller permissions

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -7,38 +7,7 @@ App Mesh controller Helm chart for Kubernetes
 ## Prerequisites
 
 * Kubernetes >= 1.13
-* IAM policies
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "appmesh:*",
-                    "servicediscovery:CreateService",
-                    "servicediscovery:DeleteService",
-                    "servicediscovery:GetService",
-                    "servicediscovery:GetInstance",
-                    "servicediscovery:RegisterInstance",
-                    "servicediscovery:DeregisterInstance",
-                    "servicediscovery:ListInstances",
-                    "servicediscovery:ListNamespaces",
-                    "servicediscovery:ListServices",
-                    "servicediscovery:GetOperation",
-                    "servicediscovery:GetInstancesHealthStatus",
-                    "servicediscovery:UpdateInstanceCustomHealthStatus",
-                    "route53:GetHealthCheck",
-                    "route53:CreateHealthCheck",
-                    "route53:UpdateHealthCheck",
-                    "route53:ChangeResourceRecordSets",
-                    "route53:DeleteHealthCheck"
-                ],
-                "Resource": "*"
-            }
-        ]
-    }
-    ```
+* EKS nodes should have the IAM permissions from the following policies: `AWSAppMeshFullAccess`, `AWSCloudMapFullAccess`
 
 ## Installing the Chart
 


### PR DESCRIPTION
CreateMesh will use the calling identity to create the SLR in the customer account. Without this, the CreateMesh calls from the controller wouldn't be able to create the SLR, which would manifest as Cloud Map discovery issues. AWSAppMeshFullAccess does contain this permission, so the IRSA instructions work fine.

I'm open to alternatives. For example, relying directly on AWSAppMeshFullAccess rather than listing all the permissions here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
