### PR TITLE
Fix for appmesh-controller CI failure

### DIFF
--- a/stable/appmesh-controller/ci/values.yaml
+++ b/stable/appmesh-controller/ci/values.yaml
@@ -1,5 +1,7 @@
 # CI testing values for appmesh-controller
 
+# This is a dummy account for CI test. Not a valid account ID
+accountId: 123456789
 region: us-west-2
 image:
   repository: fawadkhaliq/appmesh-controller

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         control-plane: {{ template "appmesh-controller.fullname" . }}
+        app.kubernetes.io/name: {{ include "appmesh-controller.fullname" . }}
+        app.kubernetes.io/part-of: appmesh
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/test/lib/helm.sh
+++ b/test/lib/helm.sh
@@ -63,6 +63,3 @@ function waitForService() {
   done
     infof "✔ service/$chartName test passed"
 }
-
-
-


### PR DESCRIPTION
**Description of changes**
- Added label `app.kubernetes.io/part-of: appmesh` to appmesh-controller deployment. The CI test wasn't printing logs as the [CI test expects](https://github.com/aws/eks-charts/blob/master/test/e2e/appmesh.bats#L47) this label to be in place
- Fixed the CI test for appmesh-controller. It has been failing as ci/values.yaml did not provide dummy account ID for testing purposes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.