### PR TITLE
Revert "aws-vpc-cni: move default affinity to values.yaml"

### DIFF
--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -29,6 +29,38 @@ spec:
         k8s-app: aws-node
     spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "beta.kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "beta.kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
+              - matchExpressions:
+                  - key: "kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
       serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}
       hostNetwork: true
       initContainers:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -103,35 +103,4 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: "beta.kubernetes.io/os"
-              operator: In
-              values:
-                - linux
-            - key: "beta.kubernetes.io/arch"
-              operator: In
-              values:
-                - amd64
-                - arm64
-            - key: "eks.amazonaws.com/compute-type"
-              operator: NotIn
-              values:
-                - fargate
-        - matchExpressions:
-            - key: "kubernetes.io/os"
-              operator: In
-              values:
-                - linux
-            - key: "kubernetes.io/arch"
-              operator: In
-              values:
-                - amd64
-                - arm64
-            - key: "eks.amazonaws.com/compute-type"
-              operator: NotIn
-              values:
-                - fargate
+affinity: {}


### PR DESCRIPTION
Reverts aws/eks-charts#384

The chart version needs to be bumped. See https://app.circleci.com/jobs/github/aws/eks-charts/2199?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification