### PR TITLE
Add a note about custom Envoy images testing

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.11
+version: 1.1.12
 appVersion: 1.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -247,7 +247,7 @@ Parameter | Description | Default
 `serviceAccount.annotations` | optional annotations to add to service account | None
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
-`sidecar.image.repository` | Envoy image repository | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
+`sidecar.image.repository` | Envoy image repository. If you override with non-Amazon built Envoy image, you will need to test/ensure it works with the App Mesh | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
 `sidecar.image.tag` | Envoy image tag | `<VERSION>`
 `sidecar.logLevel` | Envoy log level | `info`
 `sidecar.resources.requests` | Envoy container resource requests | `requests: cpu 10m memory 32Mi`


### PR DESCRIPTION
Issue #, if available:

**Description**
We support overriding the Envoy sidecar image and tag in appmesh-controller Helm chart. Users may want to switch between Envoy versions or upgrade without upgrading the controller. If a user overrides Envoy sidecar with a non-Amazon built Envoy image, they will need to verify it works end to end with App Mesh. Added a note for this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
