### PR TITLE
Move CRD to crds/ directory as documented for Helm 3

### DIFF
--- a/stable/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/stable/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -1,10 +1,7 @@
-{{- if .Values.crd.create -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eniconfigs.crd.k8s.amazonaws.com
-  labels:
-{{ include "aws-vpc-cni.labels" . | indent 4 }}
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -16,4 +13,4 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
-{{- end -}}
+


### PR DESCRIPTION
Creation of CRD gives issue in Helm 3.

CRDs should belong to crds/, see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.