### PR TITLE
appmesh-grafana: fix unhealthy sidecar query and plot outlier metrics over an interval

### DIFF
--- a/stable/appmesh-grafana/Chart.yaml
+++ b/stable/appmesh-grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-grafana
 description: App Mesh Grafana Helm chart for Kubernetes
-version: 1.0.2
+version: 1.0.3
 appVersion: 6.4.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-grafana/dashboards/data-plane.json
+++ b/stable/appmesh-grafana/dashboards/data-plane.json
@@ -176,7 +176,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum(envoy_cluster_membership_healthy{job=\"appmesh-envoy\"})  - sum(envoy_cluster_membership_total{job=\"appmesh-envoy\"}))",
+          "expr": "(sum(envoy_cluster_membership_total{job=\"appmesh-envoy\"})  - sum(envoy_cluster_membership_healthy{job=\"appmesh-envoy\"}))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "Unhealthy sidecars",
@@ -1081,7 +1081,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_outlier_detection_ejections_enforced_total{job=\"appmesh-envoy\"}) by (kubernetes_namespace)",
+          "expr": "sum(round(increase(envoy_cluster_outlier_detection_ejections_enforced_total{job=\"appmesh-envoy\"}[1m]))) by (kubernetes_namespace)",
           "legendFormat": "{{kubernetes_namespace}}",
           "refId": "A"
         }
@@ -1261,7 +1261,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_outlier_detection_ejections_enforced_consecutive_5xx{job=\"appmesh-envoy\"}) by (kubernetes_namespace)",
+          "expr": "sum(round(increase(envoy_cluster_outlier_detection_ejections_enforced_consecutive_5xx{job=\"appmesh-envoy\"}[1m]))) by (kubernetes_namespace)",
           "legendFormat": "{{kubernetes_namespace}}",
           "refId": "A"
         }
@@ -1351,7 +1351,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_outlier_detection_ejections_detected_consecutive_5xx{job=\"appmesh-envoy\"}) by (kubernetes_namespace)",
+          "expr": "sum(round(increase(envoy_cluster_outlier_detection_ejections_detected_consecutive_5xx{job=\"appmesh-envoy\"}[1m]))) by (kubernetes_namespace)",
           "legendFormat": "{{kubernetes_namespace}}",
           "refId": "A"
         }


### PR DESCRIPTION
**Description of changes**
Fix the unhealthy sidecar query so it does not display negative number of unhealthy sidecars and changed the outlier detection counters to display metrics over 1m interval. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
