### PR TITLE
[aws-for-fluent-bit] Add support for tolerations, affinity, and nodeSelector

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.3
+version: 0.1.4
 appVersion: 2.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -75,3 +75,6 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `extraOutputs` | Adding more outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |
+| `affinity` | Map of node/pod affinities | `{}` |
+| `tolerations` | Optional deployment tolerations | `[]` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -48,4 +48,15 @@ spec:
         - name: fluentbit-config
           configMap:
             name: {{ include "aws-for-fluent-bit.fullname" . }}
-
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -110,3 +110,9 @@ resources:
 
 updateStrategy:
   type: RollingUpdate
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### Description of changes:

This adds support for tolerations, affinity, and nodeSelector to the `aws-for-fluent-bit` chart.

NOTE: I am aware that some of this change was included in https://github.com/aws/eks-charts/pull/150, but the PR appears to be blocked on the discussion around changes to the default resource settings, and we have a need for this in our company so opened a new one with just the changes to tolerations, affinity, and nodeSelector which should hopefully be less controversial. Please feel free to close this one as duplicate if the maintainers and @ArchiFleKs think we can bring the other PR home.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
