### PR TITLE
[aws-load-balancer-controller] Add support for additional pod annotations and labels

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 0.1.1
+version: 0.1.2
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -213,20 +213,21 @@ helm delete aws-load-balancer-controller -n kube-system
 
 The following tables lists the configurable parameters of the chart and their default values.
 
-| Parameter                         | Description                                               | Default                                                                                   |
-| ----------------------------------| --------------------------------------------------------- | ------------------------------------------------------------------------------------------|
-| `image.repository`                | image repository                                          | `amazon/aws-load-balancer-controller`        						    |
-| `image.tag`                       | image tag                                                 | `<VERSION>`                                                                               |
-| `image.pullPolicy`                | image pull policy                                         | `IfNotPresent`                                                                            |
-| `clusterName`                     | Kubernetes cluster name                                   | None                                                                                      |
-| `securityContext`                 | Set to security context for pod                           | `{}`                                                                                      |
-| `resources`                       | Controller pod resource requests & limits                 | `{}`                                                                                      |
-| `nodeSelector`                    | Node labels for controller pod assignment                 | `{}`                                                                                      |
-| `tolerations`                     | Controller pod toleration for taints                      | `{}`                                                                                      |
-| `affinity`                        | Affinity for pod assignment                               | `{}`                                                                                      |
-| `rbac.create`                     | if `true`, create and use RBAC resources                  | `true`                                                                                    |
-| `serviceAccount.annotations`      | optional annotations to add to service account            | None                                                                                      |
-| `serviceAccount.create`           | If `true`, create a new service account                   | `true`                                                                                    |
-| `serviceAccount.name`             | Service account to be used                                | None                                                                                      |
-| `terminationGracePeriodSeconds`   | Time period for controller pod to do a graceful shutdown  | 10                                                                                        |
-
+| Parameter                          | Description                                               | Default                                                                                    |
+| ---------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `image.repository`                 | image repository                                          | `amazon/aws-load-balancer-controller`                                                      |
+| `image.tag`                        | image tag                                                 | `<VERSION>`                                                                                |
+| `image.pullPolicy`                 | image pull policy                                         | `IfNotPresent`                                                                             |
+| `clusterName`                      | Kubernetes cluster name                                   | None                                                                                       |
+| `securityContext`                  | Set to security context for pod                           | `{}`                                                                                       |
+| `resources`                        | Controller pod resource requests & limits                 | `{}`                                                                                       |
+| `nodeSelector`                     | Node labels for controller pod assignment                 | `{}`                                                                                       |
+| `tolerations`                      | Controller pod toleration for taints                      | `{}`                                                                                       |
+| `affinity`                         | Affinity for pod assignment                               | `{}`                                                                                       |
+| `podAnnotations`                   | Annotations to add to each pod                            | `{}`                                                                                       |
+| `podLabels`                        | Labels to add to each pod                                 | `{}`                                                                                       |
+| `rbac.create`                      | if `true`, create and use RBAC resources                  | `true`                                                                                     |
+| `serviceAccount.annotations`       | optional annotations to add to service account            | None                                                                                       |
+| `serviceAccount.create`            | If `true`, create a new service account                   | `true`                                                                                     |
+| `serviceAccount.name`              | Service account to be used                                | None                                                                                       |
+| `terminationGracePeriodSeconds`    | Time period for controller pod to do a graceful shutdown  | 10                                                                                         |

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -13,9 +13,15 @@ spec:
     metadata:
       labels:
         {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -61,5 +61,9 @@ tolerations: []
 
 affinity: {}
 
+podAnnotations: {}
+
+podLabels: {}
+
 # Enable cert-manager
 enableCertManager: false


### PR DESCRIPTION
### Description of changes:

This replicates the functionality in `appmesh-controller` to allow annotating the Pods in `aws-load-balancer-controller` with additional annotations and labels.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
