### PR TITLE
Fix chart name for appmesh-spire-agent

### DIFF
--- a/stable/appmesh-spire-agent/Chart.yaml
+++ b/stable/appmesh-spire-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-name: appmesh-spire-server
-description: SPIRE Server Helm chart for AppMesh mTLS support on Kubernetes
+name: appmesh-spire-agent
+description: SPIRE Agent Helm chart for AppMesh mTLS support on Kubernetes
 version: 1.0.0
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts

--- a/stable/appmesh-spire-agent/Chart.yaml
+++ b/stable/appmesh-spire-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-agent
 description: SPIRE Agent Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
### Description of changes

Chart name in https://github.com/aws/eks-charts/tree/master/stable/appmesh-spire-agent lists the name as `appmesh-spire-server` which conflicts with https://github.com/aws/eks-charts/tree/master/stable/appmesh-spire-server. This change fixes by changing the name to `appmesh-spire-agent`.

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually fetched chart and installed, and the correct name shows up under the chart list. I can't check the public repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
