### PR TITLE
Tighten leader election role

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.0.0
+version: 1.0.1
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/rbac.yaml
+++ b/stable/aws-load-balancer-controller/templates/rbac.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [configmaps]
+  resourceNames: [aws-load-balancer-controller-leader]
   verbs: [create, get, patch, update]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Tighten leader-election-role RBAC permissions to permit access only to the configmap resource named "aws-load-balancer-controller-leader".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
