### PR TITLE
add support for aws loadbalancer webhooks

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 0.1.0
+version: 0.1.1
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/crds/crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/crds.yaml
@@ -2,17 +2,30 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.targetType
+    description: The AWS TargetGroup's TargetType
+    name: TARGET-TYPE
+    type: string
+  - JSONPath: .spec.targetGroupARN
+    description: The AWS TargetGroup's Amazon Resource Name
+    name: ARN
+    type: string
   group: elbv2.k8s.aws
   names:
+    categories:
+    - all
     kind: TargetGroupBinding
     listKind: TargetGroupBindingList
     plural: targetgroupbindings
     singular: targetgroupbinding
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: TargetGroupBinding is the Schema for the TargetGroupBinding API

--- a/stable/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/stable/aws-load-balancer-controller/templates/_helpers.tpl
@@ -32,6 +32,16 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Chart name prefix for resource names
+Strip the "-controller" suffix from the default .Chart.Name if the nameOverride is not specified.
+This enables using a shorter name for the resources, for example aws-load-balancer-webhook.
+*/}}
+{{- define "aws-load-balancer-controller.namePrefix" -}}
+{{- $defaultNamePrefix := .Chart.Name | trimSuffix "-controller" -}}
+{{- default $defaultNamePrefix .Values.nameOverride | trunc 42 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "aws-load-balancer-controller.labels" -}}
@@ -60,4 +70,17 @@ Create the name of the service account to use
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Generate certificates for webhook
+*/}}
+{{- define "aws-load-balancer-controller.gen-certs" -}}
+{{- $namePrefix := ( include "aws-load-balancer-controller.namePrefix" . ) -}}
+{{- $altNames := list ( printf "%s-%s.%s" $namePrefix "webhook-service" .Release.Namespace ) ( printf "%s-%s.%s.svc" $namePrefix "webhook-service" .Release.Namespace ) -}}
+{{- $ca := genCA "aws-load-balancer-controller-ca" 3650 -}}
+{{- $cert := genSignedCert ( include "aws-load-balancer-controller.fullname" . ) nil $altNames 3650 $ca -}}
+caCert: {{ $ca.Cert | b64enc }}
+clientCert: {{ $cert.Cert | b64enc }}
+clientKey: {{ $cert.Key | b64enc }}
 {{- end -}}

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -13,26 +13,45 @@ spec:
     metadata:
       labels:
         {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "aws-load-balancer-controller.serviceAccountName" . }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-secret
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
-          args:
-          - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
-          command:
-          - /controller
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+      - name: {{ .Chart.Name }}
+        args:
+        - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
+        command:
+        - /controller
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        ports:
+        - name: webhook-server
+          containerPort: 9443
+          protocol: TCP
+        - name: metrics-server
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+  labels:
+{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -1,0 +1,76 @@
+{{ $tls := fromYaml ( include "aws-load-balancer-controller.gen-certs" . ) }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+{{- if $.Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.fullname" . }}-serving-cert
+{{- end }}
+  name: {{ include "aws-load-balancer-controller.namePrefix" . }}-webhook
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+webhooks:
+- clientConfig:
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+    service:
+      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      namespace: {{ $.Release.Namespace }}
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.elbv2.k8s.aws
+  admissionReviewVersions: ["v1beta1"]
+  sideEffects: NoneOnDryRun
+  namespaceSelector:
+    matchExpressions:
+    - key: elbv2.k8s.aws/pod-readiness-gate-inject
+      operator: In
+      values:
+      - enabled
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+---
+{{- if not $.Values.enableCertManager }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-secret
+  labels:
+{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $tls.caCert }}
+  tls.crt: {{ $tls.clientCert }}
+  tls.key: {{ $tls.clientKey }}
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
+  labels:
+{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+spec:
+  dnsNames:
+  - {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-secret
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  labels:
+{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -5,7 +5,7 @@ kind: MutatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
 {{- end }}
   name: {{ include "aws-load-balancer-controller.namePrefix" . }}-webhook
   labels:
@@ -19,8 +19,8 @@ webhooks:
       path: /mutate-v1-pod
   failurePolicy: Fail
   name: mpod.elbv2.k8s.aws
-  admissionReviewVersions: ["v1beta1"]
-  sideEffects: NoneOnDryRun
+  admissionReviewVersions:
+  - v1beta1
   namespaceSelector:
     matchExpressions:
     - key: elbv2.k8s.aws/pod-readiness-gate-inject
@@ -36,6 +36,61 @@ webhooks:
     - CREATE
     resources:
     - pods
+  sideEffects: None
+- clientConfig:
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+    service:
+      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      namespace: {{ $.Release.Namespace }}
+      path: /mutate-elbv2-k8s-aws-v1alpha1-targetgroupbinding
+  failurePolicy: Fail
+  name: mtargetgroupbinding.elbv2.k8s.aws
+  admissionReviewVersions:
+  - v1beta1
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupbindings
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+{{- if $.Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
+{{- end }}
+  name: {{ include "aws-load-balancer-controller.namePrefix" . }}-webhook
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+webhooks:
+- clientConfig:
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+    service:
+      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      namespace: {{ $.Release.Namespace }}
+      path: /validate-elbv2-k8s-aws-v1alpha1-targetgroupbinding
+  failurePolicy: Fail
+  name: vtargetgroupbinding.elbv2.k8s.aws
+  admissionReviewVersions:
+  - v1beta1
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupbindings
+  sideEffects: None
 ---
 {{- if not $.Values.enableCertManager }}
 apiVersion: v1

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: amazon/aws-alb-ingress-controller
-  tag: v2.0.0-rc1
+  tag: v2.0.0-rc2
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: amazon/aws-alb-ingress-controller
-  tag: v2.0.0-rc0
+  tag: v2.0.0-rc1
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -60,3 +60,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Enable cert-manager
+enableCertManager: false


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add mutating webhooks for pod/targetgroupbindings
Add validating webhooks for targetgroupbindings

Tests run
- created service with NLB-IP annotation and verified loadbalancer and targetgroups get providioned as expected
- ALB gets provisioned for the correctly configured ingress objects
- Verify that targetgroupbinding ARN and type are immutable after creation
- installed chart with --set enableCertManager=true option, and verified that the cert-manager injected the webhook certs as expected, and webhooks are functional 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
