### PR TITLE
[aws-cloudwatch-metrics] add the possibility to change the hostNetwork

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.1
+version: 0.0.2
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -28,3 +28,4 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
 | `serviceAccount.create` | Whether a new service account should be created | `true` | 
 | `serviceAccount.name` | Service account to be used | | 
+| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "aws-cloudwatch-metrics.labels" . | nindent 4 }}
 spec:
-  hostNetwork: {{ .Values.hostNetwork | default false}}
+  hostNetwork: {{ .Values.hostNetwork }}
   selector:
     matchLabels:
       {{- include "aws-cloudwatch-metrics.selectorLabels" . | nindent 6 }}

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "aws-cloudwatch-metrics.labels" . | nindent 4 }}
 spec:
+  hostNetwork: {{ .Values.hostNetwork | default false}}
   selector:
     matchLabels:
       {{- include "aws-cloudwatch-metrics.selectorLabels" . | nindent 6 }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -16,3 +16,5 @@ resources:
 serviceAccount:
   create: true
   name:
+
+hostNetwork: false


### PR DESCRIPTION
Issue #, if available:
https://www.reddit.com/r/aws/comments/g2huur/deploying_cloudwatch_agent_in_eks_as_a_pod_is/

Description of changes:
Add the possibility to change the hostNetwork via passing it trough the values. 
Set default to false for backwards compatibility.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
