### PR TITLE
[aws-for-fluent-bit] Add Replace_Dots option to fluent-bit elasticsearch output #297

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.5
+version: 0.1.6
 appVersion: 2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -85,6 +85,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `elasticsearch.tls` | Enable or disable TLS support | On |
 | `elasticsearch.port` | TCP Port of the target service. | 443 |
 | `elasticsearch.retryLimit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
+| `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
 | `extraOutputs` | Adding more outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -161,6 +161,9 @@ data:
         {{- if .Values.elasticsearch.retryLimit }}
         Retry_Limit     {{ .Values.elasticsearch.retryLimit }}
         {{- end }}
+        {{- if .Values.elasticsearch.replaceDots }}
+        Replace_Dots    {{ .Values.elasticsearch.replaceDots }}
+        {{- end }}
 {{- end }}
 
 {{- if .Values.extraOutputs }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -102,6 +102,7 @@ elasticsearch:
   tls: "On"
   port: "443"
   retryLimit: 6
+  replaceDots: "On"
 
 # extraOutputs: |
 #   [OUTPUT]


### PR DESCRIPTION
Issue #297

Description of changes:

Add Replace_Dots option to fluent-bit elasticsearch output

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
