### PR TITLE
[aws-load-balancer-controller] Fix RBAC permissions on leader election role

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.0.2
+version: 1.0.3
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -5,7 +5,7 @@ AWS Load Balancer controller Helm chart for Kubernetes
 ## TL;DR:
 ```sh
 helm repo add eks https://aws.github.io/eks-charts
-kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master
+kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
 helm install eks/aws-load-balancer-controller
 ```
 
@@ -73,7 +73,7 @@ helm repo add eks https://aws.github.io/eks-charts
 Install the TargetGroupBinding CRDs:
 
 ```shell script
-kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master
+kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
 ```
 
 Install the AWS Load Balancer controller, if using iamserviceaccount
@@ -142,5 +142,5 @@ The following tables lists the configurable parameters of the chart and their de
 | `serviceAccount.name`              | Service account to be used                                | None                                                                                       |
 | `terminationGracePeriodSeconds`    | Time period for controller pod to do a graceful shutdown  | 10                                                                                         |
 | `ingressClass`                     | The ingress class to satisfy                              | alb                                                                                        |
-| `region`                          | The AWS region for the kubernetes cluster                             |       
+| `region`                           | The AWS region for the kubernetes cluster                 | None                                                                                       |
 | `livenessProbe`                    | Liveness probe settings for the controller                | (see `values.yaml`)                                                                        |

--- a/stable/aws-load-balancer-controller/templates/rbac.yaml
+++ b/stable/aws-load-balancer-controller/templates/rbac.yaml
@@ -8,8 +8,11 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [configmaps]
+  verbs: [create]
+- apiGroups: [""]
+  resources: [configmaps]
   resourceNames: [aws-load-balancer-controller-leader]
-  verbs: [create, get, patch, update]
+  verbs: [get, patch, update]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -73,7 +73,7 @@ enableCertManager: false
 ingressClass: alb
 
 # The AWS region for the kubernetes cluster. Set to use KIAM or kube2iam for example.
-region: 
+region:
 
 # Liveness probe configuration for the controller
 livenessProbe:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Undo PR #298 changes since we cannot restrict create request by resourceName. For create, this limitation is because the object name is not known at authorization time. 

Tests
- Installed chart without existing configmap aws-load-balancer-controller-leader in kube-system. Verified chart installed successfully and leader election worked.
- Installed chart with existing configmap aws-load-balancer-controller-leader

For further reference https://kubernetes.io/docs/reference/access-authn-authz/rbac/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
