### PR TITLE
[aws-for-fluent-bit] Add log_retention_days to CloudWatch plugin

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.5
+version: 0.1.6
 appVersion: 2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -49,6 +49,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.logStreamName` | The name of the CloudWatch Log Stream that you want log records sent to. |  |
 | `cloudWatch.logStreamPrefix` | Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. Not compatible with the log_stream_name option. | `"fluentbit-"` |
 | `cloudWatch.logKey` | By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify logKey log and only the log message will be sent to CloudWatch. |  |
+| `cloudWatch.logRetentionDays` | If set to a number greater than zero, and newly create log group's retention policy is set to this many days. | |
 | `cloudWatch.logFormat` | An optional parameter that can be used to tell CloudWatch the format of the data. A value of json/emf enables CloudWatch to extract custom metrics embedded in a JSON payload. See the Embedded Metric Format. |  |
 | `cloudWatch.roleArn` | ARN of an IAM role to assume (for cross account access). |  |
 | `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -61,6 +61,9 @@ data:
         {{- if .Values.cloudWatch.logFormat }}
         log_format            {{ .Values.cloudWatch.logFormat }}
         {{- end }}
+        {{- if .Values.cloudWatch.logRetentionDays }}
+        log_retention_days    {{ .Values.cloudWatch.logRetentionDays }}
+        {{- end }}
         {{- if .Values.cloudWatch.roleArn }}
         role_arn              {{ .Values.cloudWatch.roleArn }}
         {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -59,6 +59,7 @@ cloudWatch:
   logStreamPrefix: "fluentbit-"
   logKey:
   logFormat:
+  logRetentionDays:
   roleArn:
   autoCreateGroup: true
   endpoint:


### PR DESCRIPTION
The `aws-for-fluent-bit` chart was not exposing the configuration for`log_retention_days` provided by the original [CloudWatch Plugin](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit). 

This change attempts to address this, thus allowing users of the chart to set the number of days they would like their log streams to be kept for.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
