### PR TITLE
[aws-load-balancer-controller] Custom affinity overrides default podAntiAffinity

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.2.0
+version: 1.2.1
 appVersion: v2.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -137,7 +137,7 @@ helm delete aws-load-balancer-controller -n kube-system
 Chart release v1.2.0 and later enables high availability configuration by default.
 - The default number of replicas is 2. You can pass`--set replicaCount=1` flag during chart installation to disable this. Due to leader election, only one controller will actively reconcile resources.
 - The default priority class for the controller pods is `system-cluster-critical`
-- Soft pod anti-affinity is enabled for controller pods with `topologyKey: kubernetes.io/hostname`
+- Soft pod anti-affinity is enabled for controller pods with `topologyKey: kubernetes.io/hostname` if custom affinity is not configured
 - Pod disruption budget (PDB) has not been set by default. If you plan on running at least 2 controller pods, you can pass `--set podDisruptionBudget.maxUnavailable=1` flag during chart installation
 
 ## Configuration

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -135,6 +135,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -147,13 +151,11 @@ spec:
                   values:
                   - {{ include "aws-load-balancer-controller.name" . }}
               topologyKey: kubernetes.io/hostname
-    {{- with .Values.affinity }}
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}


### PR DESCRIPTION
### Issue
Fixes: #524

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
If custom affinity is specified during chart installation,
override the default podAntiAffinity configuration as well.

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
If affinity configuration is not specified during chart installation, the default podAntiAffinity gets used. When custom affinity is specified, the default gets overridden with the custom one.
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
