### PR TITLE
Deploy serviceMonitor for aws-load-balancer-controller

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.1.6
+version: 1.1.7
 appVersion: v2.1.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -21,6 +21,7 @@ AWS Load Balancer controller manages the following AWS resources
 - Kubernetes >= 1.15 for NLB IP using Service type NodePort
 - Kubernetes >= 1.20 or EKS >= 1.16 for NLB IP using Service type LoadBalancer
 - IAM permissions
+- [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) >= 0.46.0 if serviceMonitor is to be deployed
 
 The controller runs on the worker nodes, so it needs access to the AWS ALB/NLB resources via IAM permissions. The
 IAM permissions can either be setup via IAM roles for ServiceAccount or can be attached directly to the worker node IAM roles.
@@ -167,3 +168,7 @@ The default values set by the application itself can be confirmed [here](https:/
 | `extraVolumes`                              | Extra volumes for the pod                                                                                | `[]`                                                                               |
 | `defaultTags`                               | Default tags to apply to all AWS resources managed by this controller                                    | `{}`                                                                               |
 | `podDisruptionBudget`                       | PodDisruptionBudget                                                                                      | `{}`                                                                               |
+| `serviceMonitor.enabled`                    | If true, create a serviceMonitor resource                                                                | `false`                                                                            |
+| `serviceMonitor.interval`                   | Interval at which prometheus should scrape metrics                                                       | `10s`                                                                              |
+| `serviceMonitor.selector`                   | Labels to be applied on the serviceMonitor resource for prometheus-operator to discover it               | `{}                                                                                |
+| `serviceMonitor.path`                       | The path on the metrics port to scrape metrics                                                           | `/metrics                                                                          |

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -1,13 +1,31 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+    app.kubernetes.io/component: webhook-service
+    {{ include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:
   ports:
   - port: 443
     targetPort: webhook-server
+  selector:
+    {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: metrics-service
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: metrics-server
   selector:
     {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}

--- a/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
+++ b/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "aws-load-balancer-controller.fullname" . }}
+  labels:
+    {{- range $key, $value := .Values.serviceMonitor.selector }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics-service
+{{ include "aws-load-balancer-controller.labels" . | indent 6 }}
+  endpoints:
+  - port: http
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: {{ .Values.serviceMonitor.path }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{ end }}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -169,3 +169,11 @@ defaultTags: {}
 
 podDisruptionBudget: {}
 #  maxUnavailable: 1
+
+# serviceMonitor specifies the attributes of the serviceMonitor custom resource coming of the prometheus-operator
+serviceMonitor:
+  enabled: false
+  interval: "10s"
+  selector: {}
+    # prometheus: kube-prometheus
+  path: /metrics


### PR DESCRIPTION
### Issue

Fixes #498 

### Description of changes

- Add a serviceMonitor resource and necessary service
- Standardize the use of nindent over indent in service labels
- Corresponding README updates

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually deployed the load balancer controller with the service and serviceMonitor and ensured that the target shows up in prometheus. Screenshot attached
![aws-load-balancerr-controller-target](https://user-images.githubusercontent.com/2051423/113923876-5ab64180-97e9-11eb-9b98-4ed62d15706b.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
