### PR TITLE
[aws-load-balancer-controller] Release chart v1.0.0

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 0.1.6
+version: 1.0.0
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -34,7 +34,7 @@ IAM permissions can either be setup via IAM roles for ServiceAccount or can be a
     ```
 1. Download IAM policy for the AWS Load Balancer Controller
     ```
-    curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2_ga/docs/install/iam_policy.json
+    curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
     ```
 1. Create an IAM policy called AWSLoadBalancerControllerIAMPolicy
     ```
@@ -56,11 +56,11 @@ IAM permissions can either be setup via IAM roles for ServiceAccount or can be a
 #### Setup IAM manually
 If not setting up IAM for ServiceAccount, apply the IAM policies from the following URL at minimum.
 ```
-https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v2_ga/docs/install/iam_policy.json
+https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/main/docs/install/iam_policy.json
 ```
 
 #### Upgrading from ALB ingress controller
-If migrating from ALB ingress controller, grant [additional IAM permissions](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2_ga/docs/install/iam_policy_v1_to_v2_additional.json).
+If migrating from ALB ingress controller, grant [additional IAM permissions](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy_v1_to_v2_additional.json).
 
 ## Installing the Chart
 **Note**: You need to uninstall aws-alb-ingress-controller. Please refer to the [upgrade](#Upgrade) section below before you proceed.

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -136,3 +136,4 @@ The following tables lists the configurable parameters of the chart and their de
 | `serviceAccount.name`              | Service account to be used                                | None                                                                                       |
 | `terminationGracePeriodSeconds`    | Time period for controller pod to do a graceful shutdown  | 10                                                                                         |
 | `ingressClass`                     | The ingress class to satisfy                              | alb                                                                                        |
+| `livenessProbe`                    | Liveness probe settings for the controller                | (see `values.yaml`)                                                                        |

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -108,6 +108,12 @@ If you had installed the incubator/aws-alb-ingress-controller Helm chart, uninst
 $ helm delete aws-alb-ingress-controller -n kube-system
 ```
 
+If you had installed the 0.1.x version of eks-charts/aws-load-balancer-controller chart earlier, the upgrade to chart version 1.0.0 will
+not work due to incompatibility of the webhook api version, uninstall as follows
+```shell script
+$ helm delete aws-load-balancer-controller -n kube-system
+```
+
 ## Uninstalling the Chart
 ```sh
 helm delete aws-load-balancer-controller -n kube-system

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -60,7 +60,9 @@ spec:
           containerPort: 8080
           protocol: TCP
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.resources | nindent 10 }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/aws-load-balancer-controller/templates/rbac.yaml
+++ b/stable/aws-load-balancer-controller/templates/rbac.yaml
@@ -32,14 +32,17 @@ metadata:
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 rules:
-- apiGroups: ["elbv2.k8s.aws", ""]
-  resources: [targetgroupbindings, events]
+- apiGroups: ["elbv2.k8s.aws"]
+  resources: [targetgroupbindings]
   verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [create, patch]
 - apiGroups: [""]
   resources: [pods]
   verbs: [get, list, watch]
 - apiGroups: ["", "extensions", "networking.k8s.io"]
-  resources: [pods, services, ingresses]
+  resources: [services, ingresses]
   verbs: [get, list, patch, update, watch]
 - apiGroups: [""]
   resources: [nodes, secrets, namespaces, endpoints]

--- a/stable/aws-load-balancer-controller/templates/rbac.yaml
+++ b/stable/aws-load-balancer-controller/templates/rbac.yaml
@@ -8,13 +8,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [configmaps]
-  verbs: [create, delete, get, list, patch, update, watch]
-- apiGroups: [""]
-  resources: [configmaps/status]
-  verbs: [get, update, patch]
-- apiGroups: [""]
-  resources: [events]
-  verbs: [create]
+  verbs: [create, get, patch, update]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -41,6 +35,9 @@ rules:
 - apiGroups: ["elbv2.k8s.aws", ""]
   resources: [targetgroupbindings, events]
   verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
 - apiGroups: ["", "extensions", "networking.k8s.io"]
   resources: [pods, services, ingresses]
   verbs: [get, list, patch, update, watch]
@@ -49,7 +46,7 @@ rules:
   verbs: [get, list, watch]
 - apiGroups: ["elbv2.k8s.aws", "", "extensions", "networking.k8s.io"]
   resources: [targetgroupbindings/status, pods/status, services/status, ingresses/status]
-  verbs: [get, update, patch]
+  verbs: [update, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -1,6 +1,6 @@
 {{ $tls := fromYaml ( include "aws-load-balancer-controller.gen-certs" . ) }}
 ---
-apiVersion: admissionregistration.k8s.io/v1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
@@ -59,7 +59,7 @@ webhooks:
     - targetgroupbindings
   sideEffects: None
 ---
-apiVersion: admissionregistration.k8s.io/v1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -71,3 +71,13 @@ enableCertManager: false
 # The ingress class this controller will satisfy. If not specified, controller will match all
 # ingresses without ingress class annotation and ingresses of type alb
 ingressClass: alb
+
+# Liveness probe configuration for the controller
+livenessProbe:
+  failureThreshold: 2
+  httpGet:
+    path: /healthz
+    port: 61779
+    scheme: HTTP
+  initialDelaySeconds: 30
+  timeoutSeconds: 10

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: amazon/aws-alb-ingress-controller
-  tag: v2.0.0-rc4
+  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
+  tag: v2.0.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Bump chart version to 1.0.0
- Point to ECR repo for container image
- Tighten RBAC permissions
- Use webhook version v1beta1 for backwards compatibility with older EKS platforms. Due to this change helm chart cannot be upgraded from older RC versions 0.1.x to the 1.0.0 version. The old helm chart has to be uninstalled first by running `helm delete -n kube-system aws-load-balancer-controller`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
