### PR TITLE
Update Envoy image version to v1.15.1.0-prod

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.12
+version: 1.1.13
 appVersion: 1.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -14,7 +14,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.15.0.0-prod
+    tag: v1.15.1.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   resources:

--- a/stable/appmesh-gateway/Chart.yaml
+++ b/stable/appmesh-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-gateway
 description: App Mesh Gateway Helm chart for Kubernetes
-version: 0.1.4
+version: 0.1.5
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-gateway/values.yaml
+++ b/stable/appmesh-gateway/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 image:
   repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-  tag: v1.15.0.0-prod
+  tag: v1.15.1.0-prod
   pullPolicy: IfNotPresent
   # skipImageOverride: when enabled the App Mesh injector will not override the Envoy image
   skipImageOverride: false

--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-inject
 description: App Mesh Inject Helm chart for Kubernetes
-version: 0.14.7
+version: 0.14.8
 appVersion: 0.5.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -13,7 +13,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.15.0.0-prod
+    tag: v1.15.1.0-prod
   # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   resources:


### PR DESCRIPTION
Issue: https://github.com/aws/aws-app-mesh-roadmap/issues/268

Description of changes: Update the Envoy image version to the latest image release, `v1.15.1.0-prod`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
