### PR TITLE
Delete invalid status definition

### DIFF
--- a/stable/aws-load-balancer-controller/crds/crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/crds.yaml
@@ -177,9 +177,3 @@ spec:
   - name: v1beta1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Keeping this here breaks pulumi deployments as `status` is not a valid attribute of `CustomResourceDefinition`.

Issue #, if available: n/a

Description of changes:
Delete an invalid attribute, `status` on `CustomResourceDefintion`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
