### PR TITLE
Bump default appmesh-controller image version to v1.1.1

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.8
+version: 1.1.9
 appVersion: 1.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -7,7 +7,7 @@ region: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.1.1-rc2
+  tag: v1.1.1-linux_amd64
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
Description of changes:
Bump default appmesh-controller image version to [v1.1.1](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.1.1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
