### PR TITLE
Bump aws-load-balancer-controller Helm Chart apiVersion to v2

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
 version: 1.1.6

--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.1.6
+version: 1.1.7
 appVersion: v2.1.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
### Issue

Helm v3 uses `apiVersion` to indicate how it should render the chart. The contents of the chart are in the `v2` format , but they are notated as `v1` which inhibits Helm from deploying the CRDs.

Fixes #495 

### Description of changes

Bump chart `apiVersion` to `v2`

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually deployed into a local cluster with the applied changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
