### PR TITLE
Add automatic creation of ENIConfig's

### DIFF
--- a/stable/aws-vpc-cni/templates/eniconfig.yaml
+++ b/stable/aws-vpc-cni/templates/eniconfig.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.crd.create -}}
+{{- range .Values.eni_configs -}}
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+  name: {{ .az }}
+spec:
+  subnet: {{ .subnet }}
+  securityGroups:
+  {{ toYaml .security_groups | indent 2 }}
+---
+{{- end -}}
+{{- end -}}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -61,3 +61,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+eni_configs: []
+# eni_configs:
+# - az: eu-west-1a
+#   subnet: subnet-0bfb6d177a5fce771
+#   security_groups:
+#   - sg-023feb92f68dc6918
+


### PR DESCRIPTION
Added the creation of the ENIConfig to Helm. That allows to pass, for example in our case, the created subnets and SGs from terraform and pass them to Helm.
I used availability zone for the name of ENIConfig as recommanded in the doc.