### PR TITLE
aws-vpc-cni: move default affinity to values.yaml

### DIFF
--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -29,38 +29,6 @@ spec:
         k8s-app: aws-node
     spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
-                    operator: In
-                    values:
-                      - linux
-                  - key: "beta.kubernetes.io/arch"
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                  - key: "eks.amazonaws.com/compute-type"
-                    operator: NotIn
-                    values:
-                      - fargate
-              - matchExpressions:
-                  - key: "kubernetes.io/os"
-                    operator: In
-                    values:
-                      - linux
-                  - key: "kubernetes.io/arch"
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                  - key: "eks.amazonaws.com/compute-type"
-                    operator: NotIn
-                    values:
-                      - fargate
       serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}
       hostNetwork: true
       initContainers:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -103,4 +103,35 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "beta.kubernetes.io/os"
+              operator: In
+              values:
+                - linux
+            - key: "beta.kubernetes.io/arch"
+              operator: In
+              values:
+                - amd64
+                - arm64
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+                - fargate
+        - matchExpressions:
+            - key: "kubernetes.io/os"
+              operator: In
+              values:
+                - linux
+            - key: "kubernetes.io/arch"
+              operator: In
+              values:
+                - amd64
+                - arm64
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+                - fargate


### PR DESCRIPTION
This change allows you to override the affinity, should you want to, using the already existing `affinity` key in the Helm values.

Previously, setting the `affinity` key in the Helm values would cause a duplicate `affinity` key in the pod spec. This might have worked, but I think it would be dependent on the YAML parser

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
