### PR TITLE
Add podLabels to amazon-calico chart

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.4
+version: 0.3.5
 appVersion: 3.15.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -38,26 +38,32 @@ If you receive an error similar to `Error: release aws-calico failed: <resource>
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                              | Description                                             | Default                         |
-|----------------------------------------|---------------------------------------------------------|---------------------------------|
-| `calico.typha.image`                   | Calico Typha Image                                      | `quay.io/calico/typha`          |
-| `calico.typha.resources`               | Calico Typha Resources                                  | `requests.memory: 64Mi, requests.cpu: 50m, limits.memory: 96Mi, limits.cpu: 100m` |
-| `calico.typha.logseverity`             | Calico Typha Log Severity                               | `Info`                          |
-| `calico.typha.nodeSelector`            | Calico Typha Node Selector                              | `{ beta.kubernetes.io/os: linux }` |
-| `calico.node.extraEnv`                 | Calico Node extra ENV vars                              | `[]`                            |
-| `calico.node.image`                    | Calico Node Image                                       | `quay.io/calico/node`           |
-| `calico.node.resources`                | Calico Node Resources                                   | `requests.memory: 32Mi, requests.cpu: 20m, limits.memory: 64Mi, limits.cpu: 100m` |
-| `calico.node.logseverity`              | Calico Node Log Severity                                | `Info`                          |
-| `calico.node.nodeSelector`             | Calico Node Node Selector                               | `{ beta.kubernetes.io/os: linux }` |
-| `calico.typha_autoscaler.resources`    | Calico Typha Autoscaler Resources                       | `requests.memory: 16Mi, requests.cpu: 10m, limits.memory: 32Mi, limits.cpu: 10m` |
-| `calico.typha_autoscaler.nodeSelector` | Calico Typha Autoscaler Node Selector                   | `{ beta.kubernetes.io/os: linux }` |
-| `calico.tag`                           | Calico version                                          | `v3.8.1`                        |
-| `fullnameOverride`                     | Override the fullname of the chart                      | `calico`                        |
-| `podSecurityPolicy.create`             | Specifies whether podSecurityPolicy and related rbac objects should be created    | `false`                          |
-| `serviceAccount.name`                  | The name of the ServiceAccount to use                   | `nil`                           |
-| `serviceAccount.create`                | Specifies whether a ServiceAccount should be created    | `true`                          |
-| `autoscaler.image`                     | Cluster Proportional Autoscaler Image                   | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
-| `autoscaler.tag`                       | Cluster Proportional Autoscaler version                 | `1.1.2`                                            |
+| Parameter                                | Description                                             | Default                         |
+|------------------------------------------|---------------------------------------------------------|---------------------------------|
+| `calico.typha.image`                     | Calico Typha Image                                      | `quay.io/calico/typha`          |
+| `calico.typha.resources`                 | Calico Typha Resources                                  | `requests.memory: 64Mi, requests.cpu: 50m, limits.memory: 96Mi, limits.cpu: 100m` |
+| `calico.typha.logseverity`               | Calico Typha Log Severity                               | `Info`                          |
+| `calico.typha.nodeSelector`              | Calico Typha Node Selector                              | `{ beta.kubernetes.io/os: linux }` |
+| `calico.typha.podAnnotations`            | Calico Typha Node Pod Annotations                       | `{}`                            |
+| `calico.typha.podLabels`                 | Calico Typha Node Pod Labels                            | `{}`                            |
+| `calico.node.extraEnv`                   | Calico Node extra ENV vars                              | `[]`                            |
+| `calico.node.image`                      | Calico Node Image                                       | `quay.io/calico/node`           |
+| `calico.node.resources`                  | Calico Node Resources                                   | `requests.memory: 32Mi, requests.cpu: 20m, limits.memory: 64Mi, limits.cpu: 100m` |
+| `calico.node.logseverity`                | Calico Node Log Severity                                | `Info`                          |
+| `calico.node.nodeSelector`               | Calico Node Node Selector                               | `{ beta.kubernetes.io/os: linux }` |
+| `calico.node.podAnnotations`             | Calico Node Pod Annotations                             | `{}`                            |
+| `calico.node.podLabels`                  | Calico Node Pod Labels                                  | `{}`                            |
+| `calico.typha_autoscaler.resources`      | Calico Typha Autoscaler Resources                       | `requests.memory: 16Mi, requests.cpu: 10m, limits.memory: 32Mi, limits.cpu: 10m` |
+| `calico.typha_autoscaler.nodeSelector`   | Calico Typha Autoscaler Node Selector                   | `{ beta.kubernetes.io/os: linux }` |
+| `calico.typha_autoscaler.podAnnotations` | Calico Typha Autoscaler Pod Annotations                 | `{}`                            |
+| `calico.typha_autoscaler.podLabels`      | Calico Typha Autoscaler Pod Labels                      | `{}`                            |
+| `calico.tag`                             | Calico version                                          | `v3.8.1`                        |
+| `fullnameOverride`                       | Override the fullname of the chart                      | `calico`                        |
+| `podSecurityPolicy.create`               | Specifies whether podSecurityPolicy and related rbac objects should be created    | `false`                          |
+| `serviceAccount.name`                    | The name of the ServiceAccount to use                   | `nil`                           |
+| `serviceAccount.create`                  | Specifies whether a ServiceAccount should be created    | `true`                          |
+| `autoscaler.image`                       | Cluster Proportional Autoscaler Image                   | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
+| `autoscaler.tag`                         | Cluster Proportional Autoscaler version                 | `1.1.2`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -9,6 +9,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-node"
+      {{- if .Values.calico.node.podLabels }}
+{{ toYaml .Values.calico.node.podLabels | indent 6 }}
+      {{- end }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -17,6 +20,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-node"
+        {{- if .Values.calico.node.podLabels }}
+{{ toYaml .Values.calico.node.podLabels | indent 8 }}
+        {{- end }}
       {{- with .Values.calico.node.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/stable/aws-calico/templates/deployment.yaml
+++ b/stable/aws-calico/templates/deployment.yaml
@@ -10,10 +10,16 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-typha"
+      {{- if .Values.calico.typha.podLabels }}
+{{ toYaml .Values.calico.typha.podLabels | indent 6 }}
+      {{- end }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-typha"
+        {{- if .Values.calico.typha.podLabels }}
+{{ toYaml .Values.calico.typha.podLabels | indent 8 }}
+        {{- end }}
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
         {{- with .Values.calico.typha.podAnnotations }}
@@ -100,11 +106,17 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-typha-autoscaler"
+      {{- if .Values.calico.typha_autoscaler.podLabels }}
+{{ toYaml .Values.calico.typha_autoscaler.podLabels | indent 6 }}
+      {{- end }}
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ include "aws-calico.fullname" . }}-typha-autoscaler"
+        {{- if .Values.calico.typha_autoscaler.podLabels }}
+{{ toYaml .Values.calico.typha_autoscaler.podLabels | indent 8 }}
+        {{- end }}
         {{- with .Values.calico.typha_autoscaler.podAnnotations }}
         annotations: {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -23,6 +23,7 @@ calico:
     nodeSelector:
       beta.kubernetes.io/os: linux
     podAnnotations: {}
+    podLabels: {}
   node:
     logseverity: Info #Debug, Info, Warning, Error, Fatal
     image: quay.io/calico/node
@@ -39,6 +40,7 @@ calico:
     nodeSelector:
       beta.kubernetes.io/os: linux
     podAnnotations: {}
+    podLabels: {}
   typha_autoscaler:
     resources:
       requests:
@@ -51,6 +53,7 @@ calico:
     nodeSelector:
       beta.kubernetes.io/os: linux
     podAnnotations: {}
+    podLabels: {}
 
 autoscaler:
   tag: "1.7.1"


### PR DESCRIPTION
### Issue
#459 

### Description of changes
- Add podLabels parameters to aws-vpc-cni chart (calico node, typha and typha_autoscaler)
- Update README.md with `podLabels` and missing `podAnnotations` parameters  

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

#### 1 - Helm Install debug mode without `podLabels` parameter

Command: 
`helm install --dry-run --debug aws-calico ./aws-calico`

Output:
```yaml
...
---
# Source: aws-calico/templates/daemon-set.yaml
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: "calico-node"
  labels:
    app.kubernetes.io/name: "calico-node"
    helm.sh/chart: aws-calico-0.3.5
    app.kubernetes.io/instance: aws-calico
    app.kubernetes.io/version: "3.15.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-node"
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: "calico-node"
    spec:
      priorityClassName: system-node-critical
...
---
# Source: aws-calico/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "calico-typha"
  labels:
    app.kubernetes.io/name: "calico-typha"
    helm.sh/chart: aws-calico-0.3.5
    app.kubernetes.io/instance: aws-calico
    app.kubernetes.io/version: "3.15.1"
    app.kubernetes.io/managed-by: Helm
spec:
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-typha"
  template:
    metadata:
      labels:
        app.kubernetes.io/name: "calico-typha"
      annotations:
        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
    spec:
      priorityClassName: system-cluster-critical
...
---
# Source: aws-calico/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "calico-typha-horizontal-autoscaler"
  labels:
    app.kubernetes.io/name: "calico-typha-autoscaler"
    helm.sh/chart: aws-calico-0.3.5
    app.kubernetes.io/instance: aws-calico
    app.kubernetes.io/version: "3.15.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-typha-autoscaler"
  replicas: 1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: "calico-typha-autoscaler"
    spec:
      priorityClassName: system-cluster-critical
```
> No additional labels to pod (selector and template metadata)

#### 2 - Helm Install debug mode with `podLabels`  parameters

Command: 
```bash
helm install --dry-run --debug aws-calico ./aws-calico \
    --set-string calico.node.podLabels.mylabel=system-log \
    --set-string calico.typha.podLabels.mylabel=system-log-2 \
    --set-string calico.typha_autoscaler.podLabels.mylabel=system-log-3
```

Output:
```yaml
...
---
# Source: aws-calico/templates/daemon-set.yaml
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: "calico-node"
  labels:
    app.kubernetes.io/name: "calico-node"
    helm.sh/chart: aws-calico-0.3.5
    app.kubernetes.io/instance: aws-calico
    app.kubernetes.io/version: "3.15.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-node"
      mylabel: system-log                                           #expected label
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: "calico-node"
        mylabel: system-log                                          #expected label
    spec:
      priorityClassName: system-node-critical
...
---
# Source: aws-calico/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "calico-typha"
  labels:
    app.kubernetes.io/name: "calico-typha"
    helm.sh/chart: aws-calico-0.3.5
    app.kubernetes.io/instance: aws-calico
    app.kubernetes.io/version: "3.15.1"
    app.kubernetes.io/managed-by: Helm
spec:
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-typha"
      mylabel: system-log-2                                             #expected label
  template:
    metadata:
      labels:
        app.kubernetes.io/name: "calico-typha"
        mylabel: system-log-2                                           #expected label
      annotations:
        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
    spec:
      priorityClassName: system-cluster-critical
...
---
# Source: aws-calico/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "calico-typha-horizontal-autoscaler"
  labels:
    app.kubernetes.io/name: "calico-typha-autoscaler"
    helm.sh/chart: aws-calico-0.3.5
    app.kubernetes.io/instance: aws-calico
    app.kubernetes.io/version: "3.15.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-typha-autoscaler"
      mylabel: system-log-3                                               #expected label
  replicas: 1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: "calico-typha-autoscaler"
        mylabel: system-log-3                                             #expected label
    spec:
      priorityClassName: system-cluster-critical
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
