### PR TITLE
[aws-load-balancer-controller] Add namespace metadata field to the template

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.1.2
+version: 1.1.3
 appVersion: v2.1.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "aws-load-balancer-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:

--- a/stable/aws-load-balancer-controller/templates/rbac.yaml
+++ b/stable/aws-load-balancer-controller/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "aws-load-balancer-controller.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 rules:
@@ -18,6 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "aws-load-balancer-controller.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 roleRef:

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 spec:

--- a/stable/aws-load-balancer-controller/templates/serviceaccount.yaml
+++ b/stable/aws-load-balancer-controller/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aws-load-balancer-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -97,6 +97,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-tls
+  namespace: {{ .Release.Namespace }
   labels:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 type: kubernetes.io/tls
@@ -109,6 +110,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 spec:
@@ -124,6 +126,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 spec:

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -97,7 +97,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-tls
-  namespace: {{ .Release.Namespace }
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 type: kubernetes.io/tls


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/aws/eks-charts/issues/408

### Description of changes

<!-- Please explain the changes you made here. -->
Add `namespace` metadata field to AWS Load Balancer Controller `deployment.yaml`, to be able to set the namespace for resources already in the template.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
- Verified helm template renders the chart correctly
- Verified helm upgrade updates the existing chart
- Verified helm install works as expected

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
