### PR TITLE
[aws-node-termination-handler] Fix Helm templates bug which caused duplicate ports key

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.15.1
+version: 0.15.2
 appVersion: 1.13.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-node-termination-handler/README.md
+++ b/stable/aws-node-termination-handler/README.md
@@ -136,7 +136,7 @@ Parameter | Description | Default
 `windowsNodeSelector` | Tells the Windows daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
 `tolerations` | list of node taints to tolerate | `[ {"operator": "Exists"} ]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
-`rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
+`rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `true`
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
 `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -180,15 +180,16 @@ spec:
             value: {{ .Values.kubernetesEventsExtraAnnotations | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.enablePrometheusServer }}
+          {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
+          {{- end }}
+          {{- if .Values.enablePrometheusServer }}
           - containerPort: {{ .Values.prometheusServerPort }}
             hostPort: {{ .Values.prometheusServerPort }}
             name: http-metrics
             protocol: TCP
           {{- end }}
           {{- if .Values.enableProbesServer }}
-          ports:
           - containerPort: {{ .Values.probesServerPort }}
             hostPort: {{ .Values.probesServerPort }}
             name: liveness-probe

--- a/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -154,15 +154,16 @@ spec:
             value: {{ .Values.kubernetesEventsExtraAnnotations | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.enablePrometheusServer }}
+          {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
+          {{- end }}
+          {{- if .Values.enablePrometheusServer }}
           - containerPort: {{ .Values.prometheusServerPort  }}
             hostPort: {{ .Values.prometheusServerPort }}
             name: http-metrics
             protocol: TCP
           {{- end }}
           {{- if .Values.enableProbesServer }}
-          ports:
           - containerPort: {{ .Values.probesServerPort }}
             hostPort: {{ .Values.probesServerPort }}
             name: liveness-probe

--- a/stable/aws-node-termination-handler/templates/deployment.yaml
+++ b/stable/aws-node-termination-handler/templates/deployment.yaml
@@ -156,15 +156,16 @@ spec:
             value: {{ .Values.kubernetesEventsExtraAnnotations | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.enablePrometheusServer }}
+          {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
+          {{- end }}
+          {{- if .Values.enablePrometheusServer }}
           - containerPort: {{ .Values.prometheusServerPort }}
             hostPort: {{ .Values.prometheusServerPort }}
             name: http-metrics
             protocol: TCP
           {{- end }}
           {{- if .Values.enableProbesServer }}
-          ports:
           - containerPort: {{ .Values.probesServerPort }}
             hostPort: {{ .Values.probesServerPort }}
             name: liveness-probe


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/issues/550

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes
- 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
