### PR TITLE
[appmesh-controller] restrict leader election RBAC permissions

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.15
+version: 1.1.16
 appVersion: 1.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/templates/rbac.yaml
+++ b/stable/appmesh-controller/templates/rbac.yaml
@@ -9,13 +9,14 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [configmaps]
-  verbs: [create, delete, get, list, patch, update, watch]
+  verbs: [create, list, watch]
 - apiGroups: [""]
-  resources: [configmaps/status]
-  verbs: [get, update, patch]
+  resources: [configmaps]
+  resourceNames: [appmesh-controller-leader-election]
+  verbs: [get, patch, update]
 - apiGroups: [""]
   resources: [events]
-  verbs: [create]
+  verbs: [create, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**Description of changes**
Restrict the leader election RBAC role for appmesh-controller to match the permissions here https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/369

**Testing**
Verified that the controller can create the configmap when deleted or at init time and function properly. 
```
helm upgrade -i appmesh-controller ./stable/appmesh-controller \
    --namespace appmesh-system

kubectl get configmap -n appmesh-system
NAME                                 DATA   AGE
appmesh-controller-leader-election   0      1s


kubectl describe role appmesh-controller-leader-election-role -n appmesh-system
Name:         appmesh-controller-leader-election-role
Labels:       app.kubernetes.io/instance=appmesh-controller
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=appmesh-controller
              app.kubernetes.io/version=1.1.1
              helm.sh/chart=appmesh-controller-1.1.15
Annotations:  meta.helm.sh/release-name: appmesh-controller
              meta.helm.sh/release-namespace: appmesh-system
PolicyRule:
  Resources   Non-Resource URLs  Resource Names                        Verbs
  ---------   -----------------  --------------                        -----
  configmaps  []                 []                                    [create list watch]
  events      []                 []                                    [create patch]
  configmaps  []                 [appmesh-controller-leader-election]  [get patch update]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
