### PR TITLE
[aws-node-termination-handler] Add support for `AWS_STS_REGIONAL_ENDPOINTS` environment variable

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.15.0
+version: 0.15.1
 appVersion: 1.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -82,6 +82,7 @@ Parameter | Description | Default
 `podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
 `podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
 `podMonitor.namespace` | override podMonitor Helm release namespace | `{{.Release.Namespace}}`
+`stsRegionalEndpoint` | Use regional STS endpoint | `false`
 
 ### AWS Node Termination Handler - Queue-Processor Mode Configuration
 

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -174,6 +174,10 @@ spec:
             value: {{ .Values.probesServerPort | quote }}
           - name: PROBES_SERVER_ENDPOINT
             value: {{ .Values.probesServerEndpoint | quote }}
+          {{- if .Values.stsRegionalEndpoint }}
+          - name: AWS_STS_REGIONAL_ENDPOINTS
+            value: regional
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.enablePrometheusServer }}

--- a/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -148,6 +148,10 @@ spec:
             value: {{ .Values.probesServerPort | quote }}
           - name: PROBES_SERVER_ENDPOINT
             value: {{ .Values.probesServerEndpoint | quote }}
+          {{- if .Values.stsRegionalEndpoint }}
+          - name: AWS_STS_REGIONAL_ENDPOINTS
+            value: regional
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.enablePrometheusServer }}

--- a/stable/aws-node-termination-handler/templates/deployment.yaml
+++ b/stable/aws-node-termination-handler/templates/deployment.yaml
@@ -150,6 +150,10 @@ spec:
             value: {{ .Values.managedAsgTag | quote }}
           - name: WORKERS
             value: {{ .Values.workers | quote }}
+          {{- if .Values.stsRegionalEndpoint }}
+          - name: AWS_STS_REGIONAL_ENDPOINTS
+            value: regional
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.enablePrometheusServer }}

--- a/stable/aws-node-termination-handler/values.yaml
+++ b/stable/aws-node-termination-handler/values.yaml
@@ -65,6 +65,9 @@ awsRegion: ""
 # awsEndpoint If specified, use the AWS endpoint to make API calls.
 awsEndpoint: ""
 
+# stsRegionalEndpoint if true will use the STS regional endpoint instead of the global one
+stsRegionalEndpoint: false
+
 # These should only be used for testing w/ localstack!
 awsSecretAccessKey:
 awsAccessKeyID:


### PR DESCRIPTION
Once the fix for
https://github.com/aws/aws-node-termination-handler/issues/420 is
released, the handler can be configured to use the regional endpoint.

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

Deployed and observed the environment variable was set. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
