### PR TITLE
Adding liveness probe into helm charts appmesh controller

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -351,3 +351,4 @@ Parameter | Description | Default
 `xray.image.tag` | X-Ray image tag | `latest`
 `accountId` | AWS Account ID for the Kubernetes cluster | None
 `env` |  environment variables to be injected into the appmesh-controller pod | `{}`
+`livenessProbe` | Liveness probe settings for the controller | (see `values.yaml`)

--- a/stable/appmesh-controller/templates/deployment.yaml
+++ b/stable/appmesh-controller/templates/deployment.yaml
@@ -110,6 +110,8 @@ spec:
         {{- end}}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | nindent 10 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -123,3 +123,13 @@ env: {}
 #    http_proxy: http://proxyserver:3128
 #    https_proxy: http://proxyserver:3128
 #    no_proxy: "localhost,127.0.0.1,.cluster.local"
+
+# Liveness probe configuration for the controller
+livenessProbe:
+  failureThreshold: 2
+  httpGet:
+    path: /healthz
+    port: 61779
+    scheme: HTTP
+  initialDelaySeconds: 30
+  timeoutSeconds: 10


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The changes are for adding liveness probe for App Mesh controller.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
