### PR TITLE
[aws-cloudwatch-metrics] Allow to control whether RBAC resources are created

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.3
+version: 0.0.4
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -18,6 +18,38 @@ helm upgrade --install aws-cloudwatch-metrics \
     --set clusterName=my-eks-cluster
 ```
 
+## Using this chart with IRSA
+
+1. Create IAM OIDC provider
+
+```
+eksctl utils associate-iam-oidc-provider \
+  --region <aws-region> \
+  --cluster <your-cluster-name> \
+  --approve
+```
+
+2. Create a IAM role and ServiceAccount for the Cloudwatch Metrics agent
+
+```
+eksctl create iamserviceaccount \
+  --cluster=<cluster-name> \
+  --namespace=amazon-cloudwatch \
+  --name=aws-cloudwatch-metrics \
+  --attach-policy-arn=arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy \
+  --approve
+```
+
+3. Install helm chart using Service Account
+
+```
+helm upgrade --install aws-cloudwatch-metrics \
+  --namespace amazon-cloudwatch eks/aws-cloudwatch-metric \
+  --set clusterName=my-eks-cluster \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-cloudwatch-metrics
+```
+
 ## Configuration
 
 | Parameter | Description | Default | Required |
@@ -28,4 +60,5 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
 | `serviceAccount.create` | Whether a new service account should be created | `true` | 
 | `serviceAccount.name` | Service account to be used | | 
+| `rbac.create` | Whether RBAC resources should be created | `true` | 
 | `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 

--- a/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/stable/aws-cloudwatch-metrics/templates/clusterrolebinding.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: {{ include "aws-cloudwatch-metrics.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "aws-cloudwatch-metrics.fullname" . }}
+  name: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -17,4 +17,8 @@ serviceAccount:
   create: true
   name:
 
+rbac:
+  # Specifies whether rbac resources should be created
+  create: true
+
 hostNetwork: false


### PR DESCRIPTION
Description of changes:

This PR allow users to control whether or not create RBAC resources than can be used with custom Service Accounts this feature is very useful when using `aws-cloudwatch-metric` with IAM Roles for Service Accounts when the Service Account is mostly created via other tools like `CDK` or `eksctl`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
