### PR TITLE
[aws-for-fluent-bit] add latest kinesis features

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.4
+version: 0.1.5
 appVersion: 2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -70,8 +70,12 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.appendNewline` | If you set append_newline as true, a newline will be addded after each log record. | | 
 | `kinesis.dataKeys` | By default, the whole log record will be sent to Kinesis. If you specify key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited. | |
 | `kinesis.roleArn` | ARN of an IAM role to assume (for cross account access). | |
+| `kinesis.endpoint` | Specify a custom endpoint for the Kinesis Streams API. | |
+| `kinesis.stsEndpoint` | Specify a custom endpoint for the STS API; used to assume your custom role provided with `kinesis.roleArn`. | |
 | `kinesis.timeKey` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
 | `kinesis.timeKeyFormat` |  strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
+| `kinesis.aggregation` | Setting aggregation to `true` will enable KPL aggregation of records sent to Kinesis. This feature isn't compatible with the `partitionKey` feature.  See more about KPL aggregation [here](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit#kpl-aggregation). | |
+| `kinesis.compression` | Setting `compression` to `zlib` will enable zlib compression of each record. By default this feature is disabled and records are not compressed. | |
 | `elasticsearch.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | `true` | ✔
 | `elasticsearch.match` | The log filter | `"*"` | ✔
 | `elasticsearch.awsRegion` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -119,11 +119,27 @@ data:
         {{- if .Values.kinesis.endpoint }}
         endpoint        {{ .Values.kinesis.endpoint }}
         {{- end }}
+        {{- if .Values.kinesis.stsEndpoint }}
+        sts_endpoint    {{ .Values.kinesis.stsEndpoint }}
+        {{- end }}
         {{- if .Values.kinesis.timeKey }}
         time_key        {{ .Values.kinesis.timeKey }}
         {{- end }}
         {{- if .Values.kinesis.timeKeyFormat }}
         time_key_format {{ .Values.kinesis.timeKeyFormat }}
+        {{- end }}
+        {{- if .Values.kinesis.aggregation }}
+        aggregation     {{ .Values.kinesis.aggregation }}
+        {{- end }}
+        {{- if .Values.kinesis.compression }}
+        compression     {{ .Values.kinesis.compression }}
+        {{- end }}
+
+        {{- if .Values.kinesis.experimental.concurrency }}
+        experimental_concurrency          {{ .Values.kinesis.experimental.concurrency }}
+        {{- end }}
+        {{- if .Values.kinesis.experimental.concurrencyRetries }}
+        experimental_concurrency_retries  {{ .Values.kinesis.experimental.concurrencyRetries }}
         {{- end }}
 {{- end }}
 

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -83,8 +83,15 @@ kinesis:
   appendNewline:
   dataKeys:
   roleArn:
+  endpoint:
+  stsEndpoint:
   timeKey:
   timeKeyFormat:
+  compression:
+  aggregation:
+  experimental:
+    concurrency:
+    concurrencyRetries:
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
This PR exposes the following new config parameters from the past few Amazon Kinesis Streams for Fluent Bit release:
* `endpoint`
* `sts_endpoint`
* `aggregation`
* `compression`
* `experimental_concurrency`
* `experimental_concurrency_retries`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
