### PR TITLE
Use new MutatingWebhookConfiguration apiVersion if available

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.3.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/templates/webhook.yaml
+++ b/stable/appmesh-controller/templates/webhook.yaml
@@ -2,7 +2,11 @@
 {{ $fullName := ( include "appmesh-controller.fullname" . ) }}
 {{ $webhookConfig := .Files.Get "webhookconfig.yaml" | fromYaml }}
 ---
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
@@ -60,7 +64,11 @@ webhooks:
     - pods
   sideEffects: None
 ---
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}

--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.1.4
+version: 1.1.5
 appVersion: v2.1.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -1,6 +1,10 @@
 {{ $tls := fromYaml ( include "aws-load-balancer-controller.gen-certs" . ) }}
 ---
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
@@ -59,7 +63,11 @@ webhooks:
     - targetgroupbindings
   sideEffects: None
 ---
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}

--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-sigv4-proxy-admission-controller
 description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
-version: 0.1
+version: 0.1.1
 appVersion: 1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -1,6 +1,10 @@
 {{ $tls := fromYaml ( include "aws-sigv4-proxy-admission-controller.gen-certs" . ) }}
 ---
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-config


### PR DESCRIPTION
### Issue

Fixes #465

### Description of changes

The MutatingWebhookConfiguration API `admissionregistration.k8s.io/v1beta1` has been deprecated in v1.16 for `admissionregistration.k8s.io/v1.

It will be removed in v.1.22 according to [this comment](https://github.com/kubernetes/kubernetes/issues/82021#issuecomment-636873001)

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

`helm template` against cluster running v1.18

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
