### PR TITLE
aws-vpc-cni: Adding flags to support overriding container runtime endpoint.

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.4
+version: 1.1.5
 appVersion: "v1.7.5"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -66,6 +66,7 @@ The following table lists the configurable parameters for this chart and their d
 | `crd.create`            | Specifies whether to create the VPC-CNI CRD             | `true`                              |
 | `tolerations`           | Optional deployment tolerations                         | `[]`                                |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
+| `cri.hostPath`          | Optional use alternative container runtime              | `nil`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -98,8 +98,13 @@ spec:
 {{- end }}
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
+{{- if .Values.cri.hostPath }}
+          - mountPath: /var/run/cri.sock
+            name: cri
+{{- else }}
           - mountPath: /var/run/dockershim.sock
             name: dockershim
+{{- end }}
           - mountPath: /var/run/aws-node
             name: run-dir
           - mountPath: /run/xtables.lock
@@ -116,9 +121,15 @@ spec:
         configMap:
           name: {{ include "aws-vpc-cni.fullname" . }}
 {{- end }}
+{{- if .Values.cri.hostPath }}
+      - name: cri
+        hostPath:
+          path: {{- toYaml .Values.cri.hostPath | nindent 18 }}
+{{- else }}
       - name: dockershim
         hostPath:
           path: /var/run/dockershim.sock
+{{- end }}
       - name: log-dir
         hostPath:
           path: /var/log/aws-routed-eni

--- a/stable/aws-vpc-cni/test.yaml
+++ b/stable/aws-vpc-cni/test.yaml
@@ -1,9 +1,7 @@
-# Default values for aws-vpc-cni.
+# Test values for aws-vpc-cni.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-# This default name override is to maintain backwards compatability with
-# existing naming
+#
 nameOverride: aws-node
 
 init:
@@ -62,8 +60,6 @@ priorityClassName: system-node-critical
 podSecurityContext: {}
 
 podAnnotations: {}
-
-podLabels: {}
 
 securityContext:
   capabilities:
@@ -161,6 +157,3 @@ eniConfig:
     #   id: subnet-789
     #   securityGroups:
     #   - sg-789
-
-cri:
-  hostPath: # "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
This PR is syncing the merged changes from VPC CNI to EKS-Charts. In this PR, we want to add a flag to let user able to override dockershim.sock with alternative runtime endpoint mounted at cri.sock.

### Description of changes

<!-- Please explain the changes you made here. -->
AWS VPC CNI Helm Chart doesn't have a flag to set container runtime mounting path. We are doing in this PR

- adding a new flag to enable the overriding
- adding a new flag to input the path of new runtime socket
- updating README accordlingly 
- bump chart version to 1.1.5


### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
- helm install AWS VPC CNI with new flags enabled
```
amazon-vpc-cni-k8s % helm install aws-vpc-cni --namespace kube-system charts/aws-vpc-cni --set cri.enabled=true --set cri.hostPath=/var/run/containerd/containerd.sock
NAME: aws-vpc-cni
LAST DEPLOYED: Sat Apr 24 16:28:50 2021
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
aws-vpc-cni has been installed or updated. To check the status of pods, run:

kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"

amazon-vpc-cni-k8s % kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
NAME             READY   STATUS    RESTARTS   AGE
aws-node-gwmcr   1/1     Running   0          9s
aws-node-m9csq   1/1     Running   0          9s

```
- verified mountPath and hostPath
```
- mountPath: /var/run/cri.sock
        name: cri
- hostPath:
    path: /var/run/containerd/containerd.sock
    type: ""
  name: cri
```
- verified IPAMD logging endpoint as cri.sock and able to pull Pod Sandbox info from containerd socket
- helm uninstalled the AWS VPC CNI
- helm install without the new flags
```
amazon-vpc-cni-k8s % helm install aws-vpc-cni --namespace kube-system charts/aws-vpc-cni
NAME: aws-vpc-cni
LAST DEPLOYED: Sat Apr 24 16:20:46 2021
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
aws-vpc-cni has been installed or updated. To check the status of pods, run:

kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
amazon-vpc-cni-k8s % kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
NAME             READY   STATUS    RESTARTS   AGE
aws-node-dbqr8   1/1     Running   0          12s
aws-node-rbsrm   1/1     Running   0          12s
```
- verified dockershim.sock was mounted as expected
- verified aws-node up and running and IPAMD logs endpoint as dockershim.sock and able to pull Pod Sandbox info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
