### PR TITLE
[aws-calico] Add option to override node selectors

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.0
+version: 0.3.1
 appVersion: 3.13.4
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -38,22 +38,25 @@ If you receive an error similar to `Error: release aws-calico failed: <resource>
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter               | Description                                             | Default                         |
-| ------------------------|---------------------------------------------------------|---------------------------------|
-| `calico.typha.image`    | Calico Typha Image                                      | `quay.io/calico/typha`          |
-| `calico.typha.resources`| Calico Typha Resources                                  | `requests.memory: 64Mi, requests.cpu: 50m, limits.memory: 96Mi, limits.cpu: 100m` |
-| `calico.typha.logseverity` | Calico Typha Log Severity                            | `Info`                          |
-| `calico.node.extraEnv`  | Calico Node extra ENV vars                              | `[]`                            |
-| `calico.node.image`     | Calico Node Image                                       | `quay.io/calico/node`           |
-| `calico.node.resources` | Calico Node Resources                                   | `requests.memory: 32Mi, requests.cpu: 20m, limits.memory: 64Mi, limits.cpu: 100m` |
-| `calico.node.logseverity` | Calico Node Log Severity                              | `Info`                          |
-| `calico.typha_autoscaler.resources` | Calico Typha Autoscaler Resources           | `requests.memory: 16Mi, requests.cpu: 10m, limits.memory: 32Mi, limits.cpu: 10m` |
-| `calico.tag`            | Calico version                                          | `v3.8.1`                        |
-| `fullnameOverride`      | Override the fullname of the chart                      | `calico`                        |
-| `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                           |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                          |
-| `autoscaler.image`      | Cluster Proportional Autoscaler Image                   | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
-| `autoscaler.tag`        | Cluster Proportional Autoscaler version                 | `1.1.2`                                            |
+| Parameter                              | Description                                             | Default                         |
+|----------------------------------------|---------------------------------------------------------|---------------------------------|
+| `calico.typha.image`                   | Calico Typha Image                                      | `quay.io/calico/typha`          |
+| `calico.typha.resources`               | Calico Typha Resources                                  | `requests.memory: 64Mi, requests.cpu: 50m, limits.memory: 96Mi, limits.cpu: 100m` |
+| `calico.typha.logseverity`             | Calico Typha Log Severity                               | `Info`                          |
+| `calico.typha.nodeSelector`            | Calico Typha Node Selector                              | `{ beta.kubernetes.io/os: linux }` |
+| `calico.node.extraEnv`                 | Calico Node extra ENV vars                              | `[]`                            |
+| `calico.node.image`                    | Calico Node Image                                       | `quay.io/calico/node`           |
+| `calico.node.resources`                | Calico Node Resources                                   | `requests.memory: 32Mi, requests.cpu: 20m, limits.memory: 64Mi, limits.cpu: 100m` |
+| `calico.node.logseverity`              | Calico Node Log Severity                                | `Info`                          |
+| `calico.node.nodeSelector`             | Calico Node Node Selector                               | `{ beta.kubernetes.io/os: linux }` |
+| `calico.typha_autoscaler.resources`    | Calico Typha Autoscaler Resources                       | `requests.memory: 16Mi, requests.cpu: 10m, limits.memory: 32Mi, limits.cpu: 10m` |
+| `calico.typha_autoscaler.nodeSelector` | Calico Typha Autoscaler Node Selector                   | `{ beta.kubernetes.io/os: linux }` |
+| `calico.tag`                           | Calico version                                          | `v3.8.1`                        |
+| `fullnameOverride`                     | Override the fullname of the chart                      | `calico`                        |
+| `serviceAccount.name`                  | The name of the ServiceAccount to use                   | `nil`                           |
+| `serviceAccount.create`                | Specifies whether a ServiceAccount should be created    | `true`                          |
+| `autoscaler.image`                     | Cluster Proportional Autoscaler Image                   | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
+| `autoscaler.tag`                       | Cluster Proportional Autoscaler version                 | `1.1.2`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        {{- toYaml .Values.calico.node.nodeSelector | nindent 8 }}
       hostNetwork: true
       serviceAccountName: "{{ include "aws-calico.serviceAccountName" . }}-node"
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force

--- a/stable/aws-calico/templates/deployment.yaml
+++ b/stable/aws-calico/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        {{- toYaml .Values.calico.typha.nodeSelector | nindent 8 }}
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
@@ -105,7 +105,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        {{- toYaml .Values.calico.typha_autoscaler.nodeSelector | nindent 8 }}
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -17,6 +17,8 @@ calico:
         memory: "96Mi"
         cpu: "100m"
     tolerations: []
+    nodeSelector:
+      beta.kubernetes.io/os: linux
   node:
     logseverity: Info #Debug, Info, Warning, Error, Fatal
     image: quay.io/calico/node
@@ -30,6 +32,8 @@ calico:
     extraEnv: []
     # - name: SOME_VAR
     #   value: 'some value'
+    nodeSelector:
+      beta.kubernetes.io/os: linux
   typha_autoscaler:
     resources:
       requests:
@@ -39,6 +43,8 @@ calico:
         memory: "32Mi"
         cpu: "10m"
     tolerations: []
+    nodeSelector:
+      beta.kubernetes.io/os: linux
 
 autoscaler:
   tag: "1.7.1"


### PR DESCRIPTION
Signed-off-by: Caspar Rolfe <caspar.rolfe@engineering.digital.dwp.gov.uk>

Description of changes:

Add the option to override node selector on daemon sets and deployments