### PR TITLE
feat: Add chart for fluentd-cloudwatch

### DIFF
--- a/stable/fluentd-cloudwatch/Chart.yaml
+++ b/stable/fluentd-cloudwatch/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: v1.7.3-debian-cloudwatch-1.0
+description: A Fluentd CloudWatch Helm chart for Kubernetes.
+engine: gotpl
+home: https://www.fluentd.org/
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- cloudwatch
+- logging
+name: fluentd-cloudwatch
+sources:
+- https://github.com/fluent/fluentd-kubernetes-daemonset
+version: 0.0.1

--- a/stable/fluentd-cloudwatch/README.md
+++ b/stable/fluentd-cloudwatch/README.md
@@ -1,0 +1,81 @@
+# Fluentd CloudWatch
+
+Installs [Fluentd](https://www.fluentd.org/) [Cloudwatch](https://aws.amazon.com/cloudwatch/) log forwarder. This chart is derived from [incubator/fluentd-cloudwatch](https://github.com/helm/charts/tree/master/incubator/fluentd-cloudwatch) but modified to align with https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html.
+
+## TL;DR;
+
+```sh
+helm repo add eks https://aws.github.io/eks-charts
+
+helm install fluentd-cloudwatch eks/fluentd-cloudwatch
+```
+
+## Introduction
+
+This chart bootstraps a [Fluentd](https://www.fluentd.org/) [Cloudwatch](https://aws.amazon.com/cloudwatch/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```sh
+# use ec2 instance role credential
+helm install my-release eks/fluentd-cloudwatch
+# or add aws_access_key_id and aws_access_key_id with the key/password of a AWS user with a policy to access  Cloudwatch
+helm install my-release eks/fluentd-cloudwatch --set awsAccessKeyId=aws_access_key_id_here --set awsSecretAccessKey=aws_secret_access_key_here
+# or add a role to aws with the correct policy to add to cloud watch
+helm install my-release eks/fluentd-cloudwatch --set awsRole=roll_name_here
+```
+
+The command deploys Fluentd Cloudwatch on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall the `my-release` deployment:
+
+```sh
+helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Fluentd Cloudwatch chart and their default values.
+
+| Parameter                       | Description                                                                     | Default                               |
+| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------|
+| `image.repository`              | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                     | Image tag                                                                       | `v1.7.3-debian-cloudwatch-1.0`        |
+| `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                        |
+| `resources.limits.cpu`          | CPU limit                                                                       | `nil`                                 |
+| `resources.limits.memory`       | Memory limit                                                                    | `400Mi`                               |
+| `resources.requests.cpu`        | CPU request                                                                     | `100m`                                |
+| `resources.requests.memory`     | Memory request                                                                  | `200Mi`                               |
+| `podAnnotations`                | Annotations                                                                     | `{}`                                  |
+| `podSecurityContext`            | Security Context                                                                | `{}`                                  |
+| `awsRegion`                     | AWS Cloudwatch region                                                           | `us-east-1`                           |
+| `clusterName`                   | The cloudwatch loggroup name will be derived using the cluster name             | `kubernetes`                          |
+| `awsRole`                       | AWS IAM Role To Use                                                             | `nil`                                 |
+| `awsAccessKeyId`                | AWS Access Key Id of a AWS user with a policy to access Cloudwatch              | `nil`                                 |
+| `awsSecretAccessKey`            | AWS Secret Access Key of a AWS user with a policy to access Cloudwatch          | `nil`                                 |
+| `config.conf`                   | Fluentd ConfigMap value. The main configuration is defined under `fluent.conf`  | `{}`                                  |
+| `config.dataplane.enabled`      | Disable forwarding dataplane logs by setting this to `false`                    | `true`                                |
+| `config.dataplane.conf`         | Customise dataplane log config. Defined under `systemd.conf`                    | `{}`                                  |
+| `config.host.enabled`           | Disable forwarding host logs by setting this to `false`                         | `true`                                |
+| `config.host.conf`              | Customise host log config. Defined under `host.conf`                            | `{}`                                  |
+| `config.containers.enabled`     | Disable forwarding host logs by setting this to `false`                         | `true`                                |
+| `config.containers.conf`        | Customise container log config. Defined under `containers.conf`                 | `{}`                                  |
+| `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                |
+| `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true)                    | `default`                             |
+| `rbac.serviceAccountAnnotations`| Additional Service Account annotations                                          | `{}`                                  |
+| `rbac.pspEnabled`               | PodSecuritypolicy                                                               | `false`                               |
+| `volumeMounts`                  | Add volume mounts to daemon set                                                 | `[]`                                  |
+| `volumes`                       | Add volumes to daemon set                                                       | `[]`                                  |
+| `tolerations`                   | Add tolerations                                                                 | `[]`                                  |
+| `extraVars`                     | Add pod environment variables (must be specified as a single line object)       | `[]`                                  |
+| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                  |
+| `affinity`                      | Node affinity for pod assignment                                                | `{}`                                  |
+| `priorityClassName`             | Set priority class for daemon set                                               | `nil`                                 |
+| `busybox.repository`            | Image repository for the initcontainer                                          | `busybox`                             |
+| `busybox.tag`                   | Image tag for the initcontainer                                                 | `1.31.0`                              |

--- a/stable/fluentd-cloudwatch/templates/NOTES.txt
+++ b/stable/fluentd-cloudwatch/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To verify that Fluentd Cloudwatch has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "fluentd-cloudwatch.name" . }},release={{ .Release.Name }}"
+
+THIS APPLICATION CAPTURES ALL CONSOLE OUTPUT AND FORWARDS IT TO AWS CLOUDWATCH. Anything that might be identifying,
+including things like IP addresses, container images, and object names will NOT be anonymized.

--- a/stable/fluentd-cloudwatch/templates/_helpers.tpl
+++ b/stable/fluentd-cloudwatch/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd-cloudwatch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluentd-cloudwatch.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluentd-cloudwatch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/fluentd-cloudwatch/templates/clusterrole.yaml
+++ b/stable/fluentd-cloudwatch/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - pods/logs
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/clusterrolebinding.yaml
+++ b/stable/fluentd-cloudwatch/templates/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/stable/fluentd-cloudwatch/templates/configmap.yaml
+++ b/stable/fluentd-cloudwatch/templates/configmap.yaml
@@ -1,0 +1,339 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name | quote }}
+data:
+{{- if .Values.config.conf }}
+{{ toYaml .Values.config.conf | indent 2 }}
+{{- else }}
+  fluent.conf: |
+    @include containers.conf
+{{- if .Values.config.dataplane.enabled }}
+    @include systemd.conf
+{{- end }}
+{{- if .Values.config.host.enabled }}
+    @include host.conf
+{{- end }}
+
+    <match fluent.**>
+      @type null
+    </match>
+{{- if .Values.config.containers.conf }}
+{{ toYaml .Values.config.containers.conf | indent 2 }}
+{{- else }}
+  containers.conf: |
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      @label @containers
+      path /var/log/containers/*.log
+      exclude_path ["/var/log/containers/cloudwatch-agent*", "/var/log/containers/fluentd*"]
+      pos_file /var/log/fluentd-containers.log.pos
+      tag *
+      read_from_head true
+      <parse>
+        @type json
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_cwagent_logs
+      @label @cwagentlogs
+      path /var/log/containers/cloudwatch-agent*
+      pos_file /var/log/cloudwatch-agent.log.pos
+      tag *
+      read_from_head true
+      <parse>
+        @type json
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_fluentd_logs
+      @label @fluentdlogs
+      path /var/log/containers/fluentd*
+      pos_file /var/log/fluentd.log.pos
+      tag *
+      read_from_head true
+      <parse>
+        @type json
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    <label @fluentdlogs>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata_fluentd
+      </filter>
+
+      <filter **>
+        @type record_transformer
+        @id filter_fluentd_stream_transformer
+        <record>
+          stream_name ${tag_parts[3]}
+        </record>
+      </filter>
+
+      <match **>
+        @type relabel
+        @label @NORMAL
+      </match>
+    </label>
+
+    <label @containers>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata
+      </filter>
+
+      <filter **>
+        @type record_transformer
+        @id filter_containers_stream_transformer
+        <record>
+          stream_name ${tag_parts[3]}
+        </record>
+      </filter>
+
+      <filter **>
+        @type concat
+        key log
+        multiline_start_regexp /^\S/
+        separator ""
+        flush_interval 5
+        timeout_label @NORMAL
+      </filter>
+
+      <match **>
+        @type relabel
+        @label @NORMAL
+      </match>
+    </label>
+
+    <label @cwagentlogs>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata_cwagent
+      </filter>
+
+      <filter **>
+        @type record_transformer
+        @id filter_cwagent_stream_transformer
+        <record>
+          stream_name ${tag_parts[3]}
+        </record>
+      </filter>
+
+      <filter **>
+        @type concat
+        key log
+        multiline_start_regexp /^\d{4}[-/]\d{1,2}[-/]\d{1,2}/
+        separator ""
+        flush_interval 5
+        timeout_label @NORMAL
+      </filter>
+
+      <match **>
+        @type relabel
+        @label @NORMAL
+      </match>
+    </label>
+
+    <label @NORMAL>
+      <match **>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_containers
+        region "#{ENV.fetch('AWS_REGION')}"
+        log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/application"
+        log_stream_name_key stream_name
+        remove_log_stream_name_key true
+        auto_create_stream true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>
+{{- end }}
+{{- if .Values.config.dataplane.enabled }}
+{{- if .Values.config.dataplane.conf }}
+{{ toYaml .Values.config.dataplane.conf | indent 2 }}
+{{- else }}
+  systemd.conf: |
+    <source>
+      @type systemd
+      @id in_systemd_kubelet
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /var/log/journal
+      <storage>
+        @type local
+        persistent true
+        path /var/log/fluentd-journald-kubelet-pos.json
+      </storage>
+      read_from_head true
+      tag kubelet.service
+    </source>
+
+    <source>
+      @type systemd
+      @id in_systemd_kubeproxy
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "kubeproxy.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /var/log/journal
+      <storage>
+        @type local
+        persistent true
+        path /var/log/fluentd-journald-kubeproxy-pos.json
+      </storage>
+      read_from_head true
+      tag kubeproxy.service
+    </source>
+
+    <source>
+      @type systemd
+      @id in_systemd_docker
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /var/log/journal
+      <storage>
+        @type local
+        persistent true
+        path /var/log/fluentd-journald-docker-pos.json
+      </storage>
+      read_from_head true
+      tag docker.service
+    </source>
+
+    <label @systemd>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata_systemd
+      </filter>
+
+      <filter **>
+        @type record_transformer
+        @id filter_systemd_stream_transformer
+        <record>
+          stream_name ${tag}-${record["hostname"]}
+        </record>
+      </filter>
+
+      <match **>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_systemd
+        region "#{ENV.fetch('AWS_REGION')}"
+        log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/dataplane"
+        log_stream_name_key stream_name
+        auto_create_stream true
+        remove_log_stream_name_key true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>
+{{- end }}
+{{- end }}
+
+{{- if .Values.config.host.enabled }}
+{{- if .Values.config.host.conf }}
+{{ toYaml .Values.config.host.conf | indent 2 }}
+{{- else }}
+  host.conf: |
+    <source>
+      @type tail
+      @id in_tail_dmesg
+      @label @hostlogs
+      path /var/log/dmesg
+      pos_file /var/log/dmesg.log.pos
+      tag host.dmesg
+      read_from_head true
+      <parse>
+        @type syslog
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_secure
+      @label @hostlogs
+      path /var/log/secure
+      pos_file /var/log/secure.log.pos
+      tag host.secure
+      read_from_head true
+      <parse>
+        @type syslog
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_messages
+      @label @hostlogs
+      path /var/log/messages
+      pos_file /var/log/messages.log.pos
+      tag host.messages
+      read_from_head true
+      <parse>
+        @type syslog
+      </parse>
+    </source>
+
+    <label @hostlogs>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata_host
+      </filter>
+
+      <filter **>
+        @type record_transformer
+        @id filter_containers_stream_transformer_host
+        <record>
+          stream_name ${tag}-${record["host"]}
+        </record>
+      </filter>
+
+      <match host.**>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_host_logs
+        region "#{ENV.fetch('AWS_REGION')}"
+        log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/host"
+        log_stream_name_key stream_name
+        remove_log_stream_name_key true
+        auto_create_stream true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/stable/fluentd-cloudwatch/templates/daemonset.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fluentd-cloudwatch.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluentd-cloudwatch.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        configHash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.awsRole }}
+        iam.amazonaws.com/role: {{ .Values.awsRole }}
+{{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+{{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fluentd-cloudwatch.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      terminationGracePeriodSeconds: 30
+      # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
+      # this initContainers workaround or other is needed.
+      # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+      initContainers:
+      - name: copy-fluentd-config
+        image: {{.Values.busybox.repository}}:{{.Values.busybox.tag}}
+        command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config-volume
+        - name: fluentdconf
+          mountPath: /fluentd/etc
+      - name: update-log-driver
+        image: {{.Values.busybox.repository}}:{{.Values.busybox.tag}}
+        command: ['sh','-c','']
+      containers:
+      - name: {{ template "fluentd-cloudwatch.fullname" . }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: AWS_REGION
+          value: {{ .Values.awsRegion }}
+        - name: CLUSTER_NAME
+          value: {{ .Values.clusterName }}
+        - name: CI_VERSION
+          value: {{ .Values.ciVersion }}
+{{- if not .Values.awsRole }}
+{{- if .Values.awsAccessKeyId }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: {{ template "fluentd-cloudwatch.fullname" . }}
+{{- end }}
+{{- if .Values.awsSecretAccessKey }}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: {{ template "fluentd-cloudwatch.fullname" . }}
+{{- end }}
+{{- end }}
+{{- range $env := .Values.extraVars }}
+        - {{ $env  }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config-volume
+        - name: fluentdconf
+          mountPath: /fluentd/etc
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: runlogjournal
+          mountPath: /run/log/journal
+          readOnly: true
+        - name: dmesg
+          mountPath: /var/log/dmesg
+          readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ template "fluentd-cloudwatch.fullname" . }}
+      - name: fluentdconf
+        emptyDir: {}
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
+      - name: dmesg
+        hostPath:
+          path: /var/log/dmesg
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/psp-clusterrole.yaml
+++ b/stable/fluentd-cloudwatch/templates/psp-clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}-psp
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "fluentd-cloudwatch.fullname" . }}
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/psp-clusterrolebinding.yaml
+++ b/stable/fluentd-cloudwatch/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}-psp
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fluentd-cloudwatch.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ if .Values.rbac.create }}{{ template "fluentd-cloudwatch.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/psp.yaml
+++ b/stable/fluentd-cloudwatch/templates/psp.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 1
+    max: 65536
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/secrets.yaml
+++ b/stable/fluentd-cloudwatch/templates/secrets.yaml
@@ -1,0 +1,18 @@
+{{- if and (not .Values.awsRole) (and .Values.awsAccessKeyId .Values.awsSecretAccessKey) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+{{- if .Values.awsAccessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ .Values.awsAccessKeyId | b64enc }}
+{{- end }}
+{{- if .Values.awsSecretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.awsSecretAccessKey | b64enc }}
+{{- end }}
+{{- end }}

--- a/stable/fluentd-cloudwatch/templates/serviceaccount.yaml
+++ b/stable/fluentd-cloudwatch/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd-cloudwatch.fullname" . }}
+  labels:
+    app: {{ template "fluentd-cloudwatch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+{{- end }}
+{{- if .Values.rbac.serviceAccountAnnotations }}
+  annotations:
+{{ toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
+{{- end }}

--- a/stable/fluentd-cloudwatch/values.yaml
+++ b/stable/fluentd-cloudwatch/values.yaml
@@ -1,0 +1,110 @@
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v1.7.3-debian-cloudwatch-1.0
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+  pullPolicy: IfNotPresent
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  limits:
+    memory: 400Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+  # kubernetes.io/role: node
+# Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# Expects input structure as per specification for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+volumeMounts: []
+#   - name: runlogjournal
+#     mountPath: /run/log/journal
+#     readOnly: true
+
+volumes: []
+#   - name: runlogjournal
+#     hostPath:
+#       path: /run/log/journal
+
+## Add tolerations if specified
+tolerations: []
+#   - key: node-role.kubernetes.io/master
+#     operator: Exists
+#     effect: NoSchedule
+
+podSecurityContext: {}
+
+podAnnotations: {}
+
+# Pod priority
+# Sets PriorityClassName if defined.
+#
+# priorityClassName: "my-priority-class"
+
+awsRegion: us-east-1
+clusterName: kubernetes
+ciVersion: k8s/1.2.4
+awsRole:
+awsAccessKeyId:
+awsSecretAccessKey:
+
+rbac:
+  ## If true, create and use RBAC resources
+  create: true
+  pspEnabled: false
+
+  ## Ignored if rbac.create is true
+  serviceAccountName: default
+  ## Annotations for the Service Account
+  serviceAccountAnnotations: {}
+# Add extra environment variables if specified (must be specified as a single line object and be quoted)
+extraVars: []
+# - "{ name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }"
+
+busybox:
+  repository: busybox
+  tag: 1.31.0
+
+config:
+  # customise the whole config including setting up fluent.conf
+  conf: {}
+  dataplane:
+    enabled: true
+    # customise systemd.conf
+    ## conf:
+    ##   systemd.conf: |
+    ##     <source>
+    ##     ..
+    conf: {}
+  host:
+    enabled: true
+    # customise host.conf
+    ## conf:
+    ##   host.conf: |
+    ##     <source>
+    ##     ..
+    conf: {}
+  containers:
+    # customise containers.conf
+    ## conf:
+    ##   containers.conf: |
+    ##     <source>
+    ##     ..
+    conf: {}


### PR DESCRIPTION
This chart is derived from [incubator/fluentd-cloudwatch](https://github.com/helm/charts/tree/master/incubator/fluentd-cloudwatch) but modified to align with https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
