### PR TITLE
Added new helm chart for AWS SIGv4 Admission Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ helm repo add eks https://aws.github.io/eks-charts
 ### AWS VPC CNI
 * [aws-vpc-cni](stable/aws-vpc-cni): Networking plugin for pod networking in Kubernetes using Elastic Network Interfaces on AWS. https://github.com/aws/amazon-vpc-cni-k8s
 
+### AWS SIGv4 Proxy Admission Controller
+* [aws-sigv4-proxy-admission-controller](stable/aws-sigv4-proxy-admission-controller): A helm chart for [AWS SIGv4 Proxy Admission Controller](https://github.com/aws-observability/aws-sigv4-proxy-admission-controller)
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/stable/aws-sigv4-proxy-admission-controller/.helmignore
+++ b/stable/aws-sigv4-proxy-admission-controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: sidecar-injector
+description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
+version: 0.1
+appVersion: 1.0

--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v1
-name: sidecar-injector
+name: aws-sigv4-proxy-admission-controller
 description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
 version: 0.1
 appVersion: 1.0
+home: https://github.com/aws/eks-charts
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/eks-charts
+maintainers:
+  - name: AWS Observability Team
+    url: https://github.com/aws-observability

--- a/stable/aws-sigv4-proxy-admission-controller/README.md
+++ b/stable/aws-sigv4-proxy-admission-controller/README.md
@@ -38,5 +38,5 @@ helm uninstall aws-sigv4-proxy-admission-controller --namespace <namespace>
 | `serviceAccount.create` | Whether to create a service account or not | `true`
 | `serviceAccount.name` | The name of the service account to create or use | `""`
 | `rbac.create` | Whether to create rbac resources or not | `true`
-| `service.port` | Incoming port used by service | `443`
-| `service.targetPort` | Target port used by service | `443`
+| `webhookService.port` | Incoming port used by webhook service | `443`
+| `webhookService.targetPort` | Target port used by webhook service | `443`

--- a/stable/aws-sigv4-proxy-admission-controller/README.md
+++ b/stable/aws-sigv4-proxy-admission-controller/README.md
@@ -10,29 +10,33 @@ Add the EKS repository to Helm:
 helm repo add eks https://aws.github.io/eks-charts
 ```
 
-Install or upgrading the AWS SIGv4 Admission Controller chart with default configuration:
+Install the AWS SIGv4 Admission Controller chart with default configuration:
 
 ```bash
-helm upgrade --install aws-sigv4-proxy --namespace <namespace>
+helm install aws-sigv4-proxy-admission-controller eks/aws-sigv4-proxy-admission-controller --namespace <namespace>
 ```
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `aws-sigv4-proxy` release:
+To uninstall/delete the `aws-sigv4-proxy-admission-controller` release:
 
 ```bash
-helm delete aws-sigv4-proxy --namespace <namespace>
+helm uninstall aws-sigv4-proxy-admission-controller --namespace <namespace>
 ```
 
 ## Configuration
 
-| Parameter | Description | Default | Required |
-| - | - | - | -
-| `name` | Name of chart | `sidecar-injector` | ✔
-| `image.uri` | URI of image to deploy | `public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller:1.0` | ✔
-| `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
-| `env.awsSigV4ProxyImage` | AWS SIGv4 image to use as sidecar | `public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0` | ✔
-| `serviceAccount.create` | Whether a new service account should be created | `true` |
-| `serviceAccount.name` | Name of the service account | `""` |
-| `service.port` | Incoming port | `443` |
-| `service.targetPort` | Target port | `443` |
+| Parameter | Description | Default
+| - | - | -
+| `nameOverride` | Used to override name of chart | `""`
+| `fullnameOverride` | Used to override the full name of the application | `""`
+| `replicaCount` | Number of replicas | `1`
+| `image.repository` | Repository of image to pull for deployment | `public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller`
+| `image.tag` | Tag of image to pull from repository | `1.0`
+| `image.pullPolicy` | Policy of how to pull image | `IfNotPresent`
+| `env.awsSigV4ProxyImage` | Image URI of sidecar container for AWS SIGv4 Proxy | `public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0`
+| `serviceAccount.create` | Whether to create a service account or not | `true`
+| `serviceAccount.name` | The name of the service account to create or use | `""`
+| `rbac.create` | Whether to create rbac resources or not | `true`
+| `service.port` | Incoming port used by service | `443`
+| `service.targetPort` | Target port used by service | `443`

--- a/stable/aws-sigv4-proxy-admission-controller/README.md
+++ b/stable/aws-sigv4-proxy-admission-controller/README.md
@@ -1,0 +1,38 @@
+# AWS SIGv4 Admission Controller
+
+A helm chart for [AWS SIGv4 Admission Controller](https://github.com/aws-observability/aws-sigv4-proxy-admission-controller)
+
+## Installing the Chart
+
+Add the EKS repository to Helm:
+
+```bash
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+Install or upgrading the AWS SIGv4 Admission Controller chart with default configuration:
+
+```bash
+helm upgrade --install aws-sigv4-proxy --namespace <namespace>
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `aws-sigv4-proxy` release:
+
+```bash
+helm delete aws-sigv4-proxy --namespace <namespace>
+```
+
+## Configuration
+
+| Parameter | Description | Default | Required |
+| - | - | - | -
+| `name` | Name of chart | `sidecar-injector` | ✔
+| `image.uri` | URI of image to deploy | `public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller:1.0` | ✔
+| `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
+| `env.awsSigV4ProxyImage` | AWS SIGv4 image to use as sidecar | `public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0` | ✔
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
+| `serviceAccount.name` | Name of the service account | `""` |
+| `service.port` | Incoming port | `443` |
+| `service.targetPort` | Target port | `443` |

--- a/stable/aws-sigv4-proxy-admission-controller/templates/NOTES.txt
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/NOTES.txt
@@ -1,0 +1,2 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+kubectl get pods -n {{ .Release.Namespace }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/_helpers.tpl
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sidecar-injector.name" -}}
+{{- default .Chart.Name .Values.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sidecar-injector.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Values.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sidecar-injector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sidecar-injector.labels" -}}
+helm.sh/chart: {{ include "sidecar-injector.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sidecar-injector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sidecar-injector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate certificates for webhook
+*/}}
+{{- define "sidecar-injector.gen-certs" -}}
+{{- $serviceName := ( printf "%s-%s" ( include "sidecar-injector.fullname" . ) "webhook-svc" ) -}}
+{{- $cn := ( printf "%s.%s.%s" $serviceName .Release.Namespace "svc" ) -}}
+{{- $ca := genCA "kubernetes" 3650 -}}
+{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+caCert: {{ $ca.Cert | b64enc }}
+clientCert: {{ $cert.Cert | b64enc }}
+clientKey: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/_helpers.tpl
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "sidecar-injector.name" -}}
-{{- default .Chart.Name .Values.name | trunc 63 | trimSuffix "-" }}
+{{- define "aws-sigv4-proxy-admission-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -10,22 +10,31 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "sidecar-injector.fullname" -}}
-{{- printf "%s-%s" .Release.Name .Values.name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- define "aws-sigv4-proxy-admission-controller.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "sidecar-injector.chart" -}}
+{{- define "aws-sigv4-proxy-admission-controller.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "sidecar-injector.labels" -}}
-helm.sh/chart: {{ include "sidecar-injector.chart" . }}
+{{- define "aws-sigv4-proxy-admission-controller.labels" -}}
+helm.sh/chart: {{ include "aws-sigv4-proxy-admission-controller.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -35,22 +44,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "sidecar-injector.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "sidecar-injector.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+{{- define "aws-sigv4-proxy-admission-controller.serviceAccountName" -}}
+  {{ default (include "aws-sigv4-proxy-admission-controller.fullname" .) .Values.serviceAccount.name }}
+{{- end -}}
 
 {{/*
 Generate certificates for webhook
 */}}
-{{- define "sidecar-injector.gen-certs" -}}
-{{- $serviceName := ( printf "%s-%s" ( include "sidecar-injector.fullname" . ) "webhook-svc" ) -}}
-{{- $cn := ( printf "%s.%s.%s" $serviceName .Release.Namespace "svc" ) -}}
-{{- $ca := genCA "kubernetes" 3650 -}}
-{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- define "aws-sigv4-proxy-admission-controller.gen-certs" -}}
+{{- $fullName := ( include "aws-sigv4-proxy-admission-controller.fullname" . ) -}}
+{{- $serviceName := ( printf "%s-%s" $fullName "webhook-service" ) -}}
+{{- $altNames := list ( printf "%s.%s" $serviceName .Release.Namespace ) ( printf "%s.%s.svc" $serviceName .Release.Namespace ) -}}
+{{- $ca := genCA "aws-sigv4-proxy-admission-controller-ca" 3650 -}}
+{{- $cert := genSignedCert $fullName nil $altNames 3650 $ca -}}
 caCert: {{ $ca.Cert | b64enc }}
 clientCert: {{ $cert.Cert | b64enc }}
 clientKey: {{ $cert.Key | b64enc }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
           args:
             - -tlsCertFile=/etc/webhook/certs/cert.pem
             - -tlsKeyFile=/etc/webhook/certs/key.pem
+          ports:
+            - containerPort: {{ .Values.webhookService.targetPort }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sidecar-injector.fullname" . }}-webhook-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "sidecar-injector.fullname" . }}
+{{ include "sidecar-injector.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "sidecar-injector.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "sidecar-injector.fullname" . }}
+    spec:
+      serviceAccountName: {{ template "sidecar-injector.serviceAccountName" . }}
+      containers:
+        - name: {{ template "sidecar-injector.fullname" . }}
+          image: {{ .Values.image.uri }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -tlsCertFile=/etc/webhook/certs/cert.pem
+            - -tlsKeyFile=/etc/webhook/certs/key.pem
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+          env:
+            - name: AWS-SIGV4-PROXY-IMAGE
+              value: {{ .Values.env.awsSigV4ProxyImage }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ template "sidecar-injector.fullname" . }}-webhook-certs

--- a/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "sidecar-injector.fullname" . }}-webhook-deployment
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-deployment
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "sidecar-injector.fullname" . }}
-{{ include "sidecar-injector.labels" . | indent 4 }}
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "sidecar-injector.fullname" . }}
+      app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ template "sidecar-injector.fullname" . }}
+        app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
     spec:
-      serviceAccountName: {{ template "sidecar-injector.serviceAccountName" . }}
+      serviceAccountName: {{ template "aws-sigv4-proxy-admission-controller.serviceAccountName" . }}
       containers:
-        - name: {{ template "sidecar-injector.fullname" . }}
-          image: {{ .Values.image.uri }}
+        - name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -tlsCertFile=/etc/webhook/certs/cert.pem
@@ -34,4 +34,4 @@ spec:
       volumes:
         - name: webhook-certs
           secret:
-            secretName: {{ template "sidecar-injector.fullname" . }}-webhook-certs
+            secretName: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-certs

--- a/stable/aws-sigv4-proxy-admission-controller/templates/rbac.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/rbac.yaml
@@ -1,18 +1,11 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "sidecar-injector.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "sidecar-injector.labels" . | indent 4 }}
----
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "sidecar-injector.fullname" . }}-role
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-role
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "sidecar-injector.labels" . | indent 4 }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 rules:
   - apiGroups: [""]
     resources: [namespaces]
@@ -21,15 +14,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "sidecar-injector.fullname" . }}-rolebinding
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "sidecar-injector.labels" . | indent 4 }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "sidecar-injector.fullname" . }}-role
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-role
 subjects:
   - kind: ServiceAccount
-    name: {{ template "sidecar-injector.serviceAccountName" . }}
+    name: {{ template "aws-sigv4-proxy-admission-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/rbac.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sidecar-injector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "sidecar-injector.labels" . | indent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "sidecar-injector.fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "sidecar-injector.labels" . | indent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "sidecar-injector.fullname" . }}-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "sidecar-injector.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "sidecar-injector.fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sidecar-injector.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/service.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sidecar-injector.fullname" . }}-webhook-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "sidecar-injector.fullname" . }}
+{{ include "sidecar-injector.labels" . | indent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+  selector:
+    app: {{ template "sidecar-injector.fullname" . }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/service.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 spec:
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+    - port: {{ .Values.webhookService.port }}
+      targetPort: {{ .Values.webhookService.targetPort }}
   selector:
     app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/service.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sidecar-injector.fullname" . }}-webhook-svc
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "sidecar-injector.fullname" . }}
-{{ include "sidecar-injector.labels" . | indent 4 }}
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
   selector:
-    app: {{ template "sidecar-injector.fullname" . }}
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/serviceaccount.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+{{- end -}}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -1,17 +1,17 @@
-{{ $tls := fromYaml ( include "sidecar-injector.gen-certs" . ) }}
+{{ $tls := fromYaml ( include "aws-sigv4-proxy-admission-controller.gen-certs" . ) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ template "sidecar-injector.fullname" . }}-webhook-cfg
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-config
   labels:
-    app: {{ template "sidecar-injector.fullname" . }}
-{{ include "sidecar-injector.labels" . | indent 4 }}
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 webhooks:
-  - name: {{ template "sidecar-injector.fullname" . }}.k8s.aws
+  - name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}.k8s.aws
     clientConfig:
       service:
-        name: {{ template "sidecar-injector.fullname" . }}-webhook-svc
+        name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-service
         namespace: {{ .Release.Namespace }}
         path: "/mutate"
       caBundle: {{ $tls.caCert }}
@@ -20,14 +20,15 @@ webhooks:
         apiGroups: ["apps", ""]
         apiVersions: ["v1"]
         resources: ["pods"]
+    sideEffects: None
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "sidecar-injector.fullname" . }}-webhook-certs
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-certs
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "sidecar-injector.labels" . | indent 4 }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
 type: Opaque
 data:
   cert.pem: {{ $tls.clientCert }}

--- a/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -1,0 +1,34 @@
+{{ $tls := fromYaml ( include "sidecar-injector.gen-certs" . ) }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "sidecar-injector.fullname" . }}-webhook-cfg
+  labels:
+    app: {{ template "sidecar-injector.fullname" . }}
+{{ include "sidecar-injector.labels" . | indent 4 }}
+webhooks:
+  - name: {{ template "sidecar-injector.fullname" . }}.k8s.aws
+    clientConfig:
+      service:
+        name: {{ template "sidecar-injector.fullname" . }}-webhook-svc
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate"
+      caBundle: {{ $tls.caCert }}
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: ["apps", ""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sidecar-injector.fullname" . }}-webhook-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "sidecar-injector.labels" . | indent 4 }}
+type: Opaque
+data:
+  cert.pem: {{ $tls.clientCert }}
+  key.pem: {{ $tls.clientKey }}

--- a/stable/aws-sigv4-proxy-admission-controller/values.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/values.yaml
@@ -1,0 +1,18 @@
+name: sidecar-injector
+
+replicaCount: 1
+
+image:
+  uri: public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller:1.0
+  pullPolicy: IfNotPresent
+
+env:
+  awsSigV4ProxyImage: public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  port: 443
+  targetPort: 443

--- a/stable/aws-sigv4-proxy-admission-controller/values.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/values.yaml
@@ -28,8 +28,8 @@ rbac:
   # rbac.create: Whether to create rbac resources or not
   create: true
 
-service:
-  # service.port: Incoming port used by service
+webhookService:
+  # webhookService.port: Incoming port used by webhook service
   port: 443
-  # service.targetPort: Target port used by service
+  # webhookService.targetPort: Target port used by webhook service
   targetPort: 443

--- a/stable/aws-sigv4-proxy-admission-controller/values.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/values.yaml
@@ -1,18 +1,35 @@
-name: sidecar-injector
+# nameOverride: Used to override name of chart
+nameOverride: ""
+# fullnameOverride: Used to override the full name of the application
+fullnameOverride: ""
 
+# replicaCount: Number of replicas
 replicaCount: 1
 
 image:
-  uri: public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller:1.0
+  # image.repository: Repository of image to pull for deployment
+  repository: public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller
+  # image.tag: Tag of image to pull from repository
+  tag: "1.0"
+  # image.pullPolicy: Policy of how to pull image
   pullPolicy: IfNotPresent
 
 env:
+  # env.awsSigV4ProxyImage: Image URI of sidecar container for AWS SIGv4 Proxy
   awsSigV4ProxyImage: public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0
 
 serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
   create: true
+  # serviceAccount.name: The name of the service account to create or use
   name: ""
 
+rbac:
+  # rbac.create: Whether to create rbac resources or not
+  create: true
+
 service:
+  # service.port: Incoming port used by service
   port: 443
+  # service.targetPort: Target port used by service
   targetPort: 443


### PR DESCRIPTION
Added new helm chart for AWS SIGv4 Admission Controller

Repository URL: https://github.com/aws-observability/aws-sigv4-proxy-admission-controller

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
