### PR TITLE
Missing release name in example

### DIFF
--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -5,7 +5,6 @@ AWS Load Balancer controller Helm chart for Kubernetes
 ## TL;DR:
 ```sh
 helm repo add eks https://aws.github.io/eks-charts
-kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
 helm install aws-load-balancer-controller eks/aws-load-balancer-controller --set clusterName=my-cluster
 ```
 

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -6,7 +6,7 @@ AWS Load Balancer controller Helm chart for Kubernetes
 ```sh
 helm repo add eks https://aws.github.io/eks-charts
 kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
-helm install eks/aws-load-balancer-controller
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller
 ```
 
 ## Introduction

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -6,7 +6,7 @@ AWS Load Balancer controller Helm chart for Kubernetes
 ```sh
 helm repo add eks https://aws.github.io/eks-charts
 kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
-helm install aws-load-balancer-controller eks/aws-load-balancer-controller
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller --set clusterName=my-cluster
 ```
 
 ## Introduction


### PR DESCRIPTION
### Issue

- missing release name in example load balancer controller deployment 
- missing mandatory `clusterName` variable
- no need to install CRDs, it's being installed with the chart

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
