### PR TITLE
[aws-load-balancer-controller] Update comments for hostNetwork

### DIFF
--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -136,6 +136,7 @@ env:
 
 # Specifies if aws-load-balancer-controller should be started in hostNetwork mode.
 #
-# This is required if using a custom CNI with a managed kubernetes service (e.g. EKS).
-# The managed control plane is unable to communicate with the pods/service IP address.
+# This is required if using a custom CNI where the managed control plane nodes are unable to initiate
+# network connections to the pods, for example using Calico CNI plugin on EKS. This is not required or
+# recommended if using the Amazon VPC CNI plugin.
 hostNetwork: false


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Update comments to indicate that the hostNetwork parameter is not required or recommended for Amazon VPC CNI plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
