### PR TITLE
Added a note about Mesh namespace selector in the upgrade steps

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.14
+version: 1.1.15
 appVersion: 1.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -46,6 +46,38 @@ The [configuration](#configuration) section lists the parameters that can be con
 
 ## Upgrade
 
+This section will assist you in upgrading the appmesh-controller from <=v0.5.0 version to >=v1.0.0 version.
+
+You can either build new CRDs from scratch or migrate existing CRDs to the new schema. Please refer to the documentation [here for the new API spec](https://aws.github.io/aws-app-mesh-controller-for-k8s/reference/api_spec/). Also, you can find several examples [here](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs) with v1beta2 spec to help you get started.
+
+Starting v1.0.0, Mesh resource supports namespaceSelectors, where you can either select namespace based on labels (recommended option) or select all namespaces. To select a namespace in a Mesh, you will need to define `namespaceSelector`:
+
+```
+apiVersion: appmesh.k8s.aws/v1beta2
+kind: Mesh
+metadata:
+  name: <mesh-name>
+spec:
+  namespaceSelector:
+    matchLabels:
+      mesh: <mesh-name> // any string value
+```
+
+Note: If you set `namespaceSelector: {}`, mesh will select all the namespace in your cluster.
+
+In the namespace spec, you will need to add a label `mesh: <mesh-name>`. Here's a sample namespace spec:
+
+```
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns
+  labels:
+    mesh: <mesh-name>
+    appmesh.k8s.aws/sidecarInjectorWebhook: enabled
+```
+
+For more examples, please refer to the walkthroughs [here](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs). If you don't find an example that fits your use-case, please read the API spec [here](https://aws.github.io/aws-app-mesh-controller-for-k8s/reference/api_spec/). If you find an issue in the documentation or the examples, please open an issue and we'll help resolve it.
 
 ### Upgrade without preserving old App Mesh resources
 

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -63,7 +63,7 @@ spec:
       mesh: <mesh-name> // any string value
 ```
 
-Note: If you set `namespaceSelector: {}`, mesh will select all the namespace in your cluster.
+Note: If you set `namespaceSelector: {}`, mesh will select all the namespace in your cluster. Labels on your namespace spec is a no-op when selecting all namespaces.
 
 In the namespace spec, you will need to add a label `mesh: <mesh-name>`. Here's a sample namespace spec:
 

--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.10.0
+version: 0.10.1
 appVersion: 1.8.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
**Issue** #194 

**Description of changes**
Added a note about Mesh namespace selector in the upgrade steps

Note: During the revert/merge of https://github.com/aws/eks-charts/pull/278, aws-node-termination-handler chart version was failing in the CI that chart version isn't changed. So bumped to 0.10.1 so the CI does not complain

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
