### PR TITLE
[aws-vpc-cni] added eniconfig template

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.2
+version: 1.1.3
 appVersion: "v1.7.5"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -31,6 +31,11 @@ The following table lists the configurable parameters for this chart and their d
 | `affinity`              | Map of node/pod affinities                              | `{}`                                |
 | `cniConfig.enabled`     | Enable overriding the default 10-aws.conflist file      | `false`                             |
 | `cniConfig.fileContents`| The contents of the custom cni config file              | `nil`                               |
+| `eniConfig.create`      | Specifies whether to create ENIConfig resource(s)       | `false`                             |
+| `eniConfig.region`      | Region to use when generating ENIConfig resource names  | `us-west-2`                         |
+| `eniConfig.subnets`     | A map of AZ identifiers to config                       | `{}`                                |
+| `eniConfig.subnets.id`  | The ID of the subnet within the AZ which will be used in the ENIConfig | `nil`                |
+| `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -33,7 +33,7 @@ The following table lists the configurable parameters for this chart and their d
 | `cniConfig.fileContents`| The contents of the custom cni config file              | `nil`                               |
 | `eniConfig.create`      | Specifies whether to create ENIConfig resource(s)       | `false`                             |
 | `eniConfig.region`      | Region to use when generating ENIConfig resource names  | `us-west-2`                         |
-| `eniConfig.subnets`     | A map of AZ identifiers to config per AZ                | `{}`                                |
+| `eniConfig.subnets`     | A map of AZ identifiers to config per AZ                | `nil`                               |
 | `eniConfig.subnets.id`  | The ID of the subnet within the AZ which will be used in the ENIConfig | `nil`                |
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -33,7 +33,7 @@ The following table lists the configurable parameters for this chart and their d
 | `cniConfig.fileContents`| The contents of the custom cni config file              | `nil`                               |
 | `eniConfig.create`      | Specifies whether to create ENIConfig resource(s)       | `false`                             |
 | `eniConfig.region`      | Region to use when generating ENIConfig resource names  | `us-west-2`                         |
-| `eniConfig.subnets`     | A map of AZ identifiers to config                       | `{}`                                |
+| `eniConfig.subnets`     | A map of AZ identifiers to config per AZ                | `{}`                                |
 | `eniConfig.subnets.id`  | The ID of the subnet within the AZ which will be used in the ENIConfig | `nil`                |
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |

--- a/stable/aws-vpc-cni/templates/eniconfig.yaml
+++ b/stable/aws-vpc-cni/templates/eniconfig.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   {{- if $value.securityGroups }}
   securityGroups:
-    {{- toYaml $value.securityGroups | nindent 4 }}
+    {{- range $sg := $value.securityGroups }}
+    - {{ $sg }}
+    {{- end }}
   {{- end }}
   subnet: {{ $value.id }}
 ---

--- a/stable/aws-vpc-cni/templates/eniconfig.yaml
+++ b/stable/aws-vpc-cni/templates/eniconfig.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.eniConfig.create }}
+{{- range $key, $value := (required ".Values.eniConfig.subnets must be specified" .Values.eniConfig.subnets) }}
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+  name: {{ required ".Values.eniConfig.region must be specified" $.Values.eniConfig.region }}{{ $key }}
+spec:
+  {{- if $value.securityGroups }}
+  securityGroups:
+    {{- toYaml $value.securityGroups | nindent 4 }}
+  {{- end }}
+  subnet: {{ $value.id }}
+---
+{{- end }}
+{{- end }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -144,7 +144,7 @@ eniConfig:
   # Specifies whether ENIConfigs should be created
   create: false
   region: us-west-2
-  subnets:
+  subnets: {}
     # Key identifies the AZ
     # Value contains the subnet ID and security group IDs within that AZ
     # a:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -144,7 +144,7 @@ eniConfig:
   # Specifies whether ENIConfigs should be created
   create: false
   region: us-west-2
-  subnets: {}
+  subnets:
     # Key identifies the AZ
     # Value contains the subnet ID and security group IDs within that AZ
     # a:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -139,3 +139,23 @@ affinity:
               operator: NotIn
               values:
                 - fargate
+
+eniConfig:
+  # Specifies whether ENIConfigs should be created
+  create: false
+  region: us-west-2
+  subnets:
+    # Key identifies the AZ
+    # Value contains the subnet ID and security group IDs within that AZ
+    # a:
+    #   id: subnet-123
+    #   securityGroups:
+    #   - sg-123
+    # b:
+    #   id: subnet-456
+    #   securityGroups:
+    #   - sg-456
+    # c:
+    #   id: subnet-789
+    #   securityGroups:
+    #   - sg-789


### PR DESCRIPTION
### Issue

This would partially address #453 

### Description of changes

Added template for defining ENIConfig resources based upon user-defined values.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

> In the following code blocks I omit all the resources that existed in the helm chart before this PR (i.e. DaemonSet, ConfigMap, etc)

* executed `helm template myrelease .` and validated that no ENIConfig resources were included in the output

    ```yaml
    ```

* executed `helm template myrelease . --set eniConfig.create=true` and confirmed that an error was returned stating `.Values.eniConfig.subnets must be specified`

    ```
    Error: execution error at (aws-vpc-cni/templates/eniconfig.yaml:2:27): .Values.eniConfig.subnets must be specified
    ```

* executed `helm template myrelease . --set eniConfig.create=true --set eniConfig.subnets.a.id=subnet-123` and confirmed that a single ENIConfig resource was generated with `subnet-123` and no security groups

    ```yaml
    apiVersion: crd.k8s.amazonaws.com/v1alpha1
    kind: ENIConfig
    metadata:
      name: us-west-2a
    spec:
      subnet: subnet-123
    ```

* executed `helm template myrelease . --set eniConfig.create=true --set eniConfig.subnets.a.id=subnet-123 --set eniConfig.subnets.a.securityGroups={"sg-123"}` and confirmed that a single ENIConfig resource was generated with `subnet-123` and `sg-123`

    ```yaml
    # Source: aws-vpc-cni/templates/eniconfig.yaml
    apiVersion: crd.k8s.amazonaws.com/v1alpha1
    kind: ENIConfig
    metadata:
      name: us-west-2a
    spec:
      securityGroups:
        - sg-123
      subnet: subnet-123
    ```

* executed `helm template myrelease . --set eniConfig.create=true --set eniConfig.subnets.a.id=subnet-123 --set eniConfig.subnets.a.securityGroups={"sg-123"} --set eniConfig.subnets.b.id=subnet-456 --set eniConfig.subnets.b.securityGroups={"sg-456"}` and confirmed that 2 ENIConfig resources were generated each with their correct subnet and security groups

    ```yaml
    apiVersion: crd.k8s.amazonaws.com/v1alpha1
    kind: ENIConfig
    metadata:
      name: us-west-2a
    spec:
      securityGroups:
        - sg-123
      subnet: subnet-123
    ---
    apiVersion: crd.k8s.amazonaws.com/v1alpha1
    kind: ENIConfig
    metadata:
      name: us-west-2b
    spec:
      securityGroups:
        - sg-456
      subnet: subnet-456
    ```

* executed `helm template myrelease . --set eniConfig.create=true --set eniConfig.subnets.a.id=subnet-123 --set eniConfig.subnets.a.securityGroups={"sg-123"} --set eniConfig.subnets.b.id=subnet-456 --set "eniConfig.subnets.b.securityGroups={sg-456,sg-789}"` and confirmed that 2 ENIConfig resources were generated and that 2 security groups were attached to the ENIConfig for AZ `b`

    ```yaml
    apiVersion: crd.k8s.amazonaws.com/v1alpha1
    kind: ENIConfig
    metadata:
      name: us-west-2a
    spec:
      securityGroups:
        - sg-123
      subnet: subnet-123
    ---
    apiVersion: crd.k8s.amazonaws.com/v1alpha1
    kind: ENIConfig
    metadata:
      name: us-west-2b
    spec:
      securityGroups:
        - sg-456
        - sg-789
      subnet: subnet-456
    ```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
