### PR TITLE
[aws-calico] Bump calico to v3.15.1

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.3
-appVersion: 3.13.4
+version: 0.3.4
+appVersion: 3.15.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -82,6 +82,8 @@ spec:
               value: "none"
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "true"
+            - name: FELIX_ROUTESOURCE
+              value: "WorkloadIPs"
             - name: NO_DEFAULT_POOLS
               value: "true"
             # Set based on the k8s node name.

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -7,7 +7,7 @@ podSecurityPolicy:
   create: false
 
 calico:
-  tag: v3.13.4
+  tag: v3.15.1
 
   typha:
     logseverity: Info #Debug, Info, Warning, Error, Fatal


### PR DESCRIPTION
As per aws-cni v1.7.2 and up:
Bump calico version to 3.15.1
Add/set FELIX_ROUTESOURCE env var to "WorkloadIPs"

Ref: aws/amazon-vpc-cni-k8s@190a275

Issue #, if available: N/A

Description of changes:
Update aws-calico version & configuration to be in sync with current aws-cni versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
