### PR TITLE
[aws-load-balancer-controller]Add extraArgs

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.0.1
+version: 1.0.2
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -143,3 +143,4 @@ The following tables lists the configurable parameters of the chart and their de
 | `terminationGracePeriodSeconds`    | Time period for controller pod to do a graceful shutdown  | 10                                                                                         |
 | `ingressClass`                     | The ingress class to satisfy                              | alb                                                                                        |
 | `livenessProbe`                    | Liveness probe settings for the controller                | (see `values.yaml`)                                                                        |
+| `extraArgs`                    | Extra arguments for the controller                | `[]`                                                                       

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- if .Values.ingressClass }}
         - --ingress-class={{ .Values.ingressClass }}
         {{- end }}
+        {{- with .Values.extraArgs }}{{ toYaml . | nindent 8 }}{{- end }}
         command:
         - /controller
         securityContext:

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -81,3 +81,8 @@ livenessProbe:
     scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10
+
+# Extra args(Excluding clusterName and ingressClass) for controller
+extraArgs: []
+ #- --aws-region=XXX
+ #- --aws-vpc-id=XXX


### PR DESCRIPTION
Signed-off-by: cw-sakamoto <sakamoto@chatwork.com>

Issue #, if available:

Description of changes:
- I'd like to set some arguments to the command args, but I think it depends on the use case, so I've made it so that anything can be set as `extraArgs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
