### PR TITLE
Support for Envoy configuration variables

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -324,6 +324,8 @@ Parameter | Description | Default
 `sidecar.image.repository` | Envoy image repository. If you override with non-Amazon built Envoy image, you will need to test/ensure it works with the App Mesh | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`
 `sidecar.image.tag` | Envoy image tag | `<VERSION>`
 `sidecar.logLevel` | Envoy log level | `info`
+`sidecar.envoyAdminAccessPort` | Envoy Admin Access Port | `9901`
+`sidecar.envoyAdminAccessLogFile` | Envoy Admin Access Log File | `/tmp/envoy_admin_access.log`
 `sidecar.resources.requests` | Envoy container resource requests | `requests: cpu 10m memory 32Mi`
 `sidecar.resources.limits` | Envoy container resource limits | `limits: cpu "" memory ""`
 `sidecar.lifecycleHooks.preStopDelay` | Envoy container PreStop Hook Delay Value | `20s`
@@ -333,6 +335,8 @@ Parameter | Description | Default
 `init.image.tag` | Route manager image tag | `<VERSION>`
 `stats.tagsEnabled` |  If `true`, Envoy should include app-mesh tags | `false`
 `stats.statsdEnabled` |  If `true`, Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125 | `false`
+`stats.statsdAddress` |  DogStatsD daemon IP address | `127.0.0.1`
+`stats.statsdPort` |  DogStatsD daemon port | `8125`
 `cloudMapCustomHealthCheck.enabled` |  If `true`, CustomHealthCheck will be enabled for CloudMap Services | `false`
 `cloudMapDNS.ttl` |  Sets CloudMap DNS TTL | `300`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`

--- a/stable/appmesh-controller/ci/values.yaml
+++ b/stable/appmesh-controller/ci/values.yaml
@@ -2,6 +2,6 @@
 
 region: us-west-2
 image:
-  repository: fawadkhaliq/appmesh-controller
-  tag: v1.1.1-rc2
+  repository: apuroop/appmesh-controller
+  tag: v1.2.0-rc2
   pullPolicy: IfNotPresent

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -61,19 +61,26 @@ spec:
         - --sidecar-memory-limits={{ .Values.sidecar.resources.limits.memory }}
         - --init-image={{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
         - --enable-stats-tags={{ .Values.stats.tagsEnabled }}
-        - --enable-statsd={{ .Values.stats.statsdEnabled }}
         - --prestop-delay={{ .Values.sidecar.lifecycleHooks.preStopDelay }}
         - --readiness-probe-initial-delay={{ .Values.sidecar.probes.readinessProbeInitialDelay }}
         - --readiness-probe-period={{ .Values.sidecar.probes.readinessProbePeriod }}
+        - --envoy-admin-access-port={{ .Values.sidecar.envoyAdminAccessPort }}
+        - --envoy-admin-access-log-file={{ .Values.sidecar.envoyAdminAccessLogFile }}
         {{- if .Values.cloudMapCustomHealthCheck.enabled }}
         - --enable-custom-health-check=true
         {{- end }}
         {{- if kindIs "float64" .Values.cloudMapDNS.ttl }}
         - --cloudmap-dns-ttl={{ .Values.cloudMapDNS.ttl }}
         {{- end }}
+        {{- if .Values.stats.statsdEnabled }}
+        - --enable-statsd=true
+        - --statsd-address={{ .Values.stats.statsdAddress }}
+        - --statsd-port={{ .Values.stats.statsdPort }}
+        {{- end }}
         {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "x-ray" ) }}
         - --enable-xray-tracing=true
         - --xray-image={{ .Values.xray.image.repository}}:{{ .Values.xray.image.tag }}
+        - --xray-daemon-port={{ .Values.tracing.port }}
         {{- end }}
         {{- if and .Values.tracing.enabled ( eq .Values.tracing.provider "jaeger" ) }}
         - --enable-jaeger-tracing=true

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -17,6 +17,8 @@ sidecar:
     tag: v1.15.1.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
+  envoyAdminAccessPort: 9901
+  envoyAdminAccessLogFile: /tmp/envoy_admin_access.log
   resources:
     # sidecar.resources.requests: Envoy CPU and memory requests
     requests:
@@ -97,14 +99,18 @@ tracing:
   provider: x-ray
   # tracing.address: Jaeger or Datadog agent server address (ignored for X-Ray)
   address: appmesh-jaeger.appmesh-system
-  # tracing.address: Jaeger or Datadog agent server port (ignored for X-Ray)
-  port: 9411
+  # tracing.address: Jaeger or Datadog agent server port
+  port: 2000
 
 stats:
   # stats.tagsEnabled: `true` if Envoy should include app-mesh tags
   tagsEnabled: false
   # stats.statsdEnabled: `true` if Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125
   statsdEnabled: false
+  #stats.statsdAddress: DogStatsD daemon address
+  statsdAddress: 127.0.0.1
+  #stats.statsdPort: DogStatsD daemon port
+  statsdPort: 8125
 
 # Enable cert-manager
 enableCertManager: false

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -99,7 +99,7 @@ tracing:
   provider: x-ray
   # tracing.address: Jaeger or Datadog agent server address (ignored for X-Ray)
   address: appmesh-jaeger.appmesh-system
-  # tracing.address: Jaeger or Datadog agent server port
+  # tracing.port: Jaeger or Datadog agent server port
   port: 2000
 
 stats:


### PR DESCRIPTION
Issue #, if available:
#289
Description of changes:
Support for below envoy configuration variables ..

- Envoy Admin Access Port
- Envoy Admin Access Log File
- StatsD Daemon Address
- StatsD Daemon Port


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
