### PR TITLE
[calico-node] Adds support for pod annotations.

### DIFF
--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-node"
+      {{- with .Values.calico.node.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       priorityClassName: system-node-critical
       nodeSelector:

--- a/stable/aws-calico/templates/deployment.yaml
+++ b/stable/aws-calico/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-typha"
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
+        {{- with .Values.calico.typha.podAnnotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+        {{- end }}
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
@@ -102,6 +105,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-typha-autoscaler"
+        {{- with .Values.calico.typha_autoscaler.podAnnotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+        {{- end }}
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -22,6 +22,7 @@ calico:
     tolerations: []
     nodeSelector:
       beta.kubernetes.io/os: linux
+    podAnnotations: {}
   node:
     logseverity: Info #Debug, Info, Warning, Error, Fatal
     image: quay.io/calico/node
@@ -37,6 +38,7 @@ calico:
     #   value: 'some value'
     nodeSelector:
       beta.kubernetes.io/os: linux
+    podAnnotations: {}
   typha_autoscaler:
     resources:
       requests:
@@ -48,6 +50,7 @@ calico:
     tolerations: []
     nodeSelector:
       beta.kubernetes.io/os: linux
+    podAnnotations: {}
 
 autoscaler:
   tag: "1.7.1"


### PR DESCRIPTION
Description of changes:

This PR adds support for specifying pod annotations on components of `calico-node`. Annotations have many uses. For example many systems such as prometheus or Datadog agents use them to note how metrics should be collected off the pods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
