### PR TITLE
[FIX-cloudwatch-metrics] - Use helper for serviceAccountName when using custom SA name

### DIFF
--- a/stable/aws-cloudwatch-metrics/templates/clusterrolebinding.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/clusterrolebinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   name: {{ include "aws-cloudwatch-metrics.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "aws-cloudwatch-metrics.fullname" . }}
+  name: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
When making ClusterRoleBinding call helper for serviceAccountName instead of using aws-cloudwatch-metrics.fullname. In case of defining custom serviceAccount name in values file, ClusterRoleBinding is unable to use correct serviceAccount name to match to the clusterRole. 

Example: 
ServiceAccountName = custom-name
CLusterRoleBinding: ... 
subjects:
  - kind: ServiceAccount
    name: cloudwatch-metrics-aws-cloudwatch-metrics
    namespace: amazon-cloudwatch
...

Solution: Use same helper "aws-cloudwatch-metrics.serviceAccountName" both in creating ServiceAccount and calling it in ClusterRoleBinding

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
