### PR TITLE
upgrade aws calico software version

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.5
-appVersion: 3.15.1
+version: 0.3.6
+appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -1,6 +1,10 @@
 # Calico on AWS
+**Note**: The recommended way to install calico on EKS is via tigera-opeartor instead of this helm-chart. 
+You can follow https://docs.aws.amazon.com/eks/latest/userguide/calico.html for detailed instructions.
+
 
 This chart installs Calico on AWS: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
+
 
 ## Prerequisites
 

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -7,7 +7,7 @@ podSecurityPolicy:
   create: false
 
 calico:
-  tag: v3.15.1
+  tag: v3.19.1
 
   typha:
     logseverity: Info #Debug, Info, Warning, Error, Fatal
@@ -56,5 +56,5 @@ calico:
     podLabels: {}
 
 autoscaler:
-  tag: "1.7.1"
-  image: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+  tag: "1.8.3"
+  image: k8s.gcr.io/cpa/cluster-proportional-autoscaler-amd64


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

1. Upgrade the default bundled calico & cluster-proportional-autoscaler version in aws-calico helm chart.
   * calico: v3.15.1-> v3.19.1
   * cluster-proportional-autoscaler: v1.7.1 -> v1.8.3
2. Add a readme note about the recommended way to install calico on AWS

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
1. Tested the walkthrough in [EKS calico documentation](https://docs.aws.amazon.com/eks/latest/userguide/calico.html), works as expected.
2. Tested scale up calico-typha using CPA works as expected: `Replicas are not as expected : updating replicas from 1 to 2`

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
