### PR TITLE
[appmesh-jaeger] bump jaeger version to 1.19

### DIFF
--- a/stable/appmesh-jaeger/Chart.yaml
+++ b/stable/appmesh-jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-jaeger
 description: App Mesh Jaeger Helm chart for Kubernetes
-version: 1.0.0
-appVersion: 1.14.0
+version: 1.0.1
+appVersion: 1.19.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-jaeger/values.yaml
+++ b/stable/appmesh-jaeger/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jaegertracing/all-in-one
-  tag: 1.14
+  tag: 1.19
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
**Description of changes**
Bump Jaeger version to v1.19 [1][2]. All the input parameters and env variables are compatible with v1.19 version

[1] https://www.jaegertracing.io/docs/1.19/getting-started/
[2] https://www.jaegertracing.io/docs/1.19/deployment/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
