### PR TITLE
Don't schedule pods in fargate nodes

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.2
+version: 0.3.3
 appVersion: 3.13.4
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -19,6 +19,15 @@ spec:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-node"
     spec:
       priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: "eks.amazonaws.com/compute-type"
+                  operator: NotIn
+                  values:
+                    - fargate
       nodeSelector:
         {{- toYaml .Values.calico.node.nodeSelector | nindent 8 }}
       hostNetwork: true


### PR DESCRIPTION
Issue #177 

Description of changes:
This resolves an issue where the aws calico pods tries to get scheduled on a fargate pod, adding affinity to make sure that it will not be scheduled on fargate.

This solution is taken from a similar problem with the `aws-node-termination-handler` chart in commit 86c6e24eab7e22f5edfda7884a827c5119d2c2c4 so if there is a different method of solving this let me know


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
