### PR TITLE
[aws-sigv4-proxy-admission-controller] add admissionReviewVersions to webhook

### DIFF
--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-sigv4-proxy-admission-controller
 description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -25,6 +25,8 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     sideEffects: None
+    admissionReviewVersions:
+    - v1beta1
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Fix aws-sigv4-proxy-admission-controller webhook, changes introduced in #456

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Verified chart can be installed/uninstalled on k8s 1.19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
