### PR TITLE
appmesh-controller: bump version to v1.2.0 and add note on iamserviceaccount create

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.1.18
+version: 1.2.0
 appVersion: 1.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -62,8 +62,10 @@ aws iam create-policy \
 ```
 Take note of the policy ARN that is returned
 
-
 Create an IAM role for service account for the App Mesh Kubernetes controller, use the ARN from the step above
+
+> Note: if you deleted `serviceaccount` in the `appmesh-system` namespace, you will need to delete and re-create `iamserviceaccount`. `eksctl` does not override the `iamserviceaccount` correctly ([see this issue](https://github.com/weaveworks/eksctl/issues/2665))
+
 ```
 eksctl create iamserviceaccount --cluster $CLUSTER_NAME \
     --namespace appmesh-system \
@@ -142,6 +144,9 @@ aws iam create-policy \
 Take note of the policy ARN that is returned
 
 Create an IAM role for service account for the App Mesh Kubernetes controller, use the ARN from the step above
+
+> Note: if you deleted `serviceaccount` in the `appmesh-system` namespace, you will need to delete and re-create `iamserviceaccount`. `eksctl` does not override the `iamserviceaccount` correctly ([see this issue](https://github.com/weaveworks/eksctl/issues/2665))
+
 ```
 eksctl create iamserviceaccount --cluster $CLUSTER_NAME \
     --namespace appmesh-system \

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -8,7 +8,7 @@ accountId: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.2.0-rc1
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
**Description of changes**
aws-app-mesh-controller-for-k8s has [released version 1.2.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.2.0). Bumping the Helm chart to use the v1.2.0. Also, added a note on iamserviceaccount override in the README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
