### PR TITLE
[aws-load-balancer-controller] revert to rc4

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.0.0
+version: 0.1.6
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.0.0
+  repository: amazon/aws-alb-ingress-controller
+  tag: v2.0.0-rc4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The 2.0.0 image is not available yet, revert to 2.0.0-rc4 image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
