### PR TITLE
Add v1.1.1 release candidate image to appmesh-controller

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.6
-appVersion: 1.1.0
+version: 1.1.7
+appVersion: 1.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-controller/ci/values.yaml
+++ b/stable/appmesh-controller/ci/values.yaml
@@ -3,5 +3,5 @@
 region: us-west-2
 image:
   repository: fawadkhaliq/appmesh-controller
-  tag: v1.0.0-rc5
+  tag: v1.1.1-rc2
   pullPolicy: IfNotPresent

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -7,7 +7,7 @@ region: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.1.0
+  tag: v1.1.1-rc2
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
Description of changes:
Add v1.1.1 release candidate (v1.1.1-rc2) image for App Mesh controller image to appmesh-controller Helm chart. This will be moved to v1.1.1 with the release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
