### PR TITLE
Add support for Envoy PreStop Hook Delay, Readiness Probe Parameters …

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.4
+version: 1.1.5
 appVersion: 1.1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -249,11 +249,16 @@ Parameter | Description | Default
 `sidecar.image.repository` | Envoy image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
 `sidecar.image.tag` | Envoy image tag | `<VERSION>`
 `sidecar.logLevel` | Envoy log level | `info`
-`sidecar.resources` | Envoy container resources | `requests: cpu 10m memory 32Mi`
+`sidecar.resources.requests` | Envoy container resource requests | `requests: cpu 10m memory 32Mi`
+`sidecar.resources.limits` | Envoy container resource limits | `limits: cpu "" memory ""`
+`sidecar.lifecycleHooks.preStopDelay` | Envoy container PreStop Hook Delay Value | `20s`
+`sidecar.probes.readinessProbeInitialDelay` | Envoy container Readiness Probe Initial Delay | `1s`
+`sidecar.probes.readinessProbePeriod` | Envoy container Readiness Probe Period | `10s`
 `init.image.repository` | Route manager image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager`
 `init.image.tag` | Route manager image tag | `<VERSION>`
 `stats.tagsEnabled` |  If `true`, Envoy should include app-mesh tags | `false`
 `stats.statsdEnabled` |  If `true`, Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125 | `false`
+`cloudMapCustomHealthCheck.enabled` |  If `true`, CustomHealthCheck will be enabled for CloudMap Services | `false`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -51,9 +51,17 @@ spec:
         - --sidecar-image={{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}
         - --sidecar-cpu-requests={{ .Values.sidecar.resources.requests.cpu }}
         - --sidecar-memory-requests={{ .Values.sidecar.resources.requests.memory }}
+        - --sidecar-cpu-limits={{ .Values.sidecar.resources.limits.cpu }}
+        - --sidecar-memory-limits={{ .Values.sidecar.resources.limits.memory }}
         - --init-image={{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
         - --enable-stats-tags={{ .Values.stats.tagsEnabled }}
         - --enable-statsd={{ .Values.stats.statsdEnabled }}
+        - --prestop-delay={{ .Values.sidecar.lifecycleHooks.preStopDelay }}
+        - --readiness-probe-initial-delay={{ .Values.sidecar.probes.readinessProbeInitialDelay }}
+        - --readiness-probe-period={{ .Values.sidecar.probes.readinessProbePeriod }}
+        {{- if .Values.cloudMapCustomHealthCheck.enabled }}
+        - --enable-custom-health-check=true
+        {{- end }}
         {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "x-ray" ) }}
         - --enable-xray-tracing=true
         {{- end }}

--- a/stable/appmesh-controller/templates/webhook.yaml
+++ b/stable/appmesh-controller/templates/webhook.yaml
@@ -42,8 +42,12 @@ webhooks:
   failurePolicy: Fail
   name: mpod.appmesh.k8s.aws
   namespaceSelector:
-    matchLabels:
-      appmesh.k8s.aws/sidecarInjectorWebhook: enabled
+    matchExpressions:
+      - key: appmesh.k8s.aws/sidecarInjectorWebhook
+        operator: In
+        values:
+          - enabled
+          - disabled
   rules:
   - apiGroups:
     - ""

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -21,6 +21,17 @@ sidecar:
     requests:
       cpu: 10m
       memory: 32Mi
+    # sidecar.resources/limits: Envoy CPU and memory limits
+    limits:
+      cpu: ""
+      memory: ""
+  lifecycleHooks:
+    # sidecar.lifecycleHooks: Envoy PreStop Hook Delay
+    preStopDelay: 20
+  probes:
+    # sidecar.probes: Envoy Readiness Probe
+    readinessProbeInitialDelay: 1
+    readinessProbePeriod: 10
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
@@ -44,6 +55,10 @@ tolerations: []
 affinity: {}
 
 podAnnotations: {}
+
+cloudMapCustomHealthCheck:
+  # cloudMapCustomHealthCheck.enabled: `true` if CustomHealthCheck needs to be enabled in CloudMap
+  enabled: false
 
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 Support for 
  - Envoy PreStop Hook Delay
  - Envoy Readiness Probe Parameters 
  - CloudMap CustomHealthCheck
  - Update MutatingWebHook Namespace selector to reflect https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/338
  - Bump Chart version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
