### PR TITLE
[aws-node-termination-handler] Add support to override pod monitor namespace

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.13.3
+version: 0.14.0
 appVersion: 1.12.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -78,7 +78,7 @@ Parameter | Description | Default
 `podMonitor.interval` | Prometheus scrape interval | `30s`
 `podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
 `podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
-`podMonitor.namespace` | override podMonitor Helm release namespace | `{{.Release.namespace}}`
+`podMonitor.namespace` | override podMonitor Helm release namespace | `{{.Release.Namespace}}`
 
 ### AWS Node Termination Handler - Queue-Processor Mode Configuration
 

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -78,6 +78,7 @@ Parameter | Description | Default
 `podMonitor.interval` | Prometheus scrape interval | `30s`
 `podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
 `podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
+`podMonitor.namespace` | override podMonitor Helm release namespace | `{{.Release.namespace}}`
 
 ### AWS Node Termination Handler - Queue-Processor Mode Configuration
 

--- a/stable/aws-node-termination-handler/templates/podmonitor.yaml
+++ b/stable/aws-node-termination-handler/templates/podmonitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "aws-node-termination-handler.fullname" . }}
+  {{- if .Values.podMonitor.namespace }}
+  namespace: {{ .Values.podMonitor.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "aws-node-termination-handler.labels" . | indent 4 }}
 {{- with .Values.podMonitor.labels }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -175,6 +175,9 @@ podMonitor:
   sampleLimit: 5000
    # Additional labels to add to the metadata
   labels: {}
+  # Specifies whether a pod monitor should be created in a different namespace than
+  # the Helm release
+  # namespace: monitoring
 
 # K8s DaemonSet update strategy.
 updateStrategy:

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -168,7 +168,7 @@ dnsPolicy: ""
 
 podMonitor:
   # Specifies whether PodMonitor should be created
-  create: true
+  create: false
    # The Prometheus scrape interval
   interval: 30s
   # The number of scraped samples that will be accepted
@@ -177,7 +177,7 @@ podMonitor:
   labels: {}
   # Specifies whether a pod monitor should be created in a different namespace than
   # the Helm release
-  namespace: monitoring
+  # namespace: monitoring
 
 # K8s DaemonSet update strategy.
 updateStrategy:

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -168,7 +168,7 @@ dnsPolicy: ""
 
 podMonitor:
   # Specifies whether PodMonitor should be created
-  create: false
+  create: true
    # The Prometheus scrape interval
   interval: 30s
   # The number of scraped samples that will be accepted
@@ -177,7 +177,7 @@ podMonitor:
   labels: {}
   # Specifies whether a pod monitor should be created in a different namespace than
   # the Helm release
-  # namespace: monitoring
+  namespace: monitoring
 
 # K8s DaemonSet update strategy.
 updateStrategy:


### PR DESCRIPTION
### Description of changes

The pod monitor is only created in the Helm release namespace. The Prometheus operator by default watches pod monitors resources only in its own namespace. To watch resources in another namespace, it can be configured to use label selectors. However, in some cases, we do not want to add labels to an already existing namespace like `kube-system`.

This PR allows overriding the release namespace for the pod monitor. Some other Helm charts already support this feature like the [pushgateway](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-pushgateway/templates/servicemonitor.yaml#L6).

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Forked the Helm chart and deployed it. Working as intended.
`helm template` output is working as well: previous release namespace and overridden namespace when the added `namespace` is uncommented.