### PR TITLE
Support the managedAsgTag option in aws-node-termination-handler

### DIFF
--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -85,6 +85,8 @@ Parameter | Description | Default
 `enableSqsTerminationDraining` | If true, this turns on queue-processor mode which drains nodes when an SQS termination event is received| `false`
 `queueURL` | Listens for messages on the specified SQS queue URL | None
 `awsRegion` | If specified, use the AWS region for AWS API calls, else NTH will try to find the region through AWS_REGION env var, IMDS, or the specified queue URL | ``
+`checkASGTagBeforeDraining` | If true, check that the instance is tagged with "aws-node-termination-handler/managed" as the key before draining the node | `true`
+`managedAsgTag` | The tag to ensure is on a node if checkASGTagBeforeDraining is true | `aws-node-termination-handler/managed`
 
 ### AWS Node Termination Handler - IMDS Mode Configuration
 

--- a/stable/aws-node-termination-handler/templates/deployment.yaml
+++ b/stable/aws-node-termination-handler/templates/deployment.yaml
@@ -138,6 +138,10 @@ spec:
           {{- end }}
           - name: CHECK_ASG_TAG_BEFORE_DRAINING
             value: {{ .Values.checkASGTagBeforeDraining | quote }}
+          {{- if .Values.managedAsgTag }}
+          - name: MANAGED_ASG_TAG
+            value: {{ .Values.managedAsgTag | quote }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.enablePrometheusServer }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -42,6 +42,9 @@ queueURL: ""
 # checkASGTagBeforeDraining  If true, check that the instance is tagged with "aws-node-termination-handler/managed" as the key before draining the node
 checkASGTagBeforeDraining: true
 
+# managedAsgTag  The tag to ensure is on a node if checkASGTagBeforeDraining is true
+managedAsgTag: ""
+
 # awsRegion If specified, use the AWS region for AWS API calls
 awsRegion: ""
 

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -43,7 +43,7 @@ queueURL: ""
 checkASGTagBeforeDraining: true
 
 # managedAsgTag  The tag to ensure is on a node if checkASGTagBeforeDraining is true
-managedAsgTag: ""
+managedAsgTag: "aws-node-termination-handler/managed"
 
 # awsRegion If specified, use the AWS region for AWS API calls
 awsRegion: ""


### PR DESCRIPTION
Adds support for the configurable `managedAsgTag` option in aws-node-termination-handler.

NTH PR: https://github.com/aws/aws-node-termination-handler/pull/287