### PR TITLE
Support for AWS AppMesh/CloudMap access validation parameter

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -339,6 +339,7 @@ Parameter | Description | Default
 `stats.statsdPort` |  DogStatsD daemon port | `8125`
 `cloudMapCustomHealthCheck.enabled` |  If `true`, CustomHealthCheck will be enabled for CloudMap Services | `false`
 `cloudMapDNS.ttl` |  Sets CloudMap DNS TTL | `300`
+`awsAccessValidation.enabled` |  If `true`, Access to AWS App Mesh and CloudMap will be validated | `false`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -339,7 +339,7 @@ Parameter | Description | Default
 `stats.statsdPort` |  DogStatsD daemon port | `8125`
 `cloudMapCustomHealthCheck.enabled` |  If `true`, CustomHealthCheck will be enabled for CloudMap Services | `false`
 `cloudMapDNS.ttl` |  Sets CloudMap DNS TTL | `300`
-`awsAccessValidation.enabled` |  If `true`, Access to AWS App Mesh and CloudMap will be validated | `false`
+`awsAccessValidation.enabled` |  If `true`, Access to AWS App Mesh and CloudMap will be validated | `true`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`

--- a/stable/appmesh-controller/ci/values.yaml
+++ b/stable/appmesh-controller/ci/values.yaml
@@ -5,3 +5,5 @@ image:
   repository: apuroop/appmesh-controller
   tag: v1.2.0-rc3
   pullPolicy: IfNotPresent
+awsAccessValidation:
+  enabled: false

--- a/stable/appmesh-controller/ci/values.yaml
+++ b/stable/appmesh-controller/ci/values.yaml
@@ -3,5 +3,5 @@
 region: us-west-2
 image:
   repository: apuroop/appmesh-controller
-  tag: v1.2.0-rc2
+  tag: v1.2.0-rc3
   pullPolicy: IfNotPresent

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -69,6 +69,9 @@ spec:
         {{- if .Values.cloudMapCustomHealthCheck.enabled }}
         - --enable-custom-health-check=true
         {{- end }}
+        {{- if .Values.awsAccessValidation.enabled }}
+        - --enable-aws-access-validation=true
+        {{- end }}
         {{- if kindIs "float64" .Values.cloudMapDNS.ttl }}
         - --cloudmap-dns-ttl={{ .Values.cloudMapDNS.ttl }}
         {{- end }}

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -74,6 +74,10 @@ cloudMapDNS:
   # cloudMapDNS.ttl if set will use this global ttl value
   ttl: 300
 
+awsAccessValidation:
+  # awsAccessValidation.enabled: `true` to enable AWS AppMesh and CloudMap Access validation during controller boot up
+  enabled: false
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -76,7 +76,7 @@ cloudMapDNS:
 
 awsAccessValidation:
   # awsAccessValidation.enabled: `true` to enable AWS AppMesh and CloudMap Access validation during controller boot up
-  enabled: false
+  enabled: true
 
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not


### PR DESCRIPTION
Issue #, if available:
#320

Description of changes:
Adding support to configure AWS AppMesh/CloudMap access validation parameter in controller's chart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
