### PR TITLE
[appmesh-controller] CRDs for outlier detection and connection pools

### DIFF
--- a/stable/appmesh-controller/crds/crds.yaml
+++ b/stable/appmesh-controller/crds/crds.yaml
@@ -30,60 +30,42 @@ spec:
       description: GatewayRoute is the Schema for the gatewayroutes API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: GatewayRouteSpec defines the desired state of GatewayRoute
-            refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+          description: GatewayRouteSpec defines the desired state of GatewayRoute refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
           properties:
             awsName:
-              description: AWSName is the AppMesh GatewayRoute object's name. If unspecified
-                or empty, it defaults to be "${name}_${namespace}" of k8s GatewayRoute
+              description: AWSName is the AppMesh GatewayRoute object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s GatewayRoute
               type: string
             grpcRoute:
               description: An object that represents the specification of a gRPC gatewayRoute.
               properties:
                 action:
-                  description: An object that represents the action to take if a match
-                    is determined.
+                  description: An object that represents the action to take if a match is determined.
                   properties:
                     target:
-                      description: An object that represents the target that traffic
-                        is routed to when a request matches the route.
+                      description: An object that represents the target that traffic is routed to when a request matches the route.
                       properties:
                         virtualService:
-                          description: The virtual service to associate with the gateway
-                            route target.
+                          description: The virtual service to associate with the gateway route target.
                           properties:
                             virtualServiceARN:
-                              description: Amazon Resource Name to AppMesh VirtualService
-                                object to associate with the gateway route virtual
-                                service target. Exactly one of 'virtualServiceRef'
-                                or 'virtualServiceARN' must be specified.
+                              description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                               type: string
                             virtualServiceRef:
-                              description: Reference to Kubernetes VirtualService
-                                CR in cluster to associate with the gateway route
-                                virtual service target. Exactly one of 'virtualServiceRef'
-                                or 'virtualServiceARN' must be specified.
+                              description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                               properties:
                                 name:
-                                  description: Name is the name of VirtualService
-                                    CR
+                                  description: Name is the name of VirtualService CR
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of VirtualService
-                                    CR. If unspecified, defaults to the referencing
-                                    object's namespace
+                                  description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
                                   type: string
                               required:
                               - name
@@ -96,12 +78,10 @@ spec:
                   - target
                   type: object
                 match:
-                  description: An object that represents the criteria for determining
-                    a request match.
+                  description: An object that represents the criteria for determining a request match.
                   properties:
                     serviceName:
-                      description: The fully qualified domain name for the service
-                        to match from the request.
+                      description: The fully qualified domain name for the service to match from the request.
                       type: string
                   type: object
               required:
@@ -109,41 +89,28 @@ spec:
               - match
               type: object
             http2Route:
-              description: An object that represents the specification of an HTTP/2
-                gatewayRoute.
+              description: An object that represents the specification of an HTTP/2 gatewayRoute.
               properties:
                 action:
-                  description: An object that represents the action to take if a match
-                    is determined.
+                  description: An object that represents the action to take if a match is determined.
                   properties:
                     target:
-                      description: An object that represents the target that traffic
-                        is routed to when a request matches the route.
+                      description: An object that represents the target that traffic is routed to when a request matches the route.
                       properties:
                         virtualService:
-                          description: The virtual service to associate with the gateway
-                            route target.
+                          description: The virtual service to associate with the gateway route target.
                           properties:
                             virtualServiceARN:
-                              description: Amazon Resource Name to AppMesh VirtualService
-                                object to associate with the gateway route virtual
-                                service target. Exactly one of 'virtualServiceRef'
-                                or 'virtualServiceARN' must be specified.
+                              description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                               type: string
                             virtualServiceRef:
-                              description: Reference to Kubernetes VirtualService
-                                CR in cluster to associate with the gateway route
-                                virtual service target. Exactly one of 'virtualServiceRef'
-                                or 'virtualServiceARN' must be specified.
+                              description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                               properties:
                                 name:
-                                  description: Name is the name of VirtualService
-                                    CR
+                                  description: Name is the name of VirtualService CR
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of VirtualService
-                                    CR. If unspecified, defaults to the referencing
-                                    object's namespace
+                                  description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
                                   type: string
                               required:
                               - name
@@ -156,8 +123,7 @@ spec:
                   - target
                   type: object
                 match:
-                  description: An object that represents the criteria for determining
-                    a request match.
+                  description: An object that represents the criteria for determining a request match.
                   properties:
                     prefix:
                       description: Specifies the path to match requests with
@@ -170,41 +136,28 @@ spec:
               - match
               type: object
             httpRoute:
-              description: An object that represents the specification of an HTTP
-                gatewayRoute.
+              description: An object that represents the specification of an HTTP gatewayRoute.
               properties:
                 action:
-                  description: An object that represents the action to take if a match
-                    is determined.
+                  description: An object that represents the action to take if a match is determined.
                   properties:
                     target:
-                      description: An object that represents the target that traffic
-                        is routed to when a request matches the route.
+                      description: An object that represents the target that traffic is routed to when a request matches the route.
                       properties:
                         virtualService:
-                          description: The virtual service to associate with the gateway
-                            route target.
+                          description: The virtual service to associate with the gateway route target.
                           properties:
                             virtualServiceARN:
-                              description: Amazon Resource Name to AppMesh VirtualService
-                                object to associate with the gateway route virtual
-                                service target. Exactly one of 'virtualServiceRef'
-                                or 'virtualServiceARN' must be specified.
+                              description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                               type: string
                             virtualServiceRef:
-                              description: Reference to Kubernetes VirtualService
-                                CR in cluster to associate with the gateway route
-                                virtual service target. Exactly one of 'virtualServiceRef'
-                                or 'virtualServiceARN' must be specified.
+                              description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                               properties:
                                 name:
-                                  description: Name is the name of VirtualService
-                                    CR
+                                  description: Name is the name of VirtualService CR
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of VirtualService
-                                    CR. If unspecified, defaults to the referencing
-                                    object's namespace
+                                  description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
                                   type: string
                               required:
                               - name
@@ -217,8 +170,7 @@ spec:
                   - target
                   type: object
                 match:
-                  description: An object that represents the criteria for determining
-                    a request match.
+                  description: An object that represents the criteria for determining a request match.
                   properties:
                     prefix:
                       description: Specifies the path to match requests with
@@ -231,10 +183,7 @@ spec:
               - match
               type: object
             meshRef:
-              description: "A reference to k8s Mesh CR that this GatewayRoute belongs
-                to. The admission controller populates it using Meshes's selector,
-                and prevents users from setting this field. \n Populated by the system.
-                Read-only."
+              description: "A reference to k8s Mesh CR that this GatewayRoute belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
               properties:
                 name:
                   description: Name is the name of Mesh CR
@@ -247,17 +196,13 @@ spec:
               - uid
               type: object
             virtualGatewayRef:
-              description: "A reference to k8s VirtualGateway CR that this GatewayRoute
-                belongs to. The admission controller populates it using VirtualGateway's
-                selector, and prevents users from setting this field. \n Populated
-                by the system. Read-only."
+              description: "A reference to k8s VirtualGateway CR that this GatewayRoute belongs to. The admission controller populates it using VirtualGateway's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
               properties:
                 name:
                   description: Name is the name of VirtualGateway CR
                   type: string
                 namespace:
-                  description: Namespace is the namespace of VirtualGateway CR. If
-                    unspecified, defaults to the referencing object's namespace
+                  description: Namespace is the namespace of VirtualGateway CR. If unspecified, defaults to the referencing object's namespace
                   type: string
                 uid:
                   description: UID is the UID of VirtualGateway CR
@@ -275,13 +220,11 @@ spec:
               items:
                 properties:
                   lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                    description: Last time the condition transitioned from one status to another.
                     format: date-time
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: A human readable message indicating details about the transition.
                     type: string
                   reason:
                     description: The reason for the condition's last transition.
@@ -298,8 +241,7 @@ spec:
                 type: object
               type: array
             gatewayRouteARN:
-              description: GatewayRouteARN is the AppMesh GatewayRoute object's Amazon
-                Resource Name
+              description: GatewayRouteARN is the AppMesh GatewayRoute object's Amazon Resource Name
               type: string
             observedGeneration:
               description: The generation observed by the GatewayRoute controller.
@@ -349,14 +291,10 @@ spec:
       description: Mesh is the Schema for the meshes API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -364,13 +302,10 @@ spec:
           description: MeshSpec defines the desired state of Mesh refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_MeshSpec.html
           properties:
             awsName:
-              description: AWSName is the AppMesh Mesh object's name. If unspecified
-                or empty, it defaults to be "${name}" of k8s Mesh
+              description: AWSName is the AppMesh Mesh object's name. If unspecified or empty, it defaults to be "${name}" of k8s Mesh
               type: string
             egressFilter:
-              description: The egress filter rules for the service mesh. If unspecified,
-                default settings from AWS API will be applied. Refer to AWS Docs for
-                default settings.
+              description: The egress filter rules for the service mesh. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
               properties:
                 type:
                   description: The egress filter type.
@@ -382,37 +317,24 @@ spec:
               - type
               type: object
             meshOwner:
-              description: The AWS IAM account ID of the service mesh owner. Required
-                if the account ID is not your own.
+              description: The AWS IAM account ID of the service mesh owner. Required if the account ID is not your own.
               type: string
             namespaceSelector:
-              description: "NamespaceSelector selects Namespaces using labels to designate
-                mesh membership. This field follows standard label selector semantics:
-                \tif present but empty, it selects all namespaces. \tif absent, it
-                selects no namespace."
+              description: "NamespaceSelector selects Namespaces using labels to designate mesh membership. This field follows standard label selector semantics: \tif present but empty, it selects all namespaces. \tif absent, it selects no namespace."
               properties:
                 matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                   items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                     properties:
                       key:
-                        description: key is the label key that the selector applies
-                          to.
+                        description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
+                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
+                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
@@ -424,11 +346,7 @@ spec:
                 matchLabels:
                   additionalProperties:
                     type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                   type: object
               type: object
           type: object
@@ -440,13 +358,11 @@ spec:
               items:
                 properties:
                   lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                    description: Last time the condition transitioned from one status to another.
                     format: date-time
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: A human readable message indicating details about the transition.
                     type: string
                   reason:
                     description: The reason for the condition's last transition.
@@ -515,45 +431,33 @@ spec:
       description: VirtualGateway is the Schema for the virtualgateways API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: VirtualGatewaySpec defines the desired state of VirtualGateway
-            refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+          description: VirtualGatewaySpec defines the desired state of VirtualGateway refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
           properties:
             awsName:
-              description: AWSName is the AppMesh VirtualGateway object's name. If
-                unspecified or empty, it defaults to be "${name}_${namespace}" of
-                k8s VirtualGateway
+              description: AWSName is the AppMesh VirtualGateway object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualGateway
               type: string
             backendDefaults:
-              description: A reference to an object that represents the defaults for
-                backend GatewayRoutes.
+              description: A reference to an object that represents the defaults for backend GatewayRoutes.
               properties:
                 clientPolicy:
                   description: A reference to an object that represents a client policy.
                   properties:
                     tls:
-                      description: A reference to an object that represents a Transport
-                        Layer Security (TLS) client policy.
+                      description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
                       properties:
                         enforce:
-                          description: Whether the policy is enforced. If unspecified,
-                            default settings from AWS API will be applied. Refer to
-                            AWS Docs for default settings.
+                          description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
                           type: boolean
                         ports:
-                          description: The range of ports that the policy is enforced
-                            for.
+                          description: The range of ports that the policy is enforced for.
                           items:
                             format: int64
                             maximum: 65535
@@ -561,21 +465,16 @@ spec:
                             type: integer
                           type: array
                         validation:
-                          description: A reference to an object that represents a
-                            TLS validation context.
+                          description: A reference to an object that represents a TLS validation context.
                           properties:
                             trust:
-                              description: A reference to an object that represents
-                                a TLS validation context trust
+                              description: A reference to an object that represents a TLS validation context trust
                               properties:
                                 acm:
-                                  description: A reference to an object that represents
-                                    a TLS validation context trust for an AWS Certicate
-                                    Manager (ACM) certificate.
+                                  description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
                                   properties:
                                     certificateAuthorityARNs:
-                                      description: One or more ACM Amazon Resource
-                                        Name (ARN)s.
+                                      description: One or more ACM Amazon Resource Name (ARN)s.
                                       items:
                                         type: string
                                       maxItems: 3
@@ -585,13 +484,10 @@ spec:
                                   - certificateAuthorityARNs
                                   type: object
                                 file:
-                                  description: An object that represents a TLS validation
-                                    context trust for a local file.
+                                  description: An object that represents a TLS validation context trust for a local file.
                                   properties:
                                     certificateChain:
-                                      description: The certificate trust chain for
-                                        a certificate stored on the file system of
-                                        the virtual Gateway.
+                                      description: The certificate trust chain for a certificate stored on the file system of the virtual Gateway.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
@@ -608,32 +504,70 @@ spec:
                   type: object
               type: object
             listeners:
-              description: The listener that the virtual gateway is expected to receive
-                inbound traffic from
+              description: The listener that the virtual gateway is expected to receive inbound traffic from
               items:
                 description: VirtualGatewayListener refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
                 properties:
+                  connectionPool:
+                    description: The connection pool settings for the listener
+                    properties:
+                      grpc:
+                        description: Specifies grpc connection pool settings for the virtual gateway listener
+                        properties:
+                          maxRequests:
+                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxRequests
+                        type: object
+                      http:
+                        description: Specifies http connection pool settings for the virtual gateway listener
+                        properties:
+                          maxConnections:
+                            description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
+                            format: int64
+                            minimum: 1
+                            type: integer
+                          maxPendingRequests:
+                            description: Represents the number of overflowing requests after max_connections that an envoy will queue to an upstream cluster.
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxConnections
+                        - maxPendingRequests
+                        type: object
+                      http2:
+                        description: Specifies http2 connection pool settings for the virtual gateway listener
+                        properties:
+                          maxRequests:
+                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxRequests
+                        type: object
+                    type: object
                   healthCheck:
                     description: The health check information for the listener.
                     properties:
                       healthyThreshold:
-                        description: The number of consecutive successful health checks
-                          that must occur before declaring listener healthy.
+                        description: The number of consecutive successful health checks that must occur before declaring listener healthy.
                         format: int64
                         maximum: 10
                         minimum: 2
                         type: integer
                       intervalMillis:
-                        description: The time period in milliseconds between each
-                          health check execution.
+                        description: The time period in milliseconds between each health check execution.
                         format: int64
                         maximum: 300000
                         minimum: 5000
                         type: integer
                       path:
-                        description: The destination path for the health check request.
-                          This value is only used if the specified protocol is http
-                          or http2. For any other protocol, this value is ignored.
+                        description: The destination path for the health check request. This value is only used if the specified protocol is http or http2. For any other protocol, this value is ignored.
                         type: string
                       port:
                         description: The destination port for the health check request.
@@ -649,15 +583,13 @@ spec:
                         - http2
                         type: string
                       timeoutMillis:
-                        description: The amount of time to wait when receiving a response
-                          from the health check, in milliseconds.
+                        description: The amount of time to wait when receiving a response from the health check, in milliseconds.
                         format: int64
                         maximum: 60000
                         minimum: 2000
                         type: integer
                       unhealthyThreshold:
-                        description: The number of consecutive failed health checks
-                          that must occur before declaring a virtual Gateway unhealthy.
+                        description: The number of consecutive failed health checks that must occur before declaring a virtual Gateway unhealthy.
                         format: int64
                         maximum: 10
                         minimum: 2
@@ -689,27 +621,22 @@ spec:
                     - protocol
                     type: object
                   tls:
-                    description: A reference to an object that represents the Transport
-                      Layer Security (TLS) properties for a listener.
+                    description: A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.
                     properties:
                       certificate:
-                        description: A reference to an object that represents a listener's
-                          TLS certificate.
+                        description: A reference to an object that represents a listener's TLS certificate.
                         properties:
                           acm:
-                            description: A reference to an object that represents
-                              an AWS Certificate Manager (ACM) certificate.
+                            description: A reference to an object that represents an AWS Certificate Manager (ACM) certificate.
                             properties:
                               certificateARN:
-                                description: The Amazon Resource Name (ARN) for the
-                                  certificate.
+                                description: The Amazon Resource Name (ARN) for the certificate.
                                 type: string
                             required:
                             - certificateARN
                             type: object
                           file:
-                            description: A reference to an object that represents
-                              a local file certificate.
+                            description: A reference to an object that represents a local file certificate.
                             properties:
                               certificateChain:
                                 description: The certificate chain for the certificate.
@@ -717,8 +644,7 @@ spec:
                                 minLength: 1
                                 type: string
                               privateKey:
-                                description: The private key for a certificate stored
-                                  on the file system of the virtual Gateway.
+                                description: The private key for a certificate stored on the file system of the virtual Gateway.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
@@ -745,15 +671,13 @@ spec:
               minItems: 0
               type: array
             logging:
-              description: The inbound and outbound access logging information for
-                the virtual gateway.
+              description: The inbound and outbound access logging information for the virtual gateway.
               properties:
                 accessLog:
                   description: The access log configuration for a virtual Gateway.
                   properties:
                     file:
-                      description: The file object to send virtual gateway access
-                        logs to.
+                      description: The file object to send virtual gateway access logs to.
                       properties:
                         path:
                           description: The file path to write access logs to.
@@ -766,10 +690,7 @@ spec:
                   type: object
               type: object
             meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualGateway belongs
-                to. The admission controller populates it using Meshes's selector,
-                and prevents users from setting this field. \n Populated by the system.
-                Read-only."
+              description: "A reference to k8s Mesh CR that this VirtualGateway belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
               properties:
                 name:
                   description: Name is the name of Mesh CR
@@ -782,32 +703,21 @@ spec:
               - uid
               type: object
             namespaceSelector:
-              description: NamespaceSelector selects Namespaces using labels to designate
-                GatewayRoute membership. This field follows standard label selector
-                semantics; if present but empty, it selects all namespaces.
+              description: NamespaceSelector selects Namespaces using labels to designate GatewayRoute membership. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
               properties:
                 matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                   items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                     properties:
                       key:
-                        description: key is the label key that the selector applies
-                          to.
+                        description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
+                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
+                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
@@ -819,41 +729,25 @@ spec:
                 matchLabels:
                   additionalProperties:
                     type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                   type: object
               type: object
             podSelector:
-              description: "PodSelector selects Pods using labels to designate VirtualGateway
-                membership. This field follows standard label selector semantics:
-                \tif present but empty, it selects all pods within namespace. \tif
-                absent, it selects no pod."
+              description: "PodSelector selects Pods using labels to designate VirtualGateway membership. This field follows standard label selector semantics: \tif present but empty, it selects all pods within namespace. \tif absent, it selects no pod."
               properties:
                 matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                   items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                     properties:
                       key:
-                        description: key is the label key that the selector applies
-                          to.
+                        description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
+                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
+                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
@@ -865,11 +759,7 @@ spec:
                 matchLabels:
                   additionalProperties:
                     type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                   type: object
               type: object
           type: object
@@ -881,13 +771,11 @@ spec:
               items:
                 properties:
                   lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                    description: Last time the condition transitioned from one status to another.
                     format: date-time
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: A human readable message indicating details about the transition.
                     type: string
                   reason:
                     description: The reason for the condition's last transition.
@@ -908,8 +796,7 @@ spec:
               format: int64
               type: integer
             virtualGatewayARN:
-              description: VirtualGatewayARN is the AppMesh VirtualGateway object's
-                Amazon Resource Name
+              description: VirtualGatewayARN is the AppMesh VirtualGateway object's Amazon Resource Name
               type: string
           type: object
       type: object
@@ -957,44 +844,33 @@ spec:
       description: VirtualNode is the Schema for the virtualnodes API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: VirtualNodeSpec defines the desired state of VirtualNode refers
-            to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualNodeSpec.html
+          description: VirtualNodeSpec defines the desired state of VirtualNode refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualNodeSpec.html
           properties:
             awsName:
-              description: AWSName is the AppMesh VirtualNode object's name. If unspecified
-                or empty, it defaults to be "${name}_${namespace}" of k8s VirtualNode
+              description: AWSName is the AppMesh VirtualNode object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualNode
               type: string
             backendDefaults:
-              description: A reference to an object that represents the defaults for
-                backends.
+              description: A reference to an object that represents the defaults for backends.
               properties:
                 clientPolicy:
                   description: A reference to an object that represents a client policy.
                   properties:
                     tls:
-                      description: A reference to an object that represents a Transport
-                        Layer Security (TLS) client policy.
+                      description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
                       properties:
                         enforce:
-                          description: Whether the policy is enforced. If unspecified,
-                            default settings from AWS API will be applied. Refer to
-                            AWS Docs for default settings.
+                          description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
                           type: boolean
                         ports:
-                          description: The range of ports that the policy is enforced
-                            for.
+                          description: The range of ports that the policy is enforced for.
                           items:
                             format: int64
                             maximum: 65535
@@ -1002,21 +878,16 @@ spec:
                             type: integer
                           type: array
                         validation:
-                          description: A reference to an object that represents a
-                            TLS validation context.
+                          description: A reference to an object that represents a TLS validation context.
                           properties:
                             trust:
-                              description: A reference to an object that represents
-                                a TLS validation context trust
+                              description: A reference to an object that represents a TLS validation context trust
                               properties:
                                 acm:
-                                  description: A reference to an object that represents
-                                    a TLS validation context trust for an AWS Certicate
-                                    Manager (ACM) certificate.
+                                  description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
                                   properties:
                                     certificateAuthorityARNs:
-                                      description: One or more ACM Amazon Resource
-                                        Name (ARN)s.
+                                      description: One or more ACM Amazon Resource Name (ARN)s.
                                       items:
                                         type: string
                                       maxItems: 3
@@ -1026,14 +897,10 @@ spec:
                                   - certificateAuthorityARNs
                                   type: object
                                 file:
-                                  description: An object that represents a TLS validation
-                                    context trust for a local file.
+                                  description: An object that represents a TLS validation context trust for a local file.
                                   properties:
                                     certificateChain:
-                                      description: The certificate trust chain for
-                                        a certificate stored on the file system of
-                                        the virtual node that the proxy is running
-                                        on.
+                                      description: The certificate trust chain for a certificate stored on the file system of the virtual node that the proxy is running on.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
@@ -1050,31 +917,24 @@ spec:
                   type: object
               type: object
             backends:
-              description: The backends that the virtual node is expected to send
-                outbound traffic to.
+              description: The backends that the virtual node is expected to send outbound traffic to.
               items:
                 description: Backend refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Backend.html
                 properties:
                   virtualService:
-                    description: Specifies a virtual service to use as a backend for
-                      a virtual node.
+                    description: Specifies a virtual service to use as a backend for a virtual node.
                     properties:
                       clientPolicy:
-                        description: A reference to an object that represents the
-                          client policy for a backend.
+                        description: A reference to an object that represents the client policy for a backend.
                         properties:
                           tls:
-                            description: A reference to an object that represents
-                              a Transport Layer Security (TLS) client policy.
+                            description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
                             properties:
                               enforce:
-                                description: Whether the policy is enforced. If unspecified,
-                                  default settings from AWS API will be applied. Refer
-                                  to AWS Docs for default settings.
+                                description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
                                 type: boolean
                               ports:
-                                description: The range of ports that the policy is
-                                  enforced for.
+                                description: The range of ports that the policy is enforced for.
                                 items:
                                   format: int64
                                   maximum: 65535
@@ -1082,21 +942,16 @@ spec:
                                   type: integer
                                 type: array
                               validation:
-                                description: A reference to an object that represents
-                                  a TLS validation context.
+                                description: A reference to an object that represents a TLS validation context.
                                 properties:
                                   trust:
-                                    description: A reference to an object that represents
-                                      a TLS validation context trust
+                                    description: A reference to an object that represents a TLS validation context trust
                                     properties:
                                       acm:
-                                        description: A reference to an object that
-                                          represents a TLS validation context trust
-                                          for an AWS Certicate Manager (ACM) certificate.
+                                        description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
                                         properties:
                                           certificateAuthorityARNs:
-                                            description: One or more ACM Amazon Resource
-                                              Name (ARN)s.
+                                            description: One or more ACM Amazon Resource Name (ARN)s.
                                             items:
                                               type: string
                                             maxItems: 3
@@ -1106,14 +961,10 @@ spec:
                                         - certificateAuthorityARNs
                                         type: object
                                       file:
-                                        description: An object that represents a TLS
-                                          validation context trust for a local file.
+                                        description: An object that represents a TLS validation context trust for a local file.
                                         properties:
                                           certificateChain:
-                                            description: The certificate trust chain
-                                              for a certificate stored on the file
-                                              system of the virtual node that the
-                                              proxy is running on.
+                                            description: The certificate trust chain for a certificate stored on the file system of the virtual node that the proxy is running on.
                                             maxLength: 255
                                             minLength: 1
                                             type: string
@@ -1129,24 +980,16 @@ spec:
                             type: object
                         type: object
                       virtualServiceARN:
-                        description: Amazon Resource Name to AppMesh VirtualService
-                          object that is acting as a virtual node backend. Exactly
-                          one of 'virtualServiceRef' or 'virtualServiceARN' must be
-                          specified.
+                        description: Amazon Resource Name to AppMesh VirtualService object that is acting as a virtual node backend. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                         type: string
                       virtualServiceRef:
-                        description: Reference to Kubernetes VirtualService CR in
-                          cluster that is acting as a virtual node backend. Exactly
-                          one of 'virtualServiceRef' or 'virtualServiceARN' must be
-                          specified.
+                        description: Reference to Kubernetes VirtualService CR in cluster that is acting as a virtual node backend. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
                         properties:
                           name:
                             description: Name is the name of VirtualService CR
                             type: string
                           namespace:
-                            description: Namespace is the namespace of VirtualService
-                              CR. If unspecified, defaults to the referencing object's
-                              namespace
+                            description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
                             type: string
                         required:
                         - name
@@ -1157,32 +1000,81 @@ spec:
                 type: object
               type: array
             listeners:
-              description: The listener that the virtual node is expected to receive
-                inbound traffic from
+              description: The listener that the virtual node is expected to receive inbound traffic from
               items:
                 description: Listener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Listener.html
                 properties:
+                  connectionPool:
+                    description: The connection pool settings for the listener
+                    properties:
+                      grpc:
+                        description: Specifies grpc connection pool settings for the virtual node listener
+                        properties:
+                          maxRequests:
+                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxRequests
+                        type: object
+                      http:
+                        description: Specifies http connection pool settings for the virtual node listener
+                        properties:
+                          maxConnections:
+                            description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
+                            format: int64
+                            minimum: 1
+                            type: integer
+                          maxPendingRequests:
+                            description: Represents the number of overflowing requests after max_connections that an envoy will queue to an upstream cluster.
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxConnections
+                        - maxPendingRequests
+                        type: object
+                      http2:
+                        description: Specifies http2 connection pool settings for the virtual node listener
+                        properties:
+                          maxRequests:
+                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxRequests
+                        type: object
+                      tcp:
+                        description: Specifies tcp connection pool settings for the virtual node listener
+                        properties:
+                          maxConnections:
+                            description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
+                            format: int64
+                            minimum: 1
+                            type: integer
+                        required:
+                        - maxConnections
+                        type: object
+                    type: object
                   healthCheck:
                     description: The health check information for the listener.
                     properties:
                       healthyThreshold:
-                        description: The number of consecutive successful health checks
-                          that must occur before declaring listener healthy.
+                        description: The number of consecutive successful health checks that must occur before declaring listener healthy.
                         format: int64
                         maximum: 10
                         minimum: 2
                         type: integer
                       intervalMillis:
-                        description: The time period in milliseconds between each
-                          health check execution.
+                        description: The time period in milliseconds between each health check execution.
                         format: int64
                         maximum: 300000
                         minimum: 5000
                         type: integer
                       path:
-                        description: The destination path for the health check request.
-                          This value is only used if the specified protocol is http
-                          or http2. For any other protocol, this value is ignored.
+                        description: The destination path for the health check request. This value is only used if the specified protocol is http or http2. For any other protocol, this value is ignored.
                         type: string
                       port:
                         description: The destination port for the health check request.
@@ -1199,15 +1091,13 @@ spec:
                         - tcp
                         type: string
                       timeoutMillis:
-                        description: The amount of time to wait when receiving a response
-                          from the health check, in milliseconds.
+                        description: The amount of time to wait when receiving a response from the health check, in milliseconds.
                         format: int64
                         maximum: 60000
                         minimum: 2000
                         type: integer
                       unhealthyThreshold:
-                        description: The number of consecutive failed health checks
-                          that must occur before declaring a virtual node unhealthy.
+                        description: The number of consecutive failed health checks that must occur before declaring a virtual node unhealthy.
                         format: int64
                         maximum: 10
                         minimum: 2
@@ -1218,6 +1108,62 @@ spec:
                     - protocol
                     - timeoutMillis
                     - unhealthyThreshold
+                    type: object
+                  outlierDetection:
+                    description: The outlier detection for the listener
+                    properties:
+                      baseEjectionDuration:
+                        description: The base time that a host is ejected for. The real time is equal to the base time multiplied by the number of times the host has been ejected
+                        properties:
+                          unit:
+                            description: A unit of time.
+                            enum:
+                            - s
+                            - ms
+                            type: string
+                          value:
+                            description: A number of time units.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                        required:
+                        - unit
+                        - value
+                        type: object
+                      interval:
+                        description: The time interval between ejection analysis sweeps. This can result in both new ejections as well as hosts being returned to service
+                        properties:
+                          unit:
+                            description: A unit of time.
+                            enum:
+                            - s
+                            - ms
+                            type: string
+                          value:
+                            description: A number of time units.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                        required:
+                        - unit
+                        - value
+                        type: object
+                      maxEjectionPercent:
+                        description: The threshold for the max percentage of outlier hosts that can be ejected from the load balancing set. maxEjectionPercent=100 means outlier detection can potentially eject all of the hosts from the upstream service if they are all considered outliers, leaving the load balancing set with zero hosts
+                        format: int64
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      maxServerErrors:
+                        description: The threshold for the number of server errors returned by a given host during an outlier detection interval. If the server error count meets/exceeds this threshold the host is ejected. A server error is defined as any HTTP 5xx response (or the equivalent for gRPC and TCP connections)
+                        format: int64
+                        minimum: 1
+                        type: integer
+                    required:
+                    - baseEjectionDuration
+                    - interval
+                    - maxEjectionPercent
+                    - maxServerErrors
                     type: object
                   portMapping:
                     description: The port mapping information for the listener.
@@ -1244,8 +1190,7 @@ spec:
                     description: A reference to an object that represents
                     properties:
                       grpc:
-                        description: Specifies grpc timeout information for the virtual
-                          node.
+                        description: Specifies grpc timeout information for the virtual node.
                         properties:
                           idle:
                             description: An object that represents idle timeout duration.
@@ -1266,8 +1211,7 @@ spec:
                             - value
                             type: object
                           perRequest:
-                            description: An object that represents per request timeout
-                              duration.
+                            description: An object that represents per request timeout duration.
                             properties:
                               unit:
                                 description: A unit of time.
@@ -1286,8 +1230,7 @@ spec:
                             type: object
                         type: object
                       http:
-                        description: Specifies http timeout information for the virtual
-                          node.
+                        description: Specifies http timeout information for the virtual node.
                         properties:
                           idle:
                             description: An object that represents idle timeout duration.
@@ -1308,8 +1251,7 @@ spec:
                             - value
                             type: object
                           perRequest:
-                            description: An object that represents per request timeout
-                              duration.
+                            description: An object that represents per request timeout duration.
                             properties:
                               unit:
                                 description: A unit of time.
@@ -1349,8 +1291,7 @@ spec:
                             - value
                             type: object
                           perRequest:
-                            description: An object that represents per request timeout
-                              duration.
+                            description: An object that represents per request timeout duration.
                             properties:
                               unit:
                                 description: A unit of time.
@@ -1369,8 +1310,7 @@ spec:
                             type: object
                         type: object
                       tcp:
-                        description: Specifies tcp timeout information for the virtual
-                          node.
+                        description: Specifies tcp timeout information for the virtual node.
                         properties:
                           idle:
                             description: An object that represents idle timeout duration.
@@ -1393,27 +1333,22 @@ spec:
                         type: object
                     type: object
                   tls:
-                    description: A reference to an object that represents the Transport
-                      Layer Security (TLS) properties for a listener.
+                    description: A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.
                     properties:
                       certificate:
-                        description: A reference to an object that represents a listener's
-                          TLS certificate.
+                        description: A reference to an object that represents a listener's TLS certificate.
                         properties:
                           acm:
-                            description: A reference to an object that represents
-                              an AWS Certificate Manager (ACM) certificate.
+                            description: A reference to an object that represents an AWS Certificate Manager (ACM) certificate.
                             properties:
                               certificateARN:
-                                description: The Amazon Resource Name (ARN) for the
-                                  certificate.
+                                description: The Amazon Resource Name (ARN) for the certificate.
                                 type: string
                             required:
                             - certificateARN
                             type: object
                           file:
-                            description: A reference to an object that represents
-                              a local file certificate.
+                            description: A reference to an object that represents a local file certificate.
                             properties:
                               certificateChain:
                                 description: The certificate chain for the certificate.
@@ -1421,9 +1356,7 @@ spec:
                                 minLength: 1
                                 type: string
                               privateKey:
-                                description: The private key for a certificate stored
-                                  on the file system of the virtual node that the
-                                  proxy is running on.
+                                description: The private key for a certificate stored on the file system of the virtual node that the proxy is running on.
                                 maxLength: 255
                                 minLength: 1
                                 type: string
@@ -1450,15 +1383,13 @@ spec:
               minItems: 0
               type: array
             logging:
-              description: The inbound and outbound access logging information for
-                the virtual node.
+              description: The inbound and outbound access logging information for the virtual node.
               properties:
                 accessLog:
                   description: The access log configuration for a virtual node.
                   properties:
                     file:
-                      description: The file object to send virtual node access logs
-                        to.
+                      description: The file object to send virtual node access logs to.
                       properties:
                         path:
                           description: The file path to write access logs to.
@@ -1471,10 +1402,7 @@ spec:
                   type: object
               type: object
             meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualNode belongs
-                to. The admission controller populates it using Meshes's selector,
-                and prevents users from setting this field. \n Populated by the system.
-                Read-only."
+              description: "A reference to k8s Mesh CR that this VirtualNode belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
               properties:
                 name:
                   description: Name is the name of Mesh CR
@@ -1487,33 +1415,21 @@ spec:
               - uid
               type: object
             podSelector:
-              description: "PodSelector selects Pods using labels to designate VirtualNode
-                membership. This field follows standard label selector semantics:
-                \tif present but empty, it selects all pods within namespace. \tif
-                absent, it selects no pod."
+              description: "PodSelector selects Pods using labels to designate VirtualNode membership. This field follows standard label selector semantics: \tif present but empty, it selects all pods within namespace. \tif absent, it selects no pod."
               properties:
                 matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                   items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                     properties:
                       key:
-                        description: key is the label key that the selector applies
-                          to.
+                        description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
+                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
+                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
@@ -1525,36 +1441,27 @@ spec:
                 matchLabels:
                   additionalProperties:
                     type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                   type: object
               type: object
             serviceDiscovery:
-              description: The service discovery information for the virtual node.
+              description: The service discovery information for the virtual node. Optional if there is no inbound traffic(no listeners). Mandatory if a listener is specified.
               properties:
                 awsCloudMap:
-                  description: Specifies any AWS Cloud Map information for the virtual
-                    node.
+                  description: Specifies any AWS Cloud Map information for the virtual node.
                   properties:
                     attributes:
-                      description: A string map that contains attributes with values
-                        that you can use to filter instances by any custom attribute
-                        that you specified when you registered the instance
+                      description: A string map that contains attributes with values that you can use to filter instances by any custom attribute that you specified when you registered the instance
                       items:
                         description: AWSCloudMapInstanceAttribute refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_AwsCloudMapInstanceAttribute.html
                         properties:
                           key:
-                            description: The name of an AWS Cloud Map service instance
-                              attribute key.
+                            description: The name of an AWS Cloud Map service instance attribute key.
                             maxLength: 255
                             minLength: 1
                             type: string
                           value:
-                            description: The value of an AWS Cloud Map service instance
-                              attribute key.
+                            description: The value of an AWS Cloud Map service instance attribute key.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -1581,8 +1488,7 @@ spec:
                   description: Specifies the DNS information for the virtual node.
                   properties:
                     hostname:
-                      description: Specifies the DNS service discovery hostname for
-                        the virtual node.
+                      description: Specifies the DNS service discovery hostname for the virtual node.
                       type: string
                   required:
                   - hostname
@@ -1597,13 +1503,11 @@ spec:
               items:
                 properties:
                   lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                    description: Last time the condition transitioned from one status to another.
                     format: date-time
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: A human readable message indicating details about the transition.
                     type: string
                   reason:
                     description: The reason for the condition's last transition.
@@ -1624,8 +1528,7 @@ spec:
               format: int64
               type: integer
             virtualNodeARN:
-              description: VirtualNodeARN is the AppMesh VirtualNode object's Amazon
-                Resource Name
+              description: VirtualNodeARN is the AppMesh VirtualNode object's Amazon Resource Name
               type: string
           type: object
       type: object
@@ -1673,29 +1576,21 @@ spec:
       description: VirtualRouter is the Schema for the virtualrouters API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: VirtualRouterSpec defines the desired state of VirtualRouter
-            refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterSpec.html
+          description: VirtualRouterSpec defines the desired state of VirtualRouter refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterSpec.html
           properties:
             awsName:
-              description: AWSName is the AppMesh VirtualRouter object's name. If
-                unspecified or empty, it defaults to be "${name}_${namespace}" of
-                k8s VirtualRouter
+              description: AWSName is the AppMesh VirtualRouter object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualRouter
               type: string
             listeners:
-              description: The listeners that the virtual router is expected to receive
-                inbound traffic from
+              description: The listeners that the virtual router is expected to receive inbound traffic from
               items:
                 description: VirtualRouterListener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterListener.html
                 properties:
@@ -1727,10 +1622,7 @@ spec:
               minItems: 1
               type: array
             meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualRouter belongs
-                to. The admission controller populates it using Meshes's selector,
-                and prevents users from setting this field. \n Populated by the system.
-                Read-only."
+              description: "A reference to k8s Mesh CR that this VirtualRouter belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
               properties:
                 name:
                   description: Name is the name of Mesh CR
@@ -1748,46 +1640,33 @@ spec:
                 description: Route refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteSpec.html
                 properties:
                   grpcRoute:
-                    description: An object that represents the specification of a
-                      gRPC route.
+                    description: An object that represents the specification of a gRPC route.
                     properties:
                       action:
-                        description: An object that represents the action to take
-                          if a match is determined.
+                        description: An object that represents the action to take if a match is determined.
                         properties:
                           weightedTargets:
-                            description: An object that represents the targets that
-                              traffic is routed to when a request matches the route.
+                            description: An object that represents the targets that traffic is routed to when a request matches the route.
                             items:
                               description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
                               properties:
                                 virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode
-                                    object to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   type: string
                                 virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode
-                                    CR in cluster to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   properties:
                                     name:
-                                      description: Name is the name of VirtualNode
-                                        CR
+                                      description: Name is the name of VirtualNode CR
                                       type: string
                                     namespace:
-                                      description: Namespace is the namespace of VirtualNode
-                                        CR. If unspecified, defaults to the referencing
-                                        object's namespace
+                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 weight:
-                                  description: The relative weight of the weighted
-                                    target.
+                                  description: The relative weight of the weighted target.
                                   format: int64
                                   maximum: 100
                                   minimum: 0
@@ -1802,38 +1681,31 @@ spec:
                         - weightedTargets
                         type: object
                       match:
-                        description: An object that represents the criteria for determining
-                          a request match.
+                        description: An object that represents the criteria for determining a request match.
                         properties:
                           metadata:
-                            description: An object that represents the data to match
-                              from the request.
+                            description: An object that represents the data to match from the request.
                             items:
                               description: GRPCRouteMetadata refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcRouteMetadata.html
                               properties:
                                 invert:
-                                  description: Specify True to match anything except
-                                    the match criteria. The default value is False.
+                                  description: Specify True to match anything except the match criteria. The default value is False.
                                   type: boolean
                                 match:
-                                  description: An object that represents the data
-                                    to match from the request.
+                                  description: An object that represents the data to match from the request.
                                   properties:
                                     exact:
-                                      description: The value sent by the client must
-                                        match the specified value exactly.
+                                      description: The value sent by the client must match the specified value exactly.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     prefix:
-                                      description: The value sent by the client must
-                                        begin with the specified characters.
+                                      description: The value sent by the client must begin with the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     range:
-                                      description: An object that represents the range
-                                        of values to match on
+                                      description: An object that represents the range of values to match on
                                       properties:
                                         end:
                                           description: The end of the range.
@@ -1845,14 +1717,12 @@ spec:
                                           type: integer
                                       type: object
                                     regex:
-                                      description: The value sent by the client must
-                                        include the specified characters.
+                                      description: The value sent by the client must include the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     suffix:
-                                      description: The value sent by the client must
-                                        end with the specified characters.
+                                      description: The value sent by the client must end with the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
@@ -1869,14 +1739,12 @@ spec:
                             minItems: 1
                             type: array
                           methodName:
-                            description: The method name to match from the request.
-                              If you specify a name, you must also specify a serviceName.
+                            description: The method name to match from the request. If you specify a name, you must also specify a serviceName.
                             maxLength: 50
                             minLength: 1
                             type: string
                           serviceName:
-                            description: The fully qualified domain name for the service
-                              to match from the request.
+                            description: The fully qualified domain name for the service to match from the request.
                             type: string
                         type: object
                       retryPolicy:
@@ -1962,8 +1830,7 @@ spec:
                             - value
                             type: object
                           perRequest:
-                            description: An object that represents per request timeout
-                              duration.
+                            description: An object that represents per request timeout duration.
                             properties:
                               unit:
                                 description: A unit of time.
@@ -1986,46 +1853,33 @@ spec:
                     - match
                     type: object
                   http2Route:
-                    description: An object that represents the specification of an
-                      HTTP/2 route.
+                    description: An object that represents the specification of an HTTP/2 route.
                     properties:
                       action:
-                        description: An object that represents the action to take
-                          if a match is determined.
+                        description: An object that represents the action to take if a match is determined.
                         properties:
                           weightedTargets:
-                            description: An object that represents the targets that
-                              traffic is routed to when a request matches the route.
+                            description: An object that represents the targets that traffic is routed to when a request matches the route.
                             items:
                               description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
                               properties:
                                 virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode
-                                    object to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   type: string
                                 virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode
-                                    CR in cluster to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   properties:
                                     name:
-                                      description: Name is the name of VirtualNode
-                                        CR
+                                      description: Name is the name of VirtualNode CR
                                       type: string
                                     namespace:
-                                      description: Namespace is the namespace of VirtualNode
-                                        CR. If unspecified, defaults to the referencing
-                                        object's namespace
+                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 weight:
-                                  description: The relative weight of the weighted
-                                    target.
+                                  description: The relative weight of the weighted target.
                                   format: int64
                                   maximum: 100
                                   minimum: 0
@@ -2040,37 +1894,31 @@ spec:
                         - weightedTargets
                         type: object
                       match:
-                        description: An object that represents the criteria for determining
-                          a request match.
+                        description: An object that represents the criteria for determining a request match.
                         properties:
                           headers:
-                            description: An object that represents the client request
-                              headers to match on.
+                            description: An object that represents the client request headers to match on.
                             items:
                               description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
                               properties:
                                 invert:
-                                  description: Specify True to match anything except
-                                    the match criteria. The default value is False.
+                                  description: Specify True to match anything except the match criteria. The default value is False.
                                   type: boolean
                                 match:
                                   description: The HeaderMatchMethod object.
                                   properties:
                                     exact:
-                                      description: The value sent by the client must
-                                        match the specified value exactly.
+                                      description: The value sent by the client must match the specified value exactly.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     prefix:
-                                      description: The value sent by the client must
-                                        begin with the specified characters.
+                                      description: The value sent by the client must begin with the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     range:
-                                      description: An object that represents the range
-                                        of values to match on.
+                                      description: An object that represents the range of values to match on.
                                       properties:
                                         end:
                                           description: The end of the range.
@@ -2082,21 +1930,18 @@ spec:
                                           type: integer
                                       type: object
                                     regex:
-                                      description: The value sent by the client must
-                                        include the specified characters.
+                                      description: The value sent by the client must include the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     suffix:
-                                      description: The value sent by the client must
-                                        end with the specified characters.
+                                      description: The value sent by the client must end with the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                   type: object
                                 name:
-                                  description: A name for the HTTP header in the client
-                                    request that will be matched on.
+                                  description: A name for the HTTP header in the client request that will be matched on.
                                   maxLength: 50
                                   minLength: 1
                                   type: string
@@ -2202,8 +2047,7 @@ spec:
                             - value
                             type: object
                           perRequest:
-                            description: An object that represents per request timeout
-                              duration.
+                            description: An object that represents per request timeout duration.
                             properties:
                               unit:
                                 description: A unit of time.
@@ -2226,46 +2070,33 @@ spec:
                     - match
                     type: object
                   httpRoute:
-                    description: An object that represents the specification of an
-                      HTTP route.
+                    description: An object that represents the specification of an HTTP route.
                     properties:
                       action:
-                        description: An object that represents the action to take
-                          if a match is determined.
+                        description: An object that represents the action to take if a match is determined.
                         properties:
                           weightedTargets:
-                            description: An object that represents the targets that
-                              traffic is routed to when a request matches the route.
+                            description: An object that represents the targets that traffic is routed to when a request matches the route.
                             items:
                               description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
                               properties:
                                 virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode
-                                    object to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   type: string
                                 virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode
-                                    CR in cluster to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   properties:
                                     name:
-                                      description: Name is the name of VirtualNode
-                                        CR
+                                      description: Name is the name of VirtualNode CR
                                       type: string
                                     namespace:
-                                      description: Namespace is the namespace of VirtualNode
-                                        CR. If unspecified, defaults to the referencing
-                                        object's namespace
+                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 weight:
-                                  description: The relative weight of the weighted
-                                    target.
+                                  description: The relative weight of the weighted target.
                                   format: int64
                                   maximum: 100
                                   minimum: 0
@@ -2280,37 +2111,31 @@ spec:
                         - weightedTargets
                         type: object
                       match:
-                        description: An object that represents the criteria for determining
-                          a request match.
+                        description: An object that represents the criteria for determining a request match.
                         properties:
                           headers:
-                            description: An object that represents the client request
-                              headers to match on.
+                            description: An object that represents the client request headers to match on.
                             items:
                               description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
                               properties:
                                 invert:
-                                  description: Specify True to match anything except
-                                    the match criteria. The default value is False.
+                                  description: Specify True to match anything except the match criteria. The default value is False.
                                   type: boolean
                                 match:
                                   description: The HeaderMatchMethod object.
                                   properties:
                                     exact:
-                                      description: The value sent by the client must
-                                        match the specified value exactly.
+                                      description: The value sent by the client must match the specified value exactly.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     prefix:
-                                      description: The value sent by the client must
-                                        begin with the specified characters.
+                                      description: The value sent by the client must begin with the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     range:
-                                      description: An object that represents the range
-                                        of values to match on.
+                                      description: An object that represents the range of values to match on.
                                       properties:
                                         end:
                                           description: The end of the range.
@@ -2322,21 +2147,18 @@ spec:
                                           type: integer
                                       type: object
                                     regex:
-                                      description: The value sent by the client must
-                                        include the specified characters.
+                                      description: The value sent by the client must include the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                     suffix:
-                                      description: The value sent by the client must
-                                        end with the specified characters.
+                                      description: The value sent by the client must end with the specified characters.
                                       maxLength: 255
                                       minLength: 1
                                       type: string
                                   type: object
                                 name:
-                                  description: A name for the HTTP header in the client
-                                    request that will be matched on.
+                                  description: A name for the HTTP header in the client request that will be matched on.
                                   maxLength: 50
                                   minLength: 1
                                   type: string
@@ -2442,8 +2264,7 @@ spec:
                             - value
                             type: object
                           perRequest:
-                            description: An object that represents per request timeout
-                              duration.
+                            description: An object that represents per request timeout duration.
                             properties:
                               unit:
                                 description: A unit of time.
@@ -2475,45 +2296,33 @@ spec:
                     minimum: 0
                     type: integer
                   tcpRoute:
-                    description: An object that represents the specification of a
-                      TCP route.
+                    description: An object that represents the specification of a TCP route.
                     properties:
                       action:
                         description: The action to take if a match is determined.
                         properties:
                           weightedTargets:
-                            description: An object that represents the targets that
-                              traffic is routed to when a request matches the route.
+                            description: An object that represents the targets that traffic is routed to when a request matches the route.
                             items:
                               description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
                               properties:
                                 virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode
-                                    object to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   type: string
                                 virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode
-                                    CR in cluster to associate with the weighted target.
-                                    Exactly one of 'virtualNodeRef' or 'virtualNodeARN'
-                                    must be specified.
+                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                                   properties:
                                     name:
-                                      description: Name is the name of VirtualNode
-                                        CR
+                                      description: Name is the name of VirtualNode CR
                                       type: string
                                     namespace:
-                                      description: Namespace is the namespace of VirtualNode
-                                        CR. If unspecified, defaults to the referencing
-                                        object's namespace
+                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 weight:
-                                  description: The relative weight of the weighted
-                                    target.
+                                  description: The relative weight of the weighted target.
                                   format: int64
                                   maximum: 100
                                   minimum: 0
@@ -2565,13 +2374,11 @@ spec:
               items:
                 properties:
                   lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                    description: Last time the condition transitioned from one status to another.
                     format: date-time
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: A human readable message indicating details about the transition.
                     type: string
                   reason:
                     description: The reason for the condition's last transition.
@@ -2594,12 +2401,10 @@ spec:
             routeARNs:
               additionalProperties:
                 type: string
-              description: RouteARNs is a map of AppMesh Route objects' Amazon Resource
-                Names, indexed by route name.
+              description: RouteARNs is a map of AppMesh Route objects' Amazon Resource Names, indexed by route name.
               type: object
             virtualRouterARN:
-              description: VirtualRouterARN is the AppMesh VirtualRouter object's
-                Amazon Resource Name.
+              description: VirtualRouterARN is the AppMesh VirtualRouter object's Amazon Resource Name.
               type: string
           type: object
       type: object
@@ -2647,31 +2452,21 @@ spec:
       description: VirtualService is the Schema for the virtualservices API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: VirtualServiceSpec defines the desired state of VirtualService
-            refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
+          description: VirtualServiceSpec defines the desired state of VirtualService refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
           properties:
             awsName:
-              description: AWSName is the AppMesh VirtualService object's name. If
-                unspecified or empty, it defaults to be "${name}.${namespace}" of
-                k8s VirtualService
+              description: AWSName is the AppMesh VirtualService object's name. If unspecified or empty, it defaults to be "${name}.${namespace}" of k8s VirtualService
               type: string
             meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualService belongs
-                to. The admission controller populates it using Meshes's selector,
-                and prevents users from setting this field. \n Populated by the system.
-                Read-only."
+              description: "A reference to k8s Mesh CR that this VirtualService belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
               properties:
                 name:
                   description: Name is the name of Mesh CR
@@ -2684,28 +2479,22 @@ spec:
               - uid
               type: object
             provider:
-              description: The provider for virtual services. You can specify a single
-                virtual node or virtual router.
+              description: The provider for virtual services. You can specify a single virtual node or virtual router.
               properties:
                 virtualNode:
                   description: The virtual node associated with a virtual service.
                   properties:
                     virtualNodeARN:
-                      description: Amazon Resource Name to AppMesh VirtualNode object
-                        that is acting as a service provider. Exactly one of 'virtualNodeRef'
-                        or 'virtualNodeARN' must be specified.
+                      description: Amazon Resource Name to AppMesh VirtualNode object that is acting as a service provider. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                       type: string
                     virtualNodeRef:
-                      description: Reference to Kubernetes VirtualNode CR in cluster
-                        that is acting as a service provider. Exactly one of 'virtualNodeRef'
-                        or 'virtualNodeARN' must be specified.
+                      description: Reference to Kubernetes VirtualNode CR in cluster that is acting as a service provider. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
                       properties:
                         name:
                           description: Name is the name of VirtualNode CR
                           type: string
                         namespace:
-                          description: Namespace is the namespace of VirtualNode CR.
-                            If unspecified, defaults to the referencing object's namespace
+                          description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
                           type: string
                       required:
                       - name
@@ -2715,22 +2504,16 @@ spec:
                   description: The virtual router associated with a virtual service.
                   properties:
                     virtualRouterARN:
-                      description: Amazon Resource Name to AppMesh VirtualRouter object
-                        that is acting as a service provider. Exactly one of 'virtualRouterRef'
-                        or 'virtualRouterARN' must be specified.
+                      description: Amazon Resource Name to AppMesh VirtualRouter object that is acting as a service provider. Exactly one of 'virtualRouterRef' or 'virtualRouterARN' must be specified.
                       type: string
                     virtualRouterRef:
-                      description: Reference to Kubernetes VirtualRouter CR in cluster
-                        that is acting as a service provider. Exactly one of 'virtualRouterRef'
-                        or 'virtualRouterARN' must be specified.
+                      description: Reference to Kubernetes VirtualRouter CR in cluster that is acting as a service provider. Exactly one of 'virtualRouterRef' or 'virtualRouterARN' must be specified.
                       properties:
                         name:
                           description: Name is the name of VirtualRouter CR
                           type: string
                         namespace:
-                          description: Namespace is the namespace of VirtualRouter
-                            CR. If unspecified, defaults to the referencing object's
-                            namespace
+                          description: Namespace is the namespace of VirtualRouter CR. If unspecified, defaults to the referencing object's namespace
                           type: string
                       required:
                       - name
@@ -2746,13 +2529,11 @@ spec:
               items:
                 properties:
                   lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                    description: Last time the condition transitioned from one status to another.
                     format: date-time
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: A human readable message indicating details about the transition.
                     type: string
                   reason:
                     description: The reason for the condition's last transition.
@@ -2773,8 +2554,7 @@ spec:
               format: int64
               type: integer
             virtualServiceARN:
-              description: VirtualServiceARN is the AppMesh VirtualService object's
-                Amazon Resource Name.
+              description: VirtualServiceARN is the AppMesh VirtualService object's Amazon Resource Name.
               type: string
           type: object
       type: object

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -8,7 +8,7 @@ accountId: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.1.1
+  tag: v1.2.0-rc0-preview
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
**Issue:** https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/346, https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/347

**Description of changes**
App Mesh Kubernetes controller now supports outlier detection (https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/356) and connection pools (https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/363) in preview. Adding the CRDs for outlier detection and connection pools to appmesh-controller Helm chart.

**Note:** this PR is for preview branch as App Mesh outlier detection and connection pools are in preview right now. We will create a PR for mainline once these features are out of preview. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
