### PR TITLE
[aws-node-termination-handler]: Use hostPort only with hostNetwork

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.15.0
+version: 0.15.1
 appVersion: 1.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -179,14 +179,18 @@ spec:
           {{- if .Values.enablePrometheusServer }}
           ports:
           - containerPort: {{ .Values.prometheusServerPort }}
+            {{- if .Values.useHostNetwork }}
             hostPort: {{ .Values.prometheusServerPort }}
+            {{- end }}
             name: http-metrics
             protocol: TCP
           {{- end }}
           {{- if .Values.enableProbesServer }}
           ports:
           - containerPort: {{ .Values.probesServerPort }}
+            {{- if .Values.useHostNetwork }}
             hostPort: {{ .Values.probesServerPort }}
+            {{- end }}
             name: liveness-probe
             protocol: TCP
           {{- end }}


### PR DESCRIPTION
### Description of changes

There is no need to use the hostPort option if we are not directly
connected to the hostNetwork. Using the hostPort option makes that port
unavailable for binding to any other service on the node which is
not really desirable if the pod itself is not on the host network.

### Checklist
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

No testing was done apart from checking with helmTemplate that no `hostPort` is
present in the rendered files when useHostNetwork is not enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
