### PR TITLE
Expose cloudmap-dns-ttl

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -260,6 +260,7 @@ Parameter | Description | Default
 `stats.tagsEnabled` |  If `true`, Envoy should include app-mesh tags | `false`
 `stats.statsdEnabled` |  If `true`, Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125 | `false`
 `cloudMapCustomHealthCheck.enabled` |  If `true`, CustomHealthCheck will be enabled for CloudMap Services | `false`
+`cloudMapDNS.ttl` |  Sets CloudMap DNS TTL | `300`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.cloudMapCustomHealthCheck.enabled }}
         - --enable-custom-health-check=true
         {{- end }}
+        {{- if .Values.cloudMapDNS.ttl }}
+        - --cloudmap-dns-ttl={{ .Values.cloudMapDNS.ttl }}
+        {{- end }}
         {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "x-ray" ) }}
         - --enable-xray-tracing=true
         - --xray-image={{ .Values.xray.image.repository}}:{{ .Values.xray.image.tag }}

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -68,6 +68,10 @@ cloudMapCustomHealthCheck:
   # cloudMapCustomHealthCheck.enabled: `true` if CustomHealthCheck needs to be enabled in CloudMap
   enabled: false
 
+cloudMapDNS:
+  # cloudMapDNS.ttl if set will use this global ttl value
+  ttl: 300
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true


### PR DESCRIPTION

Issue # 
 see:  https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/127

Description of changes:

This allows one to specify the cloudmap DNS TTL in the helm chart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

ping: 
@fawadkhaliq ; @achevuru