### PR TITLE
[aws-load-balancer-controller] Remove creds reference from the comments

### DIFF
--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -128,6 +128,8 @@ livenessProbe:
   timeoutSeconds: 10
 
 # Environment variables to set for aws-load-balancer-controller pod.
+# We strongly discourage programming access credentials in the controller environment. You should setup IRSA or
+# comparable solutions like kube2iam, kiam etc instead.
 env:
-  # AWS_ACCESS_KEY_ID: ""
-  # AWS_SECRET_ACCESS_KEY: ""
+  # ENV_1: ""
+  # ENV_2: ""


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Update comment to remove references to AWS credentials, and provide a warning to use alternatives so that this will not act as a bad reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
