### PR TITLE
[aws-load-balancer-controller] Allow VPC ID override

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.0.3
+version: 1.0.4
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -143,4 +143,5 @@ The following tables lists the configurable parameters of the chart and their de
 | `terminationGracePeriodSeconds`    | Time period for controller pod to do a graceful shutdown  | 10                                                                                         |
 | `ingressClass`                     | The ingress class to satisfy                              | alb                                                                                        |
 | `region`                           | The AWS region for the kubernetes cluster                 | None                                                                                       |
+| `vpcId`                            | The VPC ID for the Kubernetes cluster                     | None                                                                                       |
 | `livenessProbe`                    | Liveness probe settings for the controller                | (see `values.yaml`)                                                                        |

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         {{- if .Values.region }}
         - --aws-region={{ .Values.region }}
         {{- end }}
+        {{- if .Values.vpcId }}
+        - --aws-vpc-id={{ .Values.vpcId }}
+        {{- end }}
         command:
         - /controller
         securityContext:

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -75,6 +75,9 @@ ingressClass: alb
 # The AWS region for the kubernetes cluster. Set to use KIAM or kube2iam for example.
 region:
 
+# The VPC ID for the Kubernetes cluster. Set this manually when your pods are unable to use the metadata service to determine this automatically
+vpcId:
+
 # Liveness probe configuration for the controller
 livenessProbe:
   failureThreshold: 2


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
This adds the possibility to specify the VPC ID. This is needed when you block the EC2 metadata service for pods running on your cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
