### PR TITLE
node-termination-handler v1.11.1

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.13.0
-appVersion: 1.11.0
+version: 0.13.1
+appVersion: 1.11.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
 `taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance`, `aws-node-termination-handler/spot-itn`, and `aws-node-termination-handler/asg-lifecycle-termination` | `false`
 `jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
+`logLevel` | Sets the log level (INFO, DEBUG, or ERROR) | `INFO`
 `enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`
 `prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
 `podMonitor.create` | if `true`, create a PodMonitor | `false`

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -43,7 +43,7 @@ spec:
           hostPath:
             path: {{ .Values.procUptimeFile | default "/proc/uptime" | quote }}
         {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
-        - name: "webhookTemplate"
+        - name: "webhook-template"
           configMap:
             name: {{ .Values.webhookTemplateConfigMapName }}
         {{- end }}
@@ -91,7 +91,7 @@ spec:
               mountPath: {{ .Values.procUptimeFile | default "/proc/uptime" | quote }}
               readOnly: true
             {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
-            - name: "webhookTemplate"
+            - name: "webhook-template"
               mountPath: "/config/"
             {{- end }}
           env:
@@ -156,6 +156,8 @@ spec:
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
           - name: UPTIME_FROM_FILE

--- a/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
       volumes:
-      - name: "webhookTemplate"
+      - name: "webhook-template"
         configMap:
           name: {{ .Values.webhookTemplateConfigMapName }}
       {{- end }}
@@ -72,7 +72,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
           volumeMounts:
-          - name: "webhookTemplate"
+          - name: "webhook-template"
             mountPath: "/config/"
           {{- end }}
           env:
@@ -130,6 +130,8 @@ spec:
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
           - name: UPTIME_FROM_FILE

--- a/stable/aws-node-termination-handler/templates/deployment.yaml
+++ b/stable/aws-node-termination-handler/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
           - name: ENABLE_PROMETHEUS_SERVER

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.11.0
+  tag: v1.11.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -75,6 +75,9 @@ taintNode: false
 
 # Log messages in JSON format.
 jsonLogging: false
+
+# Sets the log level
+logLevel: "info"
 
 # dryRun tells node-termination-handler to only log calls to kubernetes control plane
 dryRun: false


### PR DESCRIPTION
# NTH Release v1.11.1


# Bug Fixes 🐛
* fixed volume name of daemonsets to follow DNS-1123 standard: [#300](https://github.com/aws/aws-node-termination-handler/pull/300) thanks @n0gu 
* fixed crashes on EC2 Instance State-change Notification events: [#307](https://github.com/aws/aws-node-termination-handler/issues/307) thanks @universam1 
* added `logLevel` as a helm installation parameter [#312](https://github.com/aws/aws-node-termination-handler/pull/312)
* fixed duplicate error checking [#314](https://github.com/aws/aws-node-termination-handler/pull/314)