### PR TITLE
aws-node-termination-handler: adding PodMonitor for Prometheus metric…

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,25 +1,19 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.9.2
+version: 0.9.3
 appVersion: 1.6.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
   - https://github.com/aws/eks-charts
 maintainers:
-  - name: Nicholas Turner
-    url: https://github.com/nckturner
-    email: nckturner@users.noreply.github.com
-  - name: Stefan Prodan
-    url: https://github.com/stefanprodan
-    email: stefanprodan@users.noreply.github.com
+  - name: Brandon Wagner
+    url: https://github.com/bwagner5
+    email: bwagner5@users.noreply.github.com
   - name: Jillian Montalvo
     url: https://github.com/jillmon
     email: jillmon@users.noreply.github.com
-  - name: Matthew Becker
-    url: https://github.com/mattrandallbecker
-    email: mattrandallbecker@users.noreply.github.com
 keywords:
   - eks
   - ec2

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -100,6 +100,10 @@ Parameter | Description | Default
 `targetNodeOs | Space separated list of node OS's to target, e.g. "linux", "windows", "linux windows".  Note: Windows support is experimental. | `"linux"`
 `enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`
 `prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
+`podMonitor.create` | if `true`, create a PodMonitor | `false`
+`podMonitor.interval` | Prometheus scrape interval | `30s`
+`podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
+`podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
 
 ## Metrics endpoint consideration
 If prometheus server is enabled and since NTH is a daemonset with `host_networking=true`, nothing else will be able to bind to `:9092` (or the port configured) in the root network namespace

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -151,6 +151,13 @@ spec:
             value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.enablePrometheusServer }}
+          ports:
+          - containerPort: {{ .Values.prometheusServerPort }}
+            hostPort: {{ .Values.prometheusServerPort }}
+            name: http-metrics
+            protocol: TCP
+          {{- end }}
       nodeSelector:
         {{ include "aws-node-termination-handler.nodeSelectorTermsOs" . }}: linux
         {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -123,6 +123,13 @@ spec:
             value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.enablePrometheusServer }}
+          ports:
+          - containerPort: {{ .Values.prometheusServerPort  }}
+            hostPort: {{ .Values.prometheusServerPort }}
+            name: http-metrics
+            protocol: TCP
+          {{- end }}
       nodeSelector:
         {{ include "aws-node-termination-handler.nodeSelectorTermsOs" . }}: windows
         {{- with .Values.nodeSelector }}

--- a/stable/aws-node-termination-handler/templates/podmonitor.yaml
+++ b/stable/aws-node-termination-handler/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "aws-node-termination-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-node-termination-handler.labels" . | indent 4 }}
+{{- with .Values.podMonitor.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+ spec:
+  jobLabel: {{ include "aws-node-termination-handler.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - interval: {{ .Values.podMonitor.interval }}
+    path: /metrics
+    port: http-metrics
+  sampleLimit: {{ .Values.podMonitor.sampleLimit }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+{{- end }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -117,3 +117,13 @@ rbac:
   pspEnabled: true
 
 dnsPolicy: ""
+
+podMonitor:
+  # Specifies whether PodMonitor should be created
+  create: false
+   # The Prometheus scrape interval
+  interval: 30s
+  # The number of scraped samples that will be accepted
+  sampleLimit: 5000
+   # Additional labels to add to the metadata
+  labels: {}


### PR DESCRIPTION
…s, update chart owners

Issue #, if available: N/A

Description of changes:
* Syncing charts after changes to NTH: 
  * [Add PodMonitor for Prometheus Metrics #206](https://github.com/aws/aws-node-termination-handler/pull/206)
  * [bump chart.yaml version #211](https://github.com/aws/aws-node-termination-handler/pull/211)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
