### PR TITLE
[aws-load-balancer-controller] Release controller v2.1.2

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.1.3
-appVersion: v2.1.1
+version: 1.1.4
+appVersion: v2.1.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -5,7 +5,7 @@ AWS Load Balancer controller Helm chart for Kubernetes
 ## TL;DR:
 ```sh
 helm repo add eks https://aws.github.io/eks-charts
-helm install aws-load-balancer-controller eks/aws-load-balancer-controller --set clusterName=my-cluster
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller --set clusterName=my-cluster -n kube-system
 ```
 
 ## Introduction

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.1.1
+  tag: v2.1.2
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
Release AWS Load Balancer controller v2.1.2.
This release of the controller relaxes the cluster tag requirement on the EC2 subnets, and will be the required chart version for new install of EKS 1.19 and later clusters.

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
<!-- Please explain what testing was done. -->
- ran helm upgrade and verified that the chart got updated, and the lb controller functions as expected.
- helm install and verified chart/crd got installed, and controller was functional

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
