### PR TITLE
Add missing calico-node get configmap permission

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.0
+version: 0.3.1
 appVersion: 3.13.4
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/rbac.yaml
+++ b/stable/aws-calico/templates/rbac.yaml
@@ -6,12 +6,13 @@ metadata:
     app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-node"
 {{ include "aws-calico.labels" . | indent 4 }}
 rules:
-  # The CNI plugin needs to get pods, nodes, and namespaces.
+  # The CNI plugin needs to get pods, nodes, namespaces, and configmaps.
   - apiGroups: [""]
     resources:
       - pods
       - nodes
       - namespaces
+      - configmaps
     verbs:
       - get
   - apiGroups: [""]


### PR DESCRIPTION
Issue:

Using version 0.3.0 of the aws-calico chart on an EKS cluster v1.16.8, the "calico-node" pod was failing with the following logs:
```
[INFO][8] startup.go 309: Early log level set to info
[INFO][8] startup.go 325: Using NODENAME environment for node name
[INFO][8] startup.go 337: Determined node name: ip-xx-x-xx-xxx.xx-xxxx-x.compute.internal
[INFO][8] startup.go 369: Checking datastore connection
[INFO][8] startup.go 393: Datastore connection verified
[INFO][8] startup.go 104: Datastore is ready
[INFO][8] customresource.go 101: Error getting resource Key=GlobalFelixConfig(name=CalicoVersion) Name="calicoversion" Resource="GlobalFelixConfigs" error=the server could not find the requested resource (get GlobalFelixConfigs.crd.projectcalico.org calicoversion)
[ERROR][8] startup.go 146: failed to query kubeadm's config map error=configmaps "kubeadm-config" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
[WARNING][8] startup.go 1214: Terminating
Calico node failed to start
```

Description of changes:
Searching for the error I found the following https://github.com/kubernetes-sigs/kubespray/pull/5912/files# which also bumped Calico to 3.13.x and added the get configmaps permission.

After I made the change I deployed to my cluster and it worked as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
