### PR TITLE
[aws-for-fluent-bit] add support for elasticsearch fix #265

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.3
-appVersion: 2.2.0
+version: 0.1.4
+appVersion: 2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -31,7 +31,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | - | - | - | -
 | `global.namespaceOverride` | Override the deployment namespace	| Not set (`Release.Namespace`) |
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
-| `image.tag` | Image tag to deploy | `2.2.0`
+| `image.tag` | Image tag to deploy | `2.7.0`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` | 
@@ -72,6 +72,14 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.roleArn` | ARN of an IAM role to assume (for cross account access). | |
 | `kinesis.timeKey` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
 | `kinesis.timeKeyFormat` |  strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
+| `elasticsearch.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | `true` | ✔
+| `elasticsearch.match` | The log filter | `"*"` | ✔
+| `elasticsearch.region` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
+| `elasticsearch.host` | The url of the Elastic Search endpoint you want log records sent to. | | ✔
+| `elasticsearch.aws_auth` | Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service | On |
+| `elasticsearch.tls` | Enable or disable TLS support | On |
+| `elasticsearch.port` | TCP Port of the target service. | 443 |
+| `elasticsearch.retry_limit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
 | `extraOutputs` | Adding more outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -127,6 +127,29 @@ data:
         {{- end }}
 {{- end }}
 
+{{- if .Values.elasticsearch.enabled }}
+    [OUTPUT]
+        Name            es
+        Match           {{ .Values.elasticsearch.match }}
+        AWS_Region      {{ .Values.elasticsearch.region }}
+        AWS_Auth        {{ .Values.elasticsearch.aws_auth }}
+        {{- if .Values.elasticsearch.host }}
+        host            {{ .Values.elasticsearch.host }}
+        {{- end }}
+        {{- if .Values.elasticsearch.port }}
+        Port            {{ .Values.elasticsearch.port }}
+        {{- end }}
+        {{- if .Values.elasticsearch.tls }}
+        TLS             {{ .Values.elasticsearch.tls }}
+        {{- end }}
+        {{- if .Values.elasticsearch.retry_limit }}
+        Retry_Limit     {{ .Values.elasticsearch.retry_limit }}
+        {{- end }}
+        {{- if .Values.elasticsearch.timeKeyFormat }}
+        time_key_format {{ .Values.elasticsearch.timeKeyFormat }}
+        {{- end }}
+{{- end }}
+
 {{- if .Values.extraOutputs }}
 {{ .Values.extraOutputs | indent 4}}
 {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: amazon/aws-for-fluent-bit
-  tag: 2.2.0
+  tag: 2.7.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -36,7 +36,6 @@ input:
 #       Interval_Sec 1
 #       DB           winlog.sqlite
 
-
 filter:
   match: "kube.*"
   kubeURL: "https://kubernetes.default.svc.cluster.local:443"
@@ -63,7 +62,7 @@ cloudWatch:
   roleArn:
   autoCreateGroup: true
   endpoint:
-  credentialsEndpoint:  {}
+  credentialsEndpoint: {}
 
 firehose:
   enabled: true
@@ -86,6 +85,16 @@ kinesis:
   roleArn:
   timeKey:
   timeKeyFormat:
+
+elasticsearch:
+  enabled: true
+  match: "*"
+  host:
+  region: "us-east-1"
+  aws_auth: "On"
+  tls: "On"
+  port: "443"
+  retry_limit: 6
 
 # extraOutputs: |
 #   [OUTPUT]


### PR DESCRIPTION
Signed-off-by: Sebastien Allamand <sebastien@allamand.com>

Issue #, if available: #265 

Description of changes:

- Upgrade to aws-for-fluent-bit [v2.7.0](https://github.com/aws/aws-for-fluent-bit/blob/6c26e384d20168c730dbe0cda70bacde6d41f9df/CHANGELOG.md)
- Add support for ElasticSearch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
