### PR TITLE
[appmesh-controller] bump to v1.2.1 controller version

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -8,7 +8,7 @@ accountId: ""
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.2.0
+  tag: v1.2.1
   pullPolicy: IfNotPresent
 
 sidecar:


### PR DESCRIPTION
**Description of changes**
aws-app-mesh-controller-for-k8s has [released version 1.2.1](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.2.1). Bumping the Helm chart to use the v1.2.1

This release includes the fix for virtual gateway pod mutator to include xray daemon port correctly and handle crash due to duplicate cloud map namespaces and service names. See the release notes [here](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.2.1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
