### PR TITLE
[aws-for-fluent-bit] allow filter.mergeLogKey to be optional and expose filter.keepLog value

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.5
+version: 0.1.6
 appVersion: 2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -35,7 +35,9 @@ data:
         Match               {{ .Values.filter.match }}
         Kube_URL            {{ .Values.filter.kubeURL }}
         Merge_Log           {{ .Values.filter.mergeLog }}
+        {{- if .Values.filter.mergeLogKey }}
         Merge_Log_Key       {{ .Values.filter.mergeLogKey }}
+        {{- end }}
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
 

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
         {{- if .Values.filter.mergeLogKey }}
         Merge_Log_Key       {{ .Values.filter.mergeLogKey }}
         {{- end }}
+        Keep_Log            {{ .Values.filter.keepLog }}
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
 

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -41,6 +41,7 @@ filter:
   kubeURL: "https://kubernetes.default.svc.cluster.local:443"
   mergeLog: "On"
   mergeLogKey: "data"
+  keepLog: "On"
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
 


### PR DESCRIPTION
In order to have JSONified log lines be merged at the top-level of the JSON event emitted by FluentBit, the [`mergeLogKey` parameter must not be defined at all](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#configuration-parameters).  However the Helm chart requires a value to be specified.

This is a similar dilemma as #214.

This PR allows `filter.mergeLogKey` to be an empty string, in which case it will not be included at all in the rendered configmap. 

Related to merging, this PR also exposes FluentBit's `Keep_Log` parameter via the `filter.keepLog` chart value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
