### PR TITLE
Fix irsa fluent bit

### DIFF
--- a/stable/aws-for-fluent-bit/templates/clusterrole.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/stable/aws-for-fluent-bit/templates/clusterrole.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -14,4 +13,3 @@ rules:
     verbs: ["use"]
     resourceNames:
       - {{ include "aws-for-fluent-bit.fullname" . }}
-{{- end -}}

--- a/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +10,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
     namespace: {{ include "aws-for-fluent-bit.namespace" . }}
-{{- end -}}

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -158,7 +158,7 @@ data:
         {{- if .Values.elasticsearch.tls }}
         TLS             {{ .Values.elasticsearch.tls }}
         {{- end }}
-        {{- if .Values.elasticsearch.retry_limit }}
+        {{- if .Values.elasticsearch.retryLimit }}
         Retry_Limit     {{ .Values.elasticsearch.retryLimit }}
         {{- end }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -109,6 +109,8 @@ elasticsearch:
 #     Format template
 #     Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
 
+rbac:
+  create: true
 serviceAccount:
   create: true
   annotations: {}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -109,8 +109,6 @@ elasticsearch:
 #     Format template
 #     Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
 
-rbac:
-  create: true
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

When deploying the aws-fluent-bit chart using IRSA (Iam role for Service Account) we generally create the service account appart so that it can include the appropriate role. But we also need the chart to create the proper RBAC needed for the chart to run properly.

I added a new value `rbac.enable` which is true by default and will be test instead of `serviceaccount.enable` when creating RBAC.

it is used with following values.yaml extract:

```yaml
rbac:
  enable: true
serviceAccount:
  create: false
  name: aws-for-fluent-bit
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
