### PR TITLE
patch install-toolchain to use new helm stable repo flag

### DIFF
--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -37,7 +37,7 @@ mv "${TMP_DIR}/helmv3/${PLATFORM}-${ARCH}/helm" "${TOOLS_DIR}/helmv3"
 rm -rf "${PLATFORM}-${ARCH}"
 
 ## Initialize helm
-helm init --client-only --kubeconfig="${BUILD_DIR}/.kube/kubeconfig"
+helm init --stable-repo-url https://charts.helm.sh/stable --client-only --kubeconfig="${BUILD_DIR}/.kube/kubeconfig"
 
 ## Install kind
 curl -sSL "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${PLATFORM}-${ARCH}" -o "${TOOLS_DIR}/kind"

--- a/test/lib/kind.sh
+++ b/test/lib/kind.sh
@@ -37,7 +37,7 @@ function installHelm() {
     kubectl create clusterrolebinding tiller-cluster-rule \
       --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 
-    helm init --service-account tiller --upgrade --wait
+    helm init --stable-repo-url https://charts.helm.sh/stable --service-account tiller --upgrade --wait
   fi
 
   if [[ "${1}" == "v3" ]]; then


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
eks-charts builds have been failing due to this error in Circle CI while executing the install-toolchain.sh script:

```
/home/circleci/project/scripts/install-toolchain.sh
Creating /home/circleci/.helm 
Creating /home/circleci/.helm/repository 
Creating /home/circleci/.helm/repository/cache 
Creating /home/circleci/.helm/repository/local 
Creating /home/circleci/.helm/plugins 
Creating /home/circleci/.helm/starters 
Creating /home/circleci/.helm/cache/archive 
Creating /home/circleci/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
make: *** [Makefile:30: install-toolchain] Error 1
```
The problem is that "https://kubernetes-charts.storage.googleapis.com" no longer resolves:

```
curl https://kubernetes-charts.storage.googleapis.com
<?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>Anonymous caller does not have storage.objects.list access to the Google Cloud Storage bucket.</Details></Error>%
```
The new stable repo is https://charts.helm.sh/stable. I've updated the helm init command to use this new repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
