### PR TITLE
[aws-calico] Fix indentation in deployment templates

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.1
+version: 0.3.2
 appVersion: 3.13.4
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/deployment.yaml
+++ b/stable/aws-calico/templates/deployment.yaml
@@ -24,9 +24,9 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-      {{- if .Values.calico.typha.tolerations }}
-{{ toYaml .Values.calico.typha.tolerations | indent 10 }}
-      {{- end }}
+        {{- if .Values.calico.typha.tolerations }}
+        {{- toYaml .Values.calico.typha.tolerations | nindent 8 }}
+        {{- end }}
       hostNetwork: true
       serviceAccountName: "{{ include "aws-calico.serviceAccountName" . }}-node"
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
@@ -110,9 +110,9 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-      {{- if .Values.calico.typha_autoscaler.tolerations }}
-{{ toYaml .Values.calico.typha_autoscaler.tolerations | indent 10 }}
-      {{- end }}
+        {{- if .Values.calico.typha_autoscaler.tolerations }}
+        {{- toYaml .Values.calico.typha_autoscaler.tolerations | nindent 8 }}
+        {{- end }}
       containers:
         - image: "{{ .Values.autoscaler.image }}:{{ .Values.autoscaler.tag }}"
           name: autoscaler


### PR DESCRIPTION
Description of changes:

Fixes YAML parsing errors when setting tolerations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
