### PR TITLE
Set the SigV4 proxy mutating webhook failurePolicy to Ignore

### DIFF
--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-sigv4-proxy-admission-controller
 description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -24,6 +24,7 @@ webhooks:
         apiGroups: ["apps", ""]
         apiVersions: ["v1"]
         resources: ["pods"]
+    failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions:
     - v1beta1


### PR DESCRIPTION
### Issue

N/A

### Description of changes

Set mutating webhook failurePolicy to Ignore:
- With [`admissionregistration.k8s.io/v` API](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#api-changes), the failurePolicy default is changed from `Ignore` to `Fail` in `v1`. We need to explicitly set it to "Ignore" so that helm chart components can come up and not be rejected by the webhook.
- Otherwise, the admission controller pod will not be scheduled due to the error in the replicaset:
```
Events:
  Type     Reason        Age                   From                   Message
  ----     ------        ----                  ----                   -------
  Warning  FailedCreate  48s (x15 over 2m10s)  replicaset-controller  Error creating: Internal error occurred: failed calling webhook "aws-sigv4-proxy-admission-controller.k8s.aws": Post "https://aws-sigv4-proxy-admission-controller-webhook-service.core.svc:443/mutate?timeout=10s": no endpoints available for service "aws-sigv4-proxy-admission-controller-webhook-service"
```

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Deploy the chart in a test cluster to ensure all helm components are deployed as expected without encountering the above error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
