### PR TITLE
Expose metrics for alb-controller through serviceMonitor

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.2.0
+version: 2.0.0
 appVersion: v2.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -26,6 +26,7 @@ AWS Load Balancer controller manages the following AWS resources
    - 1.18.18+ for 1.18
    - 1.19.10+ for 1.19
 - IAM permissions
+- [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) >= 0.46.0 if serviceMonitor is to be deployed
 
 The controller runs on the worker nodes, so it needs access to the AWS ALB/NLB resources via IAM permissions. The
 IAM permissions can either be setup via IAM roles for ServiceAccount or can be attached directly to the worker node IAM roles.
@@ -175,7 +176,6 @@ The default values set by the application itself can be confirmed [here](https:/
 | `enableWafv2`                               | Enable WAF V2 addon for ALB                                                                              | None                                                                               |
 | `ingressMaxConcurrentReconciles`            | Maximum number of concurrently running reconcile loops for ingress                                       | None                                                                               |
 | `logLevel`                                  | Set the controller log level - info, debug                                                               | None                                                                               |
-| `metricsBindAddr`                           | The address the metric endpoint binds to                                                                 | ""                                                                                 |
 | `webhookBindPort`                           | The TCP port the Webhook server binds to                                                                 | None                                                                               |
 | `serviceMaxConcurrentReconciles`            | Maximum number of concurrently running reconcile loops for service                                       | None                                                                               |
 | `targetgroupbindingMaxConcurrentReconciles` | Maximum number of concurrently running reconcile loops for targetGroupBinding                            | None                                                                               |
@@ -189,3 +189,9 @@ The default values set by the application itself can be confirmed [here](https:/
 | `defaultTags`                               | Default tags to apply to all AWS resources managed by this controller                                    | `{}`                                                                               |
 | `replicaCount`                              | Number of controller pods to run, only one will be active due to leader election                         | `2`                                                                                |
 | `podDisruptionBudget`                       | Limit the disruption for controller pods. Require at least 2 controller replicas and 3 worker nodes      | `{}`                                                                               |
+| `metrics.enabled`                           | Whether the load balancer controller should expose metrics                                               | `false`                                                                            |
+| `metrics.port`                              | The port the metric endpoint binds to                                                                    | `8080`                                                                             |
+| `metrics.serviceMonitor.enabled`            | If true, create a serviceMonitor resource                                                                | `false`                                                                            |
+| `metrics.serviceMonitor.interval`           | Interval at which prometheus should scrape metrics                                                       | `10s`                                                                              |
+| `metrics.serviceMonitor.selector`           | Labels to be applied on the serviceMonitor resource for prometheus-operator to discover it               | `{}                                                                                |
+| `metrics.serviceMonitor.path`               | The path on the metrics port to scrape metrics                                                           | `/metrics                                                                          |

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
+        {{- if and .Values.metrics.enabled (not .Values.metrics.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ (split ":" .Values.metricsBindAddr)._1 | default 8080 }}"
+        prometheus.io/port: "{{ .Values.metrics.port }}"
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
@@ -70,8 +72,8 @@ spec:
         {{- if kindIs "bool" .Values.enableWafv2 }}
         - --enable-wafv2={{ .Values.enableWafv2 }}
         {{- end }}
-        {{- if .Values.metricsBindAddr }}
-        - --metrics-bind-addr={{ .Values.metricsBindAddr }}
+        {{- if .Values.metrics.enabled }}
+        - --metrics-bind-addr={{ .Values.metrics.port }}
         {{- end }}
         {{- if .Values.ingressMaxConcurrentReconciles }}
         - --ingress-max-concurrent-reconciles={{ .Values.ingressMaxConcurrentReconciles }}
@@ -121,9 +123,11 @@ spec:
         - name: webhook-server
           containerPort: {{ .Values.webhookBindPort | default 9443 }}
           protocol: TCP
+        {{- if .Values.metrics.enabled }}
         - name: metrics-server
-          containerPort: {{ (split ":" .Values.metricsBindAddr)._1 | default 8080 }}
+          containerPort: {{ .Values.metrics.port }}
           protocol: TCP
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- with .Values.livenessProbe }}

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -1,13 +1,33 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+    app.kubernetes.io/component: webhook-service
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:
   ports:
   - port: 443
     targetPort: webhook-server
   selector:
     {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}
+---
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: metrics-service
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: metrics-server
+  selector:
+    {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
+++ b/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{ if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "aws-load-balancer-controller.fullname" . }}
+  labels:
+    {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics-service
+{{ include "aws-load-balancer-controller.labels" . | indent 6 }}
+  endpoints:
+  - port: http
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    path: {{ .Values.metrics.serviceMonitor.path }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{ end }}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -105,9 +105,6 @@ ingressMaxConcurrentReconciles:
 # Set the controller log level - info(default), debug (default "info")
 logLevel:
 
-# The address the metric endpoint binds to. (default ":8080")
-metricsBindAddr: ""
-
 # The TCP port the Webhook server binds to. (default 9443)
 webhookBindPort:
 
@@ -173,3 +170,14 @@ defaultTags: {}
 # Disruption budget will be configured only when the replicaCount is greater than 1
 podDisruptionBudget: {}
 #  maxUnavailable: 1
+
+# metrics specifies the configurable options for exposing metrics to prometheus
+metrics:
+  enabled: false
+  port: 8080
+  serviceMonitor:
+    enabled: false
+    interval: "10s"
+    selector: {}
+      # prometheus: kube-prometheus
+    path: /metrics


### PR DESCRIPTION
### Issue

Fixes #498

### Description of changes

- Make the exposing of the metrics conditional
- If enabled, bind and expose the port and deploy a service
- Deploy serviceMonitor if needed, else add legacy prometheus pod annotations
- Standardize the use of nindent over indent in service labels
- Corresponding README updates
- [DEPRECATION] Move the metrics port from `metricsBindAddr` to `metrics.port`

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually deployed the load balancer controller with the service and serviceMonitor and ensured that the target shows up in prometheus. Screenshot attached
![Screenshot 2021-04-15 at 21 05 46](https://user-images.githubusercontent.com/2051423/114924930-c4100300-9e2e-11eb-8d43-a581197accdc.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
