### PR TITLE
[aws-load-balancer-controller]Add aws-load-balancer-controller args

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.0.4
+version: 1.0.5
 appVersion: v2.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -122,6 +122,7 @@ helm delete aws-load-balancer-controller -n kube-system
 ## Configuration
 
 The following tables lists the configurable parameters of the chart and their default values.
+The default values set by the application itself can be confirmed [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/guide/controller/configurations.md).
 
 | Parameter                          | Description                                               | Default                                                                                    |
 | ---------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -156,6 +156,7 @@ The default values set by the application itself can be confirmed [here](https:/
 | `metricsBindAddr`                  | The address the metric endpoint binds to            |                                                             "" |
 | `webhookBindPort`                  | The TCP port the Webhook server binds to            |                                                             None |
 | `serviceMaxConcurrentReconciles`   | Maximum number of concurrently running reconcile loops for service  |                                             None |
+| `targetgroupbindingMaxConcurrentReconciles` | Maximum number of concurrently running reconcile loops for targetGroupBinding  |                         None |
 | `syncPeriod`                       | Period at which the controller forces the repopulation of its local object stores      |                          None |
 | `watchNamespace`                   | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watche |         None |
 | `livenessProbe`                    | Liveness probe settings for the controller                | (see `values.yaml`)                                                                        |

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -144,4 +144,17 @@ The following tables lists the configurable parameters of the chart and their de
 | `ingressClass`                     | The ingress class to satisfy                              | alb                                                                                        |
 | `region`                           | The AWS region for the kubernetes cluster                 | None                                                                                       |
 | `vpcId`                            | The VPC ID for the Kubernetes cluster                     | None                                                                                       |
+| `awsMaxRetries`                    | Maximum retries for AWS APIs                        |                                                             None |
+| `enablePodReadinessGateInject`     | If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods |        None |
+| `enableShield`                     | Enable Shield addon for ALB                         |                                                             None |
+| `enableWaf`                        | Enable WAF addon for ALB                            |                                                             None |
+| `enableWafv2`                      | Enable WAF V2 addon for ALB                         |                                                             None |
+| `healthProbeBindAddr`              | The address the health probes binds to              |                                                             "" |
+| `ingressMaxConcurrentReconciles`   | Maximum number of concurrently running reconcile loops for ingress |                                              None |
+| `logLevel`                         | Set the controller log level - info, debug          |                                                             None |
+| `metricsBindAddr`                  | The address the metric endpoint binds to            |                                                             "" |
+| `webhookBindPort`                  | The TCP port the Webhook server binds to            |                                                             None |
+| `serviceMaxConcurrentReconciles`   | Maximum number of concurrently running reconcile loops for service  |                                             None |
+| `syncPeriod`                       | Period at which the controller forces the repopulation of its local object stores      |                          None |
+| `watchNamespace`                   | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watche |         None |
 | `livenessProbe`                    | Liveness probe settings for the controller                | (see `values.yaml`)                                                                        |

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -150,7 +150,6 @@ The default values set by the application itself can be confirmed [here](https:/
 | `enableShield`                     | Enable Shield addon for ALB                         |                                                             None |
 | `enableWaf`                        | Enable WAF addon for ALB                            |                                                             None |
 | `enableWafv2`                      | Enable WAF V2 addon for ALB                         |                                                             None |
-| `healthProbeBindAddr`              | The address the health probes binds to              |                                                             "" |
 | `ingressMaxConcurrentReconciles`   | Maximum number of concurrently running reconcile loops for ingress |                                              None |
 | `logLevel`                         | Set the controller log level - info, debug          |                                                             None |
 | `metricsBindAddr`                  | The address the metric endpoint binds to            |                                                             "" |

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
         {{- if .Values.serviceMaxConcurrentReconciles }}
         - --service-max-concurrent-reconciles={{ .Values.serviceMaxConcurrentReconciles }}
         {{- end }}
+        {{- if .Values.targetgroupbindingMaxConcurrentReconciles }}
+        - --targetgroupbinding-max-concurrent-reconciles={{ .Values.targetgroupbindingMaxConcurrentReconciles }}
+        {{- end }}
         {{- if .Values.logLevel }}
         - --log-level={{ .Values.logLevel }}
         {{- end }}

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -63,9 +63,6 @@ spec:
         {{- if .Values.enableWafv2 }}
         - --enable-wafv2={{ .Values.enableWafv2 }}
         {{- end }}
-        {{- if .Values.healthProbeBindAddr }}
-        - --health-probe-bind-addr={{ .Values.healthProbeBindAddr }}
-        {{- end }}
         {{- if .Values.metricsBindAddr }}
         - --metrics-bind-addr={{ .Values.metricsBindAddr }}
         {{- end }}
@@ -107,11 +104,6 @@ spec:
         - name: metrics-server
           containerPort: {{ (split ":" .Values.metricsBindAddr)._1 | default 8080 }}
           protocol: TCP
-        {{- if .Values.livenessProbe }}
-        - name: health
-          containerPort: {{ (split ":" .Values.healthProbeBindAddr)._1 | default 61779}}
-          protocol: TCP
-        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- with .Values.livenessProbe }}

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         args:
         - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
         {{- if .Values.ingressClass }}
-        - --ingress-class={{ .Values.ingressClass}}
+        - --ingress-class={{ .Values.ingressClass }}
         {{- end }}
         {{- if .Values.region }}
         - --aws-region={{ .Values.region }}

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- end }}
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
+        prometheus.io/port: "{{ (split ":" .Values.metricsBindAddr)._1 | default 8080 }}"
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
@@ -40,13 +40,52 @@ spec:
         args:
         - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
         {{- if .Values.ingressClass }}
-        - --ingress-class={{ .Values.ingressClass }}
+        - --ingress-class={{ .Values.ingressClass}}
         {{- end }}
         {{- if .Values.region }}
         - --aws-region={{ .Values.region }}
         {{- end }}
         {{- if .Values.vpcId }}
         - --aws-vpc-id={{ .Values.vpcId }}
+        {{- end }}
+        {{- if .Values.awsMaxRetries }}
+        - --aws-max-retries={{ .Values.awsMaxRetries }}
+        {{- end }}
+        {{- if .Values.enablePodReadinessGateInject }}
+        - --enable-pod-readiness-gate-inject={{ .Values.enablePodReadinessGateInject }}
+        {{- end }}
+        {{- if .Values.enableShield }}
+        - --enable-shield={{ .Values.enableShield }}
+        {{- end }}
+        {{- if .Values.enableWaf }}
+        - --enable-waf={{ .Values.enableWaf }}
+        {{- end }}
+        {{- if .Values.enableWafv2 }}
+        - --enable-wafv2={{ .Values.enableWafv2 }}
+        {{- end }}
+        {{- if .Values.healthProbeBindAddr }}
+        - --health-probe-bind-addr={{ .Values.healthProbeBindAddr }}
+        {{- end }}
+        {{- if .Values.metricsBindAddr }}
+        - --metrics-bind-addr={{ .Values.metricsBindAddr }}
+        {{- end }}
+        {{- if .Values.ingressMaxConcurrentReconciles }}
+        - --ingress-max-concurrent-reconciles={{ .Values.ingressMaxConcurrentReconciles }}
+        {{- end }}
+        {{- if .Values.serviceMaxConcurrentReconciles }}
+        - --service-max-concurrent-reconciles={{ .Values.serviceMaxConcurrentReconciles }}
+        {{- end }}
+        {{- if .Values.logLevel }}
+        - --log-level={{ .Values.logLevel }}
+        {{- end }}
+        {{- if .Values.webhookBindPort }}
+        - --webhook-bind-port={{ .Values.webhookBindPort }}
+        {{- end }}
+        {{- if .Values.syncPeriod }}
+        - --sync-period={{ .Values.syncPeriod }}
+        {{- end }}
+        {{- if .Values.watchNamespace }}
+        - --watch-namespace={{ .Values.watchNamespace }}
         {{- end }}
         command:
         - /controller
@@ -60,15 +99,22 @@ spec:
           readOnly: true
         ports:
         - name: webhook-server
-          containerPort: 9443
+          containerPort: {{ .Values.webhookBindPort | default 9443 }}
           protocol: TCP
         - name: metrics-server
-          containerPort: 8080
+          containerPort: {{ (split ":" .Values.metricsBindAddr)._1 | default 8080 }}
           protocol: TCP
+        {{- if .Values.livenessProbe }}
+        - name: health
+          containerPort: {{ (split ":" .Values.healthProbeBindAddr)._1 | default 61779}}
+          protocol: TCP
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        {{- with .Values.livenessProbe }}
         livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: {{ .Values.webhookBindPort | default 9443 }}
+    targetPort: webhook-server
   selector:
     {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: {{ .Values.webhookBindPort | default 9443 }}
   selector:
     {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -111,6 +111,9 @@ webhookBindPort:
 # Maximum number of concurrently running reconcile loops for service (default 3)
 serviceMaxConcurrentReconciles:
 
+# Maximum number of concurrently running reconcile loops for targetGroupBinding
+targetgroupbindingMaxConcurrentReconciles:
+
 # Period at which the controller forces the repopulation of its local object stores. (default 1h0m0s)
 syncPeriod:
 

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -118,7 +118,6 @@ syncPeriod:
 watchNamespace:
 
 # Liveness probe configuration for the controller
-# livenessProbe port must be consistent with healthProbeBindAddr's port
 livenessProbe:
   failureThreshold: 2
   httpGet:

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -93,9 +93,6 @@ enableWaf:
 # Enable WAF V2 addon for ALB (default true)
 enableWafv2:
 
-# The address the health probes binds to. (default ":61779")
-healthProbeBindAddr: ""
-
 # Maximum number of concurrently running reconcile loops for ingress (default 3)
 ingressMaxConcurrentReconciles:
 
@@ -126,7 +123,7 @@ livenessProbe:
   failureThreshold: 2
   httpGet:
     path: /healthz
-    port: health
+    port: 61779
     scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -78,12 +78,52 @@ region:
 # The VPC ID for the Kubernetes cluster. Set this manually when your pods are unable to use the metadata service to determine this automatically
 vpcId:
 
+# Maximum retries for AWS APIs (default 10)
+awsMaxRetries:
+
+# If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods (default true)
+enablePodReadinessGateInject:
+
+# Enable Shield addon for ALB (default true)
+enableShield:
+
+# Enable WAF addon for ALB (default true)
+enableWaf:
+
+# Enable WAF V2 addon for ALB (default true)
+enableWafv2:
+
+# The address the health probes binds to. (default ":61779")
+healthProbeBindAddr: ""
+
+# Maximum number of concurrently running reconcile loops for ingress (default 3)
+ingressMaxConcurrentReconciles:
+
+# Set the controller log level - info(default), debug (default "info")
+logLevel:
+
+# The address the metric endpoint binds to. (default ":8080")
+metricsBindAddr: ""
+
+# The TCP port the Webhook server binds to. (default 9443)
+webhookBindPort:
+
+# Maximum number of concurrently running reconcile loops for service (default 3)
+serviceMaxConcurrentReconciles:
+
+# Period at which the controller forces the repopulation of its local object stores. (default 1h0m0s)
+syncPeriod:
+
+# Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched.
+watchNamespace:
+
 # Liveness probe configuration for the controller
+# livenessProbe port must be consistent with healthProbeBindAddr's port
 livenessProbe:
   failureThreshold: 2
   httpGet:
     path: /healthz
-    port: 61779
+    port: health
     scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Referring to [configurations](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/guide/controller/configurations.md), I've added the args we use in v1 and the args we will use in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
