### PR TITLE
Parameterize probe values for Jaeger-chart

### DIFF
--- a/stable/appmesh-jaeger/Chart.yaml
+++ b/stable/appmesh-jaeger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-jaeger
 description: App Mesh Jaeger Helm chart for Kubernetes
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.19.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-jaeger/README.md
+++ b/stable/appmesh-jaeger/README.md
@@ -62,6 +62,16 @@ Parameter | Description | Default
 `resources.requests/memory` | pod memory request | `256Mi`
 `resources.limits/cpu` | pod CPU limit | `2000m`
 `resources.limits/memory` | pod memory limit | `2Gi`
+`probes.liveness.initialDelaySeconds` | seconds to delay liveness probing | `0`
+`probes.liveness.periodSeconds` | interval between liveness probing | `10`
+`probes.liveness.timeoutSeconds` | timeout for liveness probe  | `1`
+`probes.liveness.successThreshold` | minimum consecutive successes for probe to be considered successful | `1`
+`probes.liveness.failureThreshold` | minimum consecutive fails for probe to be considered failed | `3`
+`probes.readiness.initialDelaySeconds` | seconds to delay readiness probing | `0`
+`probes.readiness.periodSeconds` | interval between readiness probing | `10`
+`probes.readiness.timeoutSeconds` | timeout for readiness probe | `1`
+`probes.readiness.successThreshold` | minimum consecutive successes for probe to be considered successful | `1`
+`probes.readiness.failureThreshold` | minimum consecutive fails for probe to be considered failed | `3`
 `affinity` | node/pod affinities | None
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | list of node taints to tolerate | `[]`

--- a/stable/appmesh-jaeger/templates/deployment.yaml
+++ b/stable/appmesh-jaeger/templates/deployment.yaml
@@ -79,10 +79,20 @@ spec:
             httpGet:
               path: /
               port: 14269
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.liveness.successThreshold }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /
               port: 14269
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           volumeMounts:
             - name: data
               mountPath: /badger

--- a/stable/appmesh-jaeger/values.yaml
+++ b/stable/appmesh-jaeger/values.yaml
@@ -20,7 +20,7 @@ resources:
     cpu: 100m
     memory: 256Mi
 
-  ## Prometheus server readiness and liveness probe initial delay and timeout
+  ## Jaeger server readiness and liveness probe initial delay and timeout
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   ##
 probes:

--- a/stable/appmesh-jaeger/values.yaml
+++ b/stable/appmesh-jaeger/values.yaml
@@ -20,6 +20,23 @@ resources:
     cpu: 100m
     memory: 256Mi
 
+  ## Prometheus server readiness and liveness probe initial delay and timeout
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  ##
+probes:
+  liveness:
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Issue #, if available: 390

Description of changes:
* Parameterize liveness and readiness probes
* Sets default values in Chart to Kubernetes default values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
