### PR TITLE
Use objectSelector for pod mutator webhook

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.1.6
+version: 1.1.7
 appVersion: v2.1.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -31,6 +31,12 @@ webhooks:
       operator: In
       values:
       - enabled
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values:
+      - aws-load-balancer-controller
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
Add objectSelector to not match the aws-load-balancer-controller pod for
the pod readiness gate injection. This will help eliminate the cyclic
dependency between the webhook and the controller pod.

### Issue

Fixes #433

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
- Added `elbv2.k8s.aws/pod-readiness-gate-inject=enabled` label to the kube-system namespace, scaled aws load balancer controller deployment to 0 replicas, and when the controller pod was no longer running, scaled the deployment back to 1 replicas. The controller pod started running right away with the modified webhook configuration.
- Verified that readiness gate config got injected as expected for pods running in a labelled namespace.
 
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
