### PR TITLE
[aws-cloudwatch-metrics] Added tolerations param to chart

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.5
+version: 0.0.6
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -26,6 +26,7 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `image.tag` | Image tag to deploy | `1.247345.36b249270`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
-| `serviceAccount.create` | Whether a new service account should be created | `true` | 
-| `serviceAccount.name` | Service account to be used | | 
-| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
+| `serviceAccount.name` | Service account to be used | |
+| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` |
+| `tolerations` | List of node taints to tolerate | `[]` |

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         {{- include "aws-cloudwatch-metrics.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
       containers:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -18,3 +18,5 @@ serviceAccount:
   name:
 
 hostNetwork: false
+
+tolerations: []


### PR DESCRIPTION
### Description of changes

Added `tolerations` param to `aws-cloudwatch-metrics` chart for node taints.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- packaged this helm chart and published as a git commits under [a feature branch in our fork](https://github.com/peakon/eks-charts/tree/cloudwatch-metrics-tolerations-build)
- applied this chart to our EKS cluster and can confirm that `tolerations` param is handled correctly (pod are scheduled on the nodes with taints that are tolerated via `tolerations` param value)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
