### PR TITLE
[aws-cloudwatch-metrics] add nodeSelector

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.4
+version: 0.0.5
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -28,4 +28,5 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
 | `serviceAccount.create` | Whether a new service account should be created | `true` | 
 | `serviceAccount.name` | Service account to be used | | 
-| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 
+| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` |
+| `nodeSelector` | limit daemonset deployment to matching nodes | `{}` |

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -76,3 +76,7 @@ spec:
         hostPath:
           path: /dev/disk/
       terminationGracePeriodSeconds: 60
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -18,3 +18,5 @@ serviceAccount:
   name:
 
 hostNetwork: false
+
+nodeSelector: {}


### PR DESCRIPTION
### Issue

in mixed-node environments, pods will not deploy on windows nodes, yet the helmchart has no way to set nodeselector values to limit deployment to linux nodes.

### Description of changes

This adds a simple nodeselector value that mirrors other helm chart defaults.

### Checklist
- [✔] Added/modified documentation as required (such as the `README.md` for modified charts)
- [✔] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [✔] Manually tested. Describe what testing was done in the testing section below
- [✔] Make sure the title of the PR is a good description that can go into the release notes

### Testing

This was deployed to an eks cluster in my own account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
