### PR TITLE
[aws-cloudwatch-metrics] Add statsd options support

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.4
+version: 0.0.5
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/templates/_helpers.tpl
+++ b/stable/aws-cloudwatch-metrics/templates/_helpers.tpl
@@ -56,3 +56,15 @@ Create the name of the service account to use
 {{- define "aws-cloudwatch-metrics.serviceAccountName" -}}
   {{ default (include "aws-cloudwatch-metrics.fullname" .) .Values.serviceAccount.name }}
 {{- end -}}
+
+{{/*
+Create a config section for StatsD ports.
+*/}}
+{{- define "aws-cloudwatch-metrics.statsdConfig" -}}
+{{- if .Values.statsd.enabled }}
+ports:
+  - containerPort: {{- .Values.statsd.containerPort -}}
+    hostPort: {{- .Values.statsd.hostPort -}}
+    protocol: {{- .Values.statsd.protocol -}}
+{{- end }}
+{{- end -}}

--- a/stable/aws-cloudwatch-metrics/templates/_helpers.tpl
+++ b/stable/aws-cloudwatch-metrics/templates/_helpers.tpl
@@ -63,8 +63,8 @@ Create a config section for StatsD ports.
 {{- define "aws-cloudwatch-metrics.statsdConfig" -}}
 {{- if .Values.statsd.enabled }}
 ports:
-  - containerPort: {{- .Values.statsd.containerPort -}}
-    hostPort: {{- .Values.statsd.hostPort -}}
+  - containerPort: {{- .Values.statsd.port -}}
+    hostPort: {{- .Values.statsd.port -}}
     protocol: {{- .Values.statsd.protocol -}}
 {{- end }}
 {{- end -}}

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -15,5 +15,16 @@ data:
           }
         },
         "force_flush_interval": 5
+{{- if .Values.statsd.enabled }}
+      },
+      "metrics": {
+        "metrics_collected": {
+            "statsd": {
+                "service_address": ":{{- .Values.statsd.port -}}"
+            }
+        }
       }
+{{- else }}
+      }
+{{- end }}
     }

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- include "aws-cloudwatch-metrics.statsdConfig" . | nindent 8 }}
         # Please don't change below envs
         env:
         - name: HOST_IP

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -21,6 +21,5 @@ hostNetwork: false
 
 statsd:
   enabled: false
-  containerPort: 8125
-  hostPort: 8125
+  port: 8125
   protocol: UDP

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -18,3 +18,9 @@ serviceAccount:
   name:
 
 hostNetwork: false
+
+statsd:
+  enabled: false
+  containerPort: 8125
+  hostPort: 8125
+  protocol: UDP


### PR DESCRIPTION
### Issue

The PR adds values.yaml options to configure StatsD metrics, which are currently missing (See #413)

### Description of changes

1. Added new values.yaml config:
```
statsd:
  enabled: false
  port: 8125
  protocol: UDP
```
2. Added config map entry for metrics if statsd is enabled
3. Added `ports` section to the daemonset set if statsd is enabled
### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Ran helm lint. Pending test in the cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
