### PR TITLE
Make hostNetwork Opt-Out

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.8.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.9.5
+version: 0.9.6
 appVersion: 1.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -83,6 +83,7 @@ Parameter | Description | Default
 `priorityClassName` | Name of the priorityClass | `system-node-critical`
 `resources` | Resources for the pods | `requests.cpu: 50m, requests.memory: 64Mi, limits.cpu: 100m, limits.memory: 128Mi`
 `dnsPolicy` | DaemonSet DNS policy | Linux: `ClusterFirstWithHostNet`, Windows: `ClusterFirst`
+`useHostNetwork` | If `true`, enables `hostNetwork` for the Linux DaemonSet.| `true`
 `nodeSelector` | Tells the all daemon sets where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
 `linuxNodeSelector` | Tells the Linux daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
 `windowsNodeSelector` | Tells the Windows daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -69,7 +69,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.useHostNetwork }} 
       dnsPolicy: {{ .Values.dnsPolicy | default "ClusterFirstWithHostNet" | quote }}
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}

--- a/stable/aws-node-termination-handler/templates/psp.yaml
+++ b/stable/aws-node-termination-handler/templates/psp.yaml
@@ -11,6 +11,7 @@ spec:
   privileged: false
   hostIPC: false
   hostNetwork: true
+  hostNetwork: {{ .Values.useHostNetwork }}
   hostPID: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -131,6 +131,11 @@ rbac:
 
 dnsPolicy: ""
 
+# Specified whether the Linux DaemonSet binds to the host network or not.
+# Enabling this gives the pod access to the loopback device, services listening
+# on localhost, and could be used to snoop on network activity of other pods on the same node
+useHostNetwork: true
+
 podMonitor:
   # Specifies whether PodMonitor should be created
   create: false


### PR DESCRIPTION
Issue #238 and aws/aws-node-termination-handler#247

Description of changes:
Makes the use of hostNetwork: true optional.
It seems hostNetwork is not necessary for NTH to function, so should remove it if possible. I have not tested this in an EKS environment however, so that might need to be clarified for the README.
I kept the default as true to avoid any nasty surprises for existing users that might rely on it binding to the host network.

Authored-by:  Leo Palmer Sunmo @leosunmo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
