### PR TITLE
[appmesh-controller] Add sideEffects:None to webhook configuration

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.2.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/templates/webhook.yaml
+++ b/stable/appmesh-controller/templates/webhook.yaml
@@ -32,6 +32,7 @@ webhooks:
     - UPDATE
     resources:
     - {{ $res.resource }}
+  sideEffects: None
 {{- end }}
 - clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
@@ -57,6 +58,7 @@ webhooks:
     - CREATE
     resources:
     - pods
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -88,6 +90,7 @@ webhooks:
     - UPDATE
     resources:
     - {{ $res.resource }}
+  sideEffects: None
 {{- end }}
 ---
 {{- if not $.Values.enableCertManager }}


### PR DESCRIPTION
Issue #, if available:
The v1beta1 version for mutating and validating webhook is deprecated and support will be removed in K8s 1.22. The sideEffects field in v1 version must be set to None or NoneOnDryRun.

Description of changes:
Add sideEffects field set to None to the mutating and validating webhook configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
