### PR TITLE
[aws-for-fluent-bit] Allow to add annotations to the pod

### DIFF
--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -92,3 +92,4 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `affinity` | Map of node/pod affinities | `{}` |
 | `tolerations` | Optional deployment tolerations | `[]` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
+| `annotations` | Optional pod annotations | `{}` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
       {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if .Values.annotations }}
+      annotations:
+        {{- toYaml .Values.annotations | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 8 }}
     spec:

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -133,3 +133,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+annotations: {}
+  # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit


### PR DESCRIPTION
This commit enables chart users to add annotations to the `aws-for-fluent-bit` pod. In practice, this e.g. allows to run the pod with `kube2iam`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
