### PR TITLE
aws-vpc-cni: move default affinity to values.yaml

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.1
+version: 1.1.2
 appVersion: "v1.7.5"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
@@ -13,10 +13,7 @@ keywords:
   - networking
   - vpc
 maintainers:
-  - name: Nicholas Turner
-    url: https://github.com/nckturner
-    email: nckturner@users.noreply.github.com
-  - name: Claes Mogren
-    url: https://github.com/mogren
-    email: mogren@users.noreply.github.com
+  - name: Jayanth Varavani
+    url: https://github.com/jayanthvn
+    email: jayanthvn@users.noreply.github.com
 engine: gotpl

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -29,38 +29,6 @@ spec:
         k8s-app: aws-node
     spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
-                    operator: In
-                    values:
-                      - linux
-                  - key: "beta.kubernetes.io/arch"
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                  - key: "eks.amazonaws.com/compute-type"
-                    operator: NotIn
-                    values:
-                      - fargate
-              - matchExpressions:
-                  - key: "kubernetes.io/os"
-                    operator: In
-                    values:
-                      - linux
-                  - key: "kubernetes.io/arch"
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                  - key: "eks.amazonaws.com/compute-type"
-                    operator: NotIn
-                    values:
-                      - fargate
       serviceAccountName: {{ template "aws-vpc-cni.serviceAccountName" . }}
       hostNetwork: true
       initContainers:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -103,4 +103,35 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "beta.kubernetes.io/os"
+              operator: In
+              values:
+                - linux
+            - key: "beta.kubernetes.io/arch"
+              operator: In
+              values:
+                - amd64
+                - arm64
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+                - fargate
+        - matchExpressions:
+            - key: "kubernetes.io/os"
+              operator: In
+              values:
+                - linux
+            - key: "kubernetes.io/arch"
+              operator: In
+              values:
+                - amd64
+                - arm64
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+                - fargate


### PR DESCRIPTION
**Details**
Same as PR: https://github.com/aws/eks-charts/pull/384 with correct chart version bump. The PR had to be reverted (see https://github.com/aws/eks-charts/pull/415) as it was breaking in the CI. Also, added the chart maintainer