### PR TITLE
appmesh-controller: modify crd v1beta1  to apiextensions.k8s.io/v1 before deprecation

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.0
-appVersion: 1.4.0
+version: 1.4.1
+appVersion: 1.4.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-controller/crds/crds.yaml
+++ b/stable/appmesh-controller/crds/crds.yaml
@@ -6,14 +6,6 @@ metadata:
   creationTimestamp: null
   name: gatewayroutes.appmesh.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.gatewayRouteARN
-    description: The AppMesh GatewayRoute object's Amazon Resource Name
-    name: ARN
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: appmesh.k8s.aws
   names:
     categories:
@@ -23,621 +15,637 @@ spec:
     plural: gatewayroutes
     singular: gatewayroute
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: GatewayRoute is the Schema for the gatewayroutes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GatewayRouteSpec defines the desired state of GatewayRoute refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
-          properties:
-            awsName:
-              description: AWSName is the AppMesh GatewayRoute object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s GatewayRoute
-              type: string
-            grpcRoute:
-              description: An object that represents the specification of a gRPC gatewayRoute.
-              properties:
-                action:
-                  description: An object that represents the action to take if a match is determined.
-                  properties:
-                    rewrite:
-                      properties:
-                        hostname:
-                          description: ENABLE or DISABLE default behavior for Hostname rewrite
-                          properties:
-                            defaultTargetHostname:
-                              enum:
-                              - ENABLED
-                              - DISABLED
-                              type: string
-                          type: object
-                      type: object
-                    target:
-                      description: An object that represents the target that traffic is routed to when a request matches the route.
-                      properties:
-                        virtualService:
-                          description: The virtual service to associate with the gateway route target.
-                          properties:
-                            virtualServiceARN:
-                              description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                              type: string
-                            virtualServiceRef:
-                              description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                              properties:
-                                name:
-                                  description: Name is the name of VirtualService CR
-                                  type: string
-                                namespace:
-                                  description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          type: object
-                      required:
-                      - virtualService
-                      type: object
-                  required:
-                  - target
-                  type: object
-                match:
-                  description: An object that represents the criteria for determining a request match.
-                  properties:
-                    hostname:
-                      description: The client specified Hostname to match on.
-                      properties:
-                        exact:
-                          description: The value sent by the client must match the specified value exactly.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        suffix:
-                          description: The value sent by the client must end with the specified characters.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      type: object
-                    metadata:
-                      description: An object that represents the data to match from the request.
-                      items:
-                        description: GRPCGatewayRouteMetadata refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcRouteMetadata.html
-                        properties:
-                          invert:
-                            description: Specify True to match anything except the match criteria. The default value is False.
-                            type: boolean
-                          match:
-                            description: An object that represents the data to match from the request.
-                            properties:
-                              exact:
-                                description: The value sent by the client must match the specified value exactly.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              prefix:
-                                description: The value sent by the client must begin with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              range:
-                                description: An object that represents the range of values to match on
-                                properties:
-                                  end:
-                                    description: The end of the range.
-                                    format: int64
-                                    type: integer
-                                  start:
-                                    description: The start of the range.
-                                    format: int64
-                                    type: integer
-                                required:
-                                - end
-                                - start
-                                type: object
-                              regex:
-                                description: The value sent by the client must include the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              suffix:
-                                description: The value sent by the client must end with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          name:
-                            description: The name of the route.
-                            maxLength: 50
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      maxItems: 10
-                      minItems: 1
-                      type: array
-                    serviceName:
-                      description: Either ServiceName or Hostname must be specified. Both are allowed as well The fully qualified domain name for the service to match from the request.
-                      type: string
-                  type: object
-              required:
-              - action
-              - match
-              type: object
-            http2Route:
-              description: An object that represents the specification of an HTTP/2 gatewayRoute.
-              properties:
-                action:
-                  description: An object that represents the action to take if a match is determined.
-                  properties:
-                    rewrite:
-                      properties:
-                        hostname:
-                          description: ENABLE or DISABLE default behavior for Hostname rewrite
-                          properties:
-                            defaultTargetHostname:
-                              enum:
-                              - ENABLED
-                              - DISABLED
-                              type: string
-                          type: object
-                        path:
-                          properties:
-                            exact:
-                              maxLength: 255
-                              minLength: 1
-                              type: string
-                          type: object
-                        prefix:
-                          properties:
-                            defaultPrefix:
-                              enum:
-                              - ENABLED
-                              - DISABLED
-                              type: string
-                            value:
-                              description: When DefaultPrefix is specified, Value cannot be set
-                              maxLength: 255
-                              minLength: 1
-                              type: string
-                          type: object
-                      type: object
-                    target:
-                      description: An object that represents the target that traffic is routed to when a request matches the route.
-                      properties:
-                        virtualService:
-                          description: The virtual service to associate with the gateway route target.
-                          properties:
-                            virtualServiceARN:
-                              description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                              type: string
-                            virtualServiceRef:
-                              description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                              properties:
-                                name:
-                                  description: Name is the name of VirtualService CR
-                                  type: string
-                                namespace:
-                                  description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          type: object
-                      required:
-                      - virtualService
-                      type: object
-                  required:
-                  - target
-                  type: object
-                match:
-                  description: An object that represents the criteria for determining a request match.
-                  properties:
-                    headers:
-                      description: An object that represents the client request headers to match on.
-                      items:
-                        description: HTTPGatewayRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
-                        properties:
-                          invert:
-                            description: Specify True to match anything except the match criteria. The default value is False.
-                            type: boolean
-                          match:
-                            description: The HeaderMatchMethod object.
-                            properties:
-                              exact:
-                                description: The value sent by the client must match the specified value exactly.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              prefix:
-                                description: The value sent by the client must begin with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              range:
-                                description: An object that represents the range of values to match on.
-                                properties:
-                                  end:
-                                    description: The end of the range.
-                                    format: int64
-                                    type: integer
-                                  start:
-                                    description: The start of the range.
-                                    format: int64
-                                    type: integer
-                                required:
-                                - end
-                                - start
-                                type: object
-                              regex:
-                                description: The value sent by the client must include the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              suffix:
-                                description: The value sent by the client must end with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          name:
-                            description: A name for the HTTP header in the client request that will be matched on.
-                            maxLength: 50
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      maxItems: 10
-                      minItems: 1
-                      type: array
-                    hostname:
-                      description: The client specified Hostname to match on.
-                      properties:
-                        exact:
-                          description: The value sent by the client must match the specified value exactly.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        suffix:
-                          description: The value sent by the client must end with the specified characters.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      type: object
-                    method:
-                      description: The client request method to match on.
-                      enum:
-                      - CONNECT
-                      - DELETE
-                      - GET
-                      - HEAD
-                      - OPTIONS
-                      - PATCH
-                      - POST
-                      - PUT
-                      - TRACE
-                      type: string
-                    path:
-                      properties:
-                        exact:
-                          description: The value sent by the client must match the specified value exactly.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        regex:
-                          description: The value sent by the client must end with the specified characters.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                      type: object
-                    prefix:
-                      description: Either Prefix or Hostname must be specified. Both are allowed as well. Specifies the path to match requests with
-                      type: string
-                    queryParameters:
-                      items:
-                        properties:
-                          match:
-                            description: The HeaderMatchMethod object.
-                            properties:
-                              exact:
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          name:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      maxItems: 10
-                      minItems: 1
-                      type: array
-                  type: object
-              required:
-              - action
-              - match
-              type: object
-            httpRoute:
-              description: An object that represents the specification of an HTTP gatewayRoute.
-              properties:
-                action:
-                  description: An object that represents the action to take if a match is determined.
-                  properties:
-                    rewrite:
-                      properties:
-                        hostname:
-                          description: ENABLE or DISABLE default behavior for Hostname rewrite
-                          properties:
-                            defaultTargetHostname:
-                              enum:
-                              - ENABLED
-                              - DISABLED
-                              type: string
-                          type: object
-                        path:
-                          properties:
-                            exact:
-                              maxLength: 255
-                              minLength: 1
-                              type: string
-                          type: object
-                        prefix:
-                          properties:
-                            defaultPrefix:
-                              enum:
-                              - ENABLED
-                              - DISABLED
-                              type: string
-                            value:
-                              description: When DefaultPrefix is specified, Value cannot be set
-                              maxLength: 255
-                              minLength: 1
-                              type: string
-                          type: object
-                      type: object
-                    target:
-                      description: An object that represents the target that traffic is routed to when a request matches the route.
-                      properties:
-                        virtualService:
-                          description: The virtual service to associate with the gateway route target.
-                          properties:
-                            virtualServiceARN:
-                              description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                              type: string
-                            virtualServiceRef:
-                              description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                              properties:
-                                name:
-                                  description: Name is the name of VirtualService CR
-                                  type: string
-                                namespace:
-                                  description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          type: object
-                      required:
-                      - virtualService
-                      type: object
-                  required:
-                  - target
-                  type: object
-                match:
-                  description: An object that represents the criteria for determining a request match.
-                  properties:
-                    headers:
-                      description: An object that represents the client request headers to match on.
-                      items:
-                        description: HTTPGatewayRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
-                        properties:
-                          invert:
-                            description: Specify True to match anything except the match criteria. The default value is False.
-                            type: boolean
-                          match:
-                            description: The HeaderMatchMethod object.
-                            properties:
-                              exact:
-                                description: The value sent by the client must match the specified value exactly.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              prefix:
-                                description: The value sent by the client must begin with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              range:
-                                description: An object that represents the range of values to match on.
-                                properties:
-                                  end:
-                                    description: The end of the range.
-                                    format: int64
-                                    type: integer
-                                  start:
-                                    description: The start of the range.
-                                    format: int64
-                                    type: integer
-                                required:
-                                - end
-                                - start
-                                type: object
-                              regex:
-                                description: The value sent by the client must include the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              suffix:
-                                description: The value sent by the client must end with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          name:
-                            description: A name for the HTTP header in the client request that will be matched on.
-                            maxLength: 50
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      maxItems: 10
-                      minItems: 1
-                      type: array
-                    hostname:
-                      description: The client specified Hostname to match on.
-                      properties:
-                        exact:
-                          description: The value sent by the client must match the specified value exactly.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        suffix:
-                          description: The value sent by the client must end with the specified characters.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      type: object
-                    method:
-                      description: The client request method to match on.
-                      enum:
-                      - CONNECT
-                      - DELETE
-                      - GET
-                      - HEAD
-                      - OPTIONS
-                      - PATCH
-                      - POST
-                      - PUT
-                      - TRACE
-                      type: string
-                    path:
-                      properties:
-                        exact:
-                          description: The value sent by the client must match the specified value exactly.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        regex:
-                          description: The value sent by the client must end with the specified characters.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                      type: object
-                    prefix:
-                      description: Either Prefix or Hostname must be specified. Both are allowed as well. Specifies the path to match requests with
-                      type: string
-                    queryParameters:
-                      items:
-                        properties:
-                          match:
-                            description: The HeaderMatchMethod object.
-                            properties:
-                              exact:
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          name:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      maxItems: 10
-                      minItems: 1
-                      type: array
-                  type: object
-              required:
-              - action
-              - match
-              type: object
-            meshRef:
-              description: "A reference to k8s Mesh CR that this GatewayRoute belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
-              properties:
-                name:
-                  description: Name is the name of Mesh CR
-                  type: string
-                uid:
-                  description: UID is the UID of Mesh CR
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-            priority:
-              description: Priority for the gatewayroute. Default Priority is 1000 which is lowest priority
-              format: int64
-              maximum: 1000
-              minimum: 0
-              type: integer
-            virtualGatewayRef:
-              description: "A reference to k8s VirtualGateway CR that this GatewayRoute belongs to. The admission controller populates it using VirtualGateway's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
-              properties:
-                name:
-                  description: Name is the name of VirtualGateway CR
-                  type: string
-                namespace:
-                  description: Namespace is the namespace of VirtualGateway CR. If unspecified, defaults to the referencing object's namespace
-                  type: string
-                uid:
-                  description: UID is the UID of VirtualGateway CR
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-          type: object
-        status:
-          description: GatewayRouteStatus defines the observed state of GatewayRoute
-          properties:
-            conditions:
-              description: The current GatewayRoute status.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The AppMesh GatewayRoute object's Amazon Resource Name
+      jsonPath: .status.gatewayRouteARN
+      name: ARN
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: GatewayRoute is the Schema for the gatewayroutes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GatewayRouteSpec defines the desired state of GatewayRoute refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+            properties:
+              awsName:
+                description: AWSName is the AppMesh GatewayRoute object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s GatewayRoute
+                type: string
+              grpcRoute:
+                description: An object that represents the specification of a gRPC gatewayRoute.
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status to another.
-                    format: date-time
+                  action:
+                    description: An object that represents the action to take if a match is determined.
+                    properties:
+                      rewrite:
+                        description: GrpcGatewayRouteRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcGatewayRouteRewrite.html
+                        properties:
+                          hostname:
+                            description: GatewayRouteHostnameRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GatewayRouteHostnameRewrite.html ENABLE or DISABLE default behavior for Hostname rewrite
+                            properties:
+                              defaultTargetHostname:
+                                enum:
+                                - ENABLED
+                                - DISABLED
+                                type: string
+                            type: object
+                        type: object
+                      target:
+                        description: An object that represents the target that traffic is routed to when a request matches the route.
+                        properties:
+                          virtualService:
+                            description: The virtual service to associate with the gateway route target.
+                            properties:
+                              virtualServiceARN:
+                                description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                                type: string
+                              virtualServiceRef:
+                                description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                                properties:
+                                  name:
+                                    description: Name is the name of VirtualService CR
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                        required:
+                        - virtualService
+                        type: object
+                    required:
+                    - target
+                    type: object
+                  match:
+                    description: An object that represents the criteria for determining a request match.
+                    properties:
+                      hostname:
+                        description: The client specified Hostname to match on.
+                        properties:
+                          exact:
+                            description: The value sent by the client must match the specified value exactly.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          suffix:
+                            description: The value sent by the client must end with the specified characters.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        type: object
+                      metadata:
+                        description: An object that represents the data to match from the request.
+                        items:
+                          description: GRPCGatewayRouteMetadata refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcGatewayRouteMetadata.html
+                          properties:
+                            invert:
+                              description: Specify True to match anything except the match criteria. The default value is False.
+                              type: boolean
+                            match:
+                              description: An object that represents the data to match from the request.
+                              properties:
+                                exact:
+                                  description: The value sent by the client must match the specified value exactly.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                prefix:
+                                  description: The value sent by the client must begin with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                range:
+                                  description: An object that represents the range of values to match on
+                                  properties:
+                                    end:
+                                      description: The end of the range.
+                                      format: int64
+                                      type: integer
+                                    start:
+                                      description: The start of the range.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - end
+                                  - start
+                                  type: object
+                                regex:
+                                  description: The value sent by the client must include the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                suffix:
+                                  description: The value sent by the client must end with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            name:
+                              description: The name of the route.
+                              maxLength: 50
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      serviceName:
+                        description: Either ServiceName or Hostname must be specified. Both are allowed as well The fully qualified domain name for the service to match from the request.
+                        type: string
+                    type: object
+                required:
+                - action
+                - match
+                type: object
+              http2Route:
+                description: An object that represents the specification of an HTTP/2 gatewayRoute.
+                properties:
+                  action:
+                    description: An object that represents the action to take if a match is determined.
+                    properties:
+                      rewrite:
+                        description: HTTPGatewayRouteRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRouteRewrite.html
+                        properties:
+                          hostname:
+                            description: GatewayRouteHostnameRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GatewayRouteHostnameRewrite.html ENABLE or DISABLE default behavior for Hostname rewrite
+                            properties:
+                              defaultTargetHostname:
+                                enum:
+                                - ENABLED
+                                - DISABLED
+                                type: string
+                            type: object
+                          path:
+                            description: GatewayRoutePathRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRoutePathRewrite.html
+                            properties:
+                              exact:
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            type: object
+                          prefix:
+                            description: GatewayRoutePrefixRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRoutePrefixRewrite.html
+                            properties:
+                              defaultPrefix:
+                                enum:
+                                - ENABLED
+                                - DISABLED
+                                type: string
+                              value:
+                                description: When DefaultPrefix is specified, Value cannot be set
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            type: object
+                        type: object
+                      target:
+                        description: An object that represents the target that traffic is routed to when a request matches the route.
+                        properties:
+                          virtualService:
+                            description: The virtual service to associate with the gateway route target.
+                            properties:
+                              virtualServiceARN:
+                                description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                                type: string
+                              virtualServiceRef:
+                                description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                                properties:
+                                  name:
+                                    description: Name is the name of VirtualService CR
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                        required:
+                        - virtualService
+                        type: object
+                    required:
+                    - target
+                    type: object
+                  match:
+                    description: An object that represents the criteria for determining a request match.
+                    properties:
+                      headers:
+                        description: An object that represents the client request headers to match on.
+                        items:
+                          description: HTTPGatewayRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRouteHeader.html
+                          properties:
+                            invert:
+                              description: Specify True to match anything except the match criteria. The default value is False.
+                              type: boolean
+                            match:
+                              description: The HeaderMatchMethod object.
+                              properties:
+                                exact:
+                                  description: The value sent by the client must match the specified value exactly.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                prefix:
+                                  description: The value sent by the client must begin with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                range:
+                                  description: An object that represents the range of values to match on.
+                                  properties:
+                                    end:
+                                      description: The end of the range.
+                                      format: int64
+                                      type: integer
+                                    start:
+                                      description: The start of the range.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - end
+                                  - start
+                                  type: object
+                                regex:
+                                  description: The value sent by the client must include the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                suffix:
+                                  description: The value sent by the client must end with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            name:
+                              description: A name for the HTTP header in the client request that will be matched on.
+                              maxLength: 50
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      hostname:
+                        description: The client specified Hostname to match on.
+                        properties:
+                          exact:
+                            description: The value sent by the client must match the specified value exactly.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          suffix:
+                            description: The value sent by the client must end with the specified characters.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        type: object
+                      method:
+                        description: The client request method to match on.
+                        enum:
+                        - CONNECT
+                        - DELETE
+                        - GET
+                        - HEAD
+                        - OPTIONS
+                        - PATCH
+                        - POST
+                        - PUT
+                        - TRACE
+                        type: string
+                      path:
+                        description: Specified path of the request to be matched on
+                        properties:
+                          exact:
+                            description: The value sent by the client must match the specified value exactly.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          regex:
+                            description: The value sent by the client must end with the specified characters.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                        type: object
+                      prefix:
+                        description: Either Prefix or Hostname must be specified. Both are allowed as well. Specifies the prefix to match requests with
+                        type: string
+                      queryParameters:
+                        description: Client specified query parameters to match on
+                        items:
+                          description: HTTPQueryParameters refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpQueryParameter.html
+                          properties:
+                            match:
+                              description: The QueryMatchMethod object.
+                              properties:
+                                exact:
+                                  type: string
+                              type: object
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                    type: object
+                required:
+                - action
+                - match
+                type: object
+              httpRoute:
+                description: An object that represents the specification of an HTTP gatewayRoute.
+                properties:
+                  action:
+                    description: An object that represents the action to take if a match is determined.
+                    properties:
+                      rewrite:
+                        description: HTTPGatewayRouteRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRouteRewrite.html
+                        properties:
+                          hostname:
+                            description: GatewayRouteHostnameRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GatewayRouteHostnameRewrite.html ENABLE or DISABLE default behavior for Hostname rewrite
+                            properties:
+                              defaultTargetHostname:
+                                enum:
+                                - ENABLED
+                                - DISABLED
+                                type: string
+                            type: object
+                          path:
+                            description: GatewayRoutePathRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRoutePathRewrite.html
+                            properties:
+                              exact:
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            type: object
+                          prefix:
+                            description: GatewayRoutePrefixRewrite refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRoutePrefixRewrite.html
+                            properties:
+                              defaultPrefix:
+                                enum:
+                                - ENABLED
+                                - DISABLED
+                                type: string
+                              value:
+                                description: When DefaultPrefix is specified, Value cannot be set
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                            type: object
+                        type: object
+                      target:
+                        description: An object that represents the target that traffic is routed to when a request matches the route.
+                        properties:
+                          virtualService:
+                            description: The virtual service to associate with the gateway route target.
+                            properties:
+                              virtualServiceARN:
+                                description: Amazon Resource Name to AppMesh VirtualService object to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                                type: string
+                              virtualServiceRef:
+                                description: Reference to Kubernetes VirtualService CR in cluster to associate with the gateway route virtual service target. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                                properties:
+                                  name:
+                                    description: Name is the name of VirtualService CR
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                        required:
+                        - virtualService
+                        type: object
+                    required:
+                    - target
+                    type: object
+                  match:
+                    description: An object that represents the criteria for determining a request match.
+                    properties:
+                      headers:
+                        description: An object that represents the client request headers to match on.
+                        items:
+                          description: HTTPGatewayRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpGatewayRouteHeader.html
+                          properties:
+                            invert:
+                              description: Specify True to match anything except the match criteria. The default value is False.
+                              type: boolean
+                            match:
+                              description: The HeaderMatchMethod object.
+                              properties:
+                                exact:
+                                  description: The value sent by the client must match the specified value exactly.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                prefix:
+                                  description: The value sent by the client must begin with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                range:
+                                  description: An object that represents the range of values to match on.
+                                  properties:
+                                    end:
+                                      description: The end of the range.
+                                      format: int64
+                                      type: integer
+                                    start:
+                                      description: The start of the range.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - end
+                                  - start
+                                  type: object
+                                regex:
+                                  description: The value sent by the client must include the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                suffix:
+                                  description: The value sent by the client must end with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            name:
+                              description: A name for the HTTP header in the client request that will be matched on.
+                              maxLength: 50
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      hostname:
+                        description: The client specified Hostname to match on.
+                        properties:
+                          exact:
+                            description: The value sent by the client must match the specified value exactly.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          suffix:
+                            description: The value sent by the client must end with the specified characters.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        type: object
+                      method:
+                        description: The client request method to match on.
+                        enum:
+                        - CONNECT
+                        - DELETE
+                        - GET
+                        - HEAD
+                        - OPTIONS
+                        - PATCH
+                        - POST
+                        - PUT
+                        - TRACE
+                        type: string
+                      path:
+                        description: Specified path of the request to be matched on
+                        properties:
+                          exact:
+                            description: The value sent by the client must match the specified value exactly.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          regex:
+                            description: The value sent by the client must end with the specified characters.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                        type: object
+                      prefix:
+                        description: Either Prefix or Hostname must be specified. Both are allowed as well. Specifies the prefix to match requests with
+                        type: string
+                      queryParameters:
+                        description: Client specified query parameters to match on
+                        items:
+                          description: HTTPQueryParameters refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpQueryParameter.html
+                          properties:
+                            match:
+                              description: The QueryMatchMethod object.
+                              properties:
+                                exact:
+                                  type: string
+                              type: object
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                    type: object
+                required:
+                - action
+                - match
+                type: object
+              meshRef:
+                description: "A reference to k8s Mesh CR that this GatewayRoute belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
+                properties:
+                  name:
+                    description: Name is the name of Mesh CR
                     type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of GatewayRoute condition.
+                  uid:
+                    description: UID is the UID of Mesh CR
                     type: string
                 required:
-                - status
-                - type
+                - name
+                - uid
                 type: object
-              type: array
-            gatewayRouteARN:
-              description: GatewayRouteARN is the AppMesh GatewayRoute object's Amazon Resource Name
-              type: string
-            observedGeneration:
-              description: The generation observed by the GatewayRoute controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v1beta2
-  versions:
-  - name: v1beta2
+              priority:
+                description: Priority for the gatewayroute. Default Priority is 1000 which is lowest priority
+                format: int64
+                maximum: 1000
+                minimum: 0
+                type: integer
+              virtualGatewayRef:
+                description: "A reference to k8s VirtualGateway CR that this GatewayRoute belongs to. The admission controller populates it using VirtualGateway's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
+                properties:
+                  name:
+                    description: Name is the name of VirtualGateway CR
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of VirtualGateway CR. If unspecified, defaults to the referencing object's namespace
+                    type: string
+                  uid:
+                    description: UID is the UID of VirtualGateway CR
+                    type: string
+                required:
+                - name
+                - uid
+                type: object
+            type: object
+          status:
+            description: GatewayRouteStatus defines the observed state of GatewayRoute
+            properties:
+              conditions:
+                description: The current GatewayRoute status.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of GatewayRoute condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRouteARN:
+                description: GatewayRouteARN is the AppMesh GatewayRoute object's Amazon Resource Name
+                type: string
+              observedGeneration:
+                description: The generation observed by the GatewayRoute controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -653,14 +661,6 @@ metadata:
   creationTimestamp: null
   name: meshes.appmesh.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.meshARN
-    description: The AppMesh Mesh object's Amazon Resource Name
-    name: ARN
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: appmesh.k8s.aws
   names:
     kind: Mesh
@@ -668,114 +668,121 @@ spec:
     plural: meshes
     singular: mesh
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Mesh is the Schema for the meshes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MeshSpec defines the desired state of Mesh refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_MeshSpec.html
-          properties:
-            awsName:
-              description: AWSName is the AppMesh Mesh object's name. If unspecified or empty, it defaults to be "${name}" of k8s Mesh
-              type: string
-            egressFilter:
-              description: The egress filter rules for the service mesh. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
-              properties:
-                type:
-                  description: The egress filter type.
-                  enum:
-                  - ALLOW_ALL
-                  - DROP_ALL
-                  type: string
-              required:
-              - type
-              type: object
-            meshOwner:
-              description: The AWS IAM account ID of the service mesh owner. Required if the account ID is not your own.
-              type: string
-            namespaceSelector:
-              description: "NamespaceSelector selects Namespaces using labels to designate mesh membership. This field follows standard label selector semantics: \tif present but empty, it selects all namespaces. \tif absent, it selects no namespace."
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-          type: object
-        status:
-          description: MeshStatus defines the observed state of Mesh
-          properties:
-            conditions:
-              description: The current Mesh status.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The AppMesh Mesh object's Amazon Resource Name
+      jsonPath: .status.meshARN
+      name: ARN
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Mesh is the Schema for the meshes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MeshSpec defines the desired state of Mesh refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_MeshSpec.html
+            properties:
+              awsName:
+                description: AWSName is the AppMesh Mesh object's name. If unspecified or empty, it defaults to be "${name}" of k8s Mesh
+                type: string
+              egressFilter:
+                description: The egress filter rules for the service mesh. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
                   type:
-                    description: Type of mesh condition.
+                    description: The egress filter type.
+                    enum:
+                    - ALLOW_ALL
+                    - DROP_ALL
                     type: string
                 required:
-                - status
                 - type
                 type: object
-              type: array
-            meshARN:
-              description: MeshARN is the AppMesh Mesh object's Amazon Resource Name
-              type: string
-            observedGeneration:
-              description: The generation observed by the Mesh controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v1beta2
-  versions:
-  - name: v1beta2
+              meshOwner:
+                description: The AWS IAM account ID of the service mesh owner. Required if the account ID is not your own.
+                type: string
+              namespaceSelector:
+                description: "NamespaceSelector selects Namespaces using labels to designate mesh membership. This field follows standard label selector semantics: \tif present but empty, it selects all namespaces. \tif absent, it selects no namespace."
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MeshStatus defines the observed state of Mesh
+            properties:
+              conditions:
+                description: The current Mesh status.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of mesh condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              meshARN:
+                description: MeshARN is the AppMesh Mesh object's Amazon Resource Name
+                type: string
+              observedGeneration:
+                description: The generation observed by the Mesh controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -791,14 +798,6 @@ metadata:
   creationTimestamp: null
   name: virtualgateways.appmesh.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.virtualGatewayARN
-    description: The AppMesh VirtualGateway object's Amazon Resource Name
-    name: ARN
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: appmesh.k8s.aws
   names:
     categories:
@@ -808,40 +807,312 @@ spec:
     plural: virtualgateways
     singular: virtualgateway
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VirtualGateway is the Schema for the virtualgateways API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VirtualGatewaySpec defines the desired state of VirtualGateway refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
-          properties:
-            awsName:
-              description: AWSName is the AppMesh VirtualGateway object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualGateway
-              type: string
-            backendDefaults:
-              description: A reference to an object that represents the defaults for backend GatewayRoutes.
-              properties:
-                clientPolicy:
-                  description: A reference to an object that represents a client policy.
+  versions:
+  - additionalPrinterColumns:
+    - description: The AppMesh VirtualGateway object's Amazon Resource Name
+      jsonPath: .status.virtualGatewayARN
+      name: ARN
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VirtualGateway is the Schema for the virtualgateways API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualGatewaySpec defines the desired state of VirtualGateway refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+            properties:
+              awsName:
+                description: AWSName is the AppMesh VirtualGateway object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualGateway
+                type: string
+              backendDefaults:
+                description: A reference to an object that represents the defaults for backend GatewayRoutes.
+                properties:
+                  clientPolicy:
+                    description: A reference to an object that represents a client policy.
+                    properties:
+                      tls:
+                        description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
+                        properties:
+                          certificate:
+                            description: A reference to an object that represents TLS certificate.
+                            properties:
+                              file:
+                                description: An object that represents a TLS cert via a local file
+                                properties:
+                                  certificateChain:
+                                    description: The certificate chain for the certificate.
+                                    maxLength: 255
+                                    minLength: 1
+                                    type: string
+                                  privateKey:
+                                    description: The private key for a certificate stored on the file system of the virtual Gateway.
+                                    maxLength: 255
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - certificateChain
+                                - privateKey
+                                type: object
+                              sds:
+                                description: An object that represents a TLS cert via SDS entry
+                                properties:
+                                  secretName:
+                                    description: The certificate trust chain for a certificate issued via SDS cluster
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                            type: object
+                          enforce:
+                            description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
+                            type: boolean
+                          ports:
+                            description: The range of ports that the policy is enforced for.
+                            items:
+                              format: int64
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            type: array
+                          validation:
+                            description: A reference to an object that represents a TLS validation context.
+                            properties:
+                              subjectAlternativeNames:
+                                description: Possible alternative names to consider
+                                properties:
+                                  match:
+                                    description: Match is a required field
+                                    properties:
+                                      exact:
+                                        description: Exact is a required field
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - exact
+                                    type: object
+                                required:
+                                - match
+                                type: object
+                              trust:
+                                description: A reference to an object that represents a TLS validation context trust
+                                properties:
+                                  acm:
+                                    description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
+                                    properties:
+                                      certificateAuthorityARNs:
+                                        description: One or more ACM Amazon Resource Name (ARN)s.
+                                        items:
+                                          type: string
+                                        maxItems: 3
+                                        minItems: 1
+                                        type: array
+                                    required:
+                                    - certificateAuthorityARNs
+                                    type: object
+                                  file:
+                                    description: An object that represents a TLS validation context trust for a local file.
+                                    properties:
+                                      certificateChain:
+                                        description: The certificate trust chain for a certificate stored on the file system of the virtual Gateway.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - certificateChain
+                                    type: object
+                                  sds:
+                                    description: An object that represents a TLS validation context trust for a SDS certificate
+                                    properties:
+                                      secretName:
+                                        description: The certificate trust chain for a certificate issued via SDS.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                type: object
+                            required:
+                            - trust
+                            type: object
+                        required:
+                        - validation
+                        type: object
+                    type: object
+                type: object
+              gatewayRouteSelector:
+                description: GatewayRouteSelector selects GatewayRoutes using labels to designate GatewayRoute membership. If not specified it selects all GatewayRoutes in that namespace.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              listeners:
+                description: The listener that the virtual gateway is expected to receive inbound traffic from
+                items:
+                  description: VirtualGatewayListener refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
                   properties:
+                    connectionPool:
+                      description: The connection pool settings for the listener
+                      properties:
+                        grpc:
+                          description: Specifies grpc connection pool settings for the virtual gateway listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        http:
+                          description: Specifies http connection pool settings for the virtual gateway listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                            maxPendingRequests:
+                              description: Represents the number of overflowing requests after max_connections that an envoy will queue to an upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                        http2:
+                          description: Specifies http2 connection pool settings for the virtual gateway listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                      type: object
+                    healthCheck:
+                      description: The health check information for the listener.
+                      properties:
+                        healthyThreshold:
+                          description: The number of consecutive successful health checks that must occur before declaring listener healthy.
+                          format: int64
+                          maximum: 10
+                          minimum: 2
+                          type: integer
+                        intervalMillis:
+                          description: The time period in milliseconds between each health check execution.
+                          format: int64
+                          maximum: 300000
+                          minimum: 5000
+                          type: integer
+                        path:
+                          description: The destination path for the health check request. This value is only used if the specified protocol is http or http2. For any other protocol, this value is ignored.
+                          type: string
+                        port:
+                          description: The destination port for the health check request.
+                          format: int64
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: The protocol for the health check request
+                          enum:
+                          - grpc
+                          - http
+                          - http2
+                          type: string
+                        timeoutMillis:
+                          description: The amount of time to wait when receiving a response from the health check, in milliseconds.
+                          format: int64
+                          maximum: 60000
+                          minimum: 2000
+                          type: integer
+                        unhealthyThreshold:
+                          description: The number of consecutive failed health checks that must occur before declaring a virtual Gateway unhealthy.
+                          format: int64
+                          maximum: 10
+                          minimum: 2
+                          type: integer
+                      required:
+                      - intervalMillis
+                      - protocol
+                      - timeoutMillis
+                      - unhealthyThreshold
+                      type: object
+                    portMapping:
+                      description: The port mapping information for the listener.
+                      properties:
+                        port:
+                          description: The port used for the port mapping.
+                          format: int64
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: The protocol used for the port mapping.
+                          enum:
+                          - grpc
+                          - http
+                          - http2
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
                     tls:
-                      description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
+                      description: A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.
                       properties:
                         certificate:
-                          description: A reference to an object that represents TLS certificate.
+                          description: A reference to an object that represents a listener's TLS certificate.
                           properties:
+                            acm:
+                              description: A reference to an object that represents an AWS Certificate Manager (ACM) certificate.
+                              properties:
+                                certificateARN:
+                                  description: The Amazon Resource Name (ARN) for the certificate.
+                                  type: string
+                              required:
+                              - certificateARN
+                              type: object
                             file:
-                              description: An object that represents a TLS cert via a local file
+                              description: A reference to an object that represents a local file certificate.
                               properties:
                                 certificateChain:
                                   description: The certificate chain for the certificate.
@@ -858,7 +1129,7 @@ spec:
                               - privateKey
                               type: object
                             sds:
-                              description: An object that represents a TLS cert via SDS entry
+                              description: A reference to an object that represents an SDS issued certificate
                               properties:
                                 secretName:
                                   description: The certificate trust chain for a certificate issued via SDS cluster
@@ -867,22 +1138,18 @@ spec:
                               - secretName
                               type: object
                           type: object
-                        enforce:
-                          description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
-                          type: boolean
-                        ports:
-                          description: The range of ports that the policy is enforced for.
-                          items:
-                            format: int64
-                            maximum: 65535
-                            minimum: 1
-                            type: integer
-                          type: array
+                        mode:
+                          description: ListenerTLS mode
+                          enum:
+                          - DISABLED
+                          - PERMISSIVE
+                          - STRICT
+                          type: string
                         validation:
-                          description: A reference to an object that represents a TLS validation context.
+                          description: A reference to an object that represents Validation context
                           properties:
                             subjectAlternativeNames:
-                              description: Possible alternative names to consider
+                              description: Possible alternate names to consider
                               properties:
                                 match:
                                   description: Match is a required field
@@ -899,7 +1166,6 @@ spec:
                               - match
                               type: object
                             trust:
-                              description: A reference to an object that represents a TLS validation context trust
                               properties:
                                 acm:
                                   description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
@@ -926,7 +1192,7 @@ spec:
                                   - certificateChain
                                   type: object
                                 sds:
-                                  description: An object that represents a TLS validation context trust for a SDS certificate
+                                  description: An object that represents a TLS validation context trust for an SDS system
                                   properties:
                                     secretName:
                                       description: The certificate trust chain for a certificate issued via SDS.
@@ -939,409 +1205,149 @@ spec:
                           - trust
                           type: object
                       required:
-                      - validation
+                      - certificate
+                      - mode
                       type: object
+                  required:
+                  - portMapping
                   type: object
-              type: object
-            gatewayRouteSelector:
-              description: GatewayRouteSelector selects GatewayRoutes using labels to designate GatewayRoute membership. If not specified it selects all GatewayRoutes in that namespace.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-            listeners:
-              description: The listener that the virtual gateway is expected to receive inbound traffic from
-              items:
-                description: VirtualGatewayListener refers to https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+                maxItems: 1
+                minItems: 0
+                type: array
+              logging:
+                description: The inbound and outbound access logging information for the virtual gateway.
                 properties:
-                  connectionPool:
-                    description: The connection pool settings for the listener
+                  accessLog:
+                    description: The access log configuration for a virtual Gateway.
                     properties:
-                      grpc:
-                        description: Specifies grpc connection pool settings for the virtual gateway listener
+                      file:
+                        description: The file object to send virtual gateway access logs to.
                         properties:
-                          maxRequests:
-                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
-                            format: int64
-                            minimum: 1
-                            type: integer
+                          path:
+                            description: The file path to write access logs to.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
                         required:
-                        - maxRequests
-                        type: object
-                      http:
-                        description: Specifies http connection pool settings for the virtual gateway listener
-                        properties:
-                          maxConnections:
-                            description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                          maxPendingRequests:
-                            description: Represents the number of overflowing requests after max_connections that an envoy will queue to an upstream cluster.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - maxConnections
-                        type: object
-                      http2:
-                        description: Specifies http2 connection pool settings for the virtual gateway listener
-                        properties:
-                          maxRequests:
-                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - maxRequests
+                        - path
                         type: object
                     type: object
-                  healthCheck:
-                    description: The health check information for the listener.
-                    properties:
-                      healthyThreshold:
-                        description: The number of consecutive successful health checks that must occur before declaring listener healthy.
-                        format: int64
-                        maximum: 10
-                        minimum: 2
-                        type: integer
-                      intervalMillis:
-                        description: The time period in milliseconds between each health check execution.
-                        format: int64
-                        maximum: 300000
-                        minimum: 5000
-                        type: integer
-                      path:
-                        description: The destination path for the health check request. This value is only used if the specified protocol is http or http2. For any other protocol, this value is ignored.
-                        type: string
-                      port:
-                        description: The destination port for the health check request.
-                        format: int64
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: The protocol for the health check request
-                        enum:
-                        - grpc
-                        - http
-                        - http2
-                        type: string
-                      timeoutMillis:
-                        description: The amount of time to wait when receiving a response from the health check, in milliseconds.
-                        format: int64
-                        maximum: 60000
-                        minimum: 2000
-                        type: integer
-                      unhealthyThreshold:
-                        description: The number of consecutive failed health checks that must occur before declaring a virtual Gateway unhealthy.
-                        format: int64
-                        maximum: 10
-                        minimum: 2
-                        type: integer
-                    required:
-                    - intervalMillis
-                    - protocol
-                    - timeoutMillis
-                    - unhealthyThreshold
-                    type: object
-                  portMapping:
-                    description: The port mapping information for the listener.
-                    properties:
-                      port:
-                        description: The port used for the port mapping.
-                        format: int64
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: The protocol used for the port mapping.
-                        enum:
-                        - grpc
-                        - http
-                        - http2
-                        type: string
-                    required:
-                    - port
-                    - protocol
-                    type: object
-                  tls:
-                    description: A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.
-                    properties:
-                      certificate:
-                        description: A reference to an object that represents a listener's TLS certificate.
-                        properties:
-                          acm:
-                            description: A reference to an object that represents an AWS Certificate Manager (ACM) certificate.
-                            properties:
-                              certificateARN:
-                                description: The Amazon Resource Name (ARN) for the certificate.
-                                type: string
-                            required:
-                            - certificateARN
-                            type: object
-                          file:
-                            description: A reference to an object that represents a local file certificate.
-                            properties:
-                              certificateChain:
-                                description: The certificate chain for the certificate.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              privateKey:
-                                description: The private key for a certificate stored on the file system of the virtual Gateway.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            required:
-                            - certificateChain
-                            - privateKey
-                            type: object
-                          sds:
-                            description: A reference to an object that represents an SDS issued certificate
-                            properties:
-                              secretName:
-                                description: The certificate trust chain for a certificate issued via SDS cluster
-                                type: string
-                            required:
-                            - secretName
-                            type: object
-                        type: object
-                      mode:
-                        description: ListenerTLS mode
-                        enum:
-                        - DISABLED
-                        - PERMISSIVE
-                        - STRICT
-                        type: string
-                      validation:
-                        description: A reference to an object that represents Validation context
-                        properties:
-                          subjectAlternativeNames:
-                            description: Possible alternate names to consider
-                            properties:
-                              match:
-                                description: Match is a required field
-                                properties:
-                                  exact:
-                                    description: Exact is a required field
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - exact
-                                type: object
-                            required:
-                            - match
-                            type: object
-                          trust:
-                            properties:
-                              acm:
-                                description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
-                                properties:
-                                  certificateAuthorityARNs:
-                                    description: One or more ACM Amazon Resource Name (ARN)s.
-                                    items:
-                                      type: string
-                                    maxItems: 3
-                                    minItems: 1
-                                    type: array
-                                required:
-                                - certificateAuthorityARNs
-                                type: object
-                              file:
-                                description: An object that represents a TLS validation context trust for a local file.
-                                properties:
-                                  certificateChain:
-                                    description: The certificate trust chain for a certificate stored on the file system of the virtual Gateway.
-                                    maxLength: 255
-                                    minLength: 1
-                                    type: string
-                                required:
-                                - certificateChain
-                                type: object
-                              sds:
-                                description: An object that represents a TLS validation context trust for an SDS system
-                                properties:
-                                  secretName:
-                                    description: The certificate trust chain for a certificate issued via SDS.
-                                    type: string
-                                required:
-                                - secretName
-                                type: object
-                            type: object
-                        required:
-                        - trust
-                        type: object
-                    required:
-                    - certificate
-                    - mode
-                    type: object
-                required:
-                - portMapping
                 type: object
-              maxItems: 1
-              minItems: 0
-              type: array
-            logging:
-              description: The inbound and outbound access logging information for the virtual gateway.
-              properties:
-                accessLog:
-                  description: The access log configuration for a virtual Gateway.
-                  properties:
-                    file:
-                      description: The file object to send virtual gateway access logs to.
+              meshRef:
+                description: "A reference to k8s Mesh CR that this VirtualGateway belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
+                properties:
+                  name:
+                    description: Name is the name of Mesh CR
+                    type: string
+                  uid:
+                    description: UID is the UID of Mesh CR
+                    type: string
+                required:
+                - name
+                - uid
+                type: object
+              namespaceSelector:
+                description: NamespaceSelector selects Namespaces using labels to designate GatewayRoute membership. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
-                        path:
-                          description: The file path to write access logs to.
-                          maxLength: 255
-                          minLength: 1
+                        key:
+                          description: key is the label key that the selector applies to.
                           type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
                       required:
-                      - path
+                      - key
+                      - operator
                       type: object
-                  type: object
-              type: object
-            meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualGateway belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
-              properties:
-                name:
-                  description: Name is the name of Mesh CR
-                  type: string
-                uid:
-                  description: UID is the UID of Mesh CR
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-            namespaceSelector:
-              description: NamespaceSelector selects Namespaces using labels to designate GatewayRoute membership. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-            podSelector:
-              description: "PodSelector selects Pods using labels to designate VirtualGateway membership. This field follows standard label selector semantics: \tif present but empty, it selects all pods within namespace. \tif absent, it selects no pod."
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-          type: object
-        status:
-          description: VirtualGatewayStatus defines the observed state of VirtualGateway
-          properties:
-            conditions:
-              description: The current VirtualGateway status.
-              items:
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of VirtualGateway condition.
-                    type: string
-                required:
-                - status
-                - type
                 type: object
-              type: array
-            observedGeneration:
-              description: The generation observed by the VirtualGateway controller.
-              format: int64
-              type: integer
-            virtualGatewayARN:
-              description: VirtualGatewayARN is the AppMesh VirtualGateway object's Amazon Resource Name
-              type: string
-          type: object
-      type: object
-  version: v1beta2
-  versions:
-  - name: v1beta2
+              podSelector:
+                description: "PodSelector selects Pods using labels to designate VirtualGateway membership. This field follows standard label selector semantics: \tif present but empty, it selects all pods within namespace. \tif absent, it selects no pod."
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualGatewayStatus defines the observed state of VirtualGateway
+            properties:
+              conditions:
+                description: The current VirtualGateway status.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of VirtualGateway condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the VirtualGateway controller.
+                format: int64
+                type: integer
+              virtualGatewayARN:
+                description: VirtualGatewayARN is the AppMesh VirtualGateway object's Amazon Resource Name
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -1357,14 +1363,6 @@ metadata:
   creationTimestamp: null
   name: virtualnodes.appmesh.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.virtualNodeARN
-    description: The AppMesh VirtualNode object's Amazon Resource Name
-    name: ARN
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: appmesh.k8s.aws
   names:
     categories:
@@ -1374,40 +1372,637 @@ spec:
     plural: virtualnodes
     singular: virtualnode
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VirtualNode is the Schema for the virtualnodes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VirtualNodeSpec defines the desired state of VirtualNode refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualNodeSpec.html
-          properties:
-            awsName:
-              description: AWSName is the AppMesh VirtualNode object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualNode
-              type: string
-            backendDefaults:
-              description: A reference to an object that represents the defaults for backends.
-              properties:
-                clientPolicy:
-                  description: A reference to an object that represents a client policy.
+  versions:
+  - additionalPrinterColumns:
+    - description: The AppMesh VirtualNode object's Amazon Resource Name
+      jsonPath: .status.virtualNodeARN
+      name: ARN
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VirtualNode is the Schema for the virtualnodes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualNodeSpec defines the desired state of VirtualNode refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualNodeSpec.html
+            properties:
+              awsName:
+                description: AWSName is the AppMesh VirtualNode object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualNode
+                type: string
+              backendDefaults:
+                description: A reference to an object that represents the defaults for backends.
+                properties:
+                  clientPolicy:
+                    description: A reference to an object that represents a client policy.
+                    properties:
+                      tls:
+                        description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
+                        properties:
+                          certificate:
+                            description: A reference to an object that represents TLS certificate.
+                            properties:
+                              file:
+                                description: An object that represents a TLS cert via a local file
+                                properties:
+                                  certificateChain:
+                                    description: The certificate chain for the certificate.
+                                    maxLength: 255
+                                    minLength: 1
+                                    type: string
+                                  privateKey:
+                                    description: The private key for a certificate stored on the file system of the virtual node that the proxy is running on.
+                                    maxLength: 255
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - certificateChain
+                                - privateKey
+                                type: object
+                              sds:
+                                description: An object that represents a TLS cert via SDS entry
+                                properties:
+                                  secretName:
+                                    description: The certificate trust chain for a certificate issued via SDS cluster
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                            type: object
+                          enforce:
+                            description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
+                            type: boolean
+                          ports:
+                            description: The range of ports that the policy is enforced for.
+                            items:
+                              format: int64
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            type: array
+                          validation:
+                            description: A reference to an object that represents a TLS validation context.
+                            properties:
+                              subjectAlternativeNames:
+                                description: Possible Alternative names to consider
+                                properties:
+                                  match:
+                                    description: Match is a required field
+                                    properties:
+                                      exact:
+                                        description: Exact is a required field
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - exact
+                                    type: object
+                                required:
+                                - match
+                                type: object
+                              trust:
+                                description: A reference to an object that represents a TLS validation context trust
+                                properties:
+                                  acm:
+                                    description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
+                                    properties:
+                                      certificateAuthorityARNs:
+                                        description: One or more ACM Amazon Resource Name (ARN)s.
+                                        items:
+                                          type: string
+                                        maxItems: 3
+                                        minItems: 1
+                                        type: array
+                                    required:
+                                    - certificateAuthorityARNs
+                                    type: object
+                                  file:
+                                    description: An object that represents a TLS validation context trust for a local file.
+                                    properties:
+                                      certificateChain:
+                                        description: The certificate trust chain for a certificate stored on the file system of the virtual node that the proxy is running on.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - certificateChain
+                                    type: object
+                                  sds:
+                                    description: An object that represents a TLS validation context trust for a SDS.
+                                    properties:
+                                      secretName:
+                                        description: The certificate trust chain for a certificate obtained via SDS
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                type: object
+                            required:
+                            - trust
+                            type: object
+                        required:
+                        - validation
+                        type: object
+                    type: object
+                type: object
+              backends:
+                description: The backends that the virtual node is expected to send outbound traffic to.
+                items:
+                  description: Backend refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Backend.html
                   properties:
+                    virtualService:
+                      description: Specifies a virtual service to use as a backend for a virtual node.
+                      properties:
+                        clientPolicy:
+                          description: A reference to an object that represents the client policy for a backend.
+                          properties:
+                            tls:
+                              description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
+                              properties:
+                                certificate:
+                                  description: A reference to an object that represents TLS certificate.
+                                  properties:
+                                    file:
+                                      description: An object that represents a TLS cert via a local file
+                                      properties:
+                                        certificateChain:
+                                          description: The certificate chain for the certificate.
+                                          maxLength: 255
+                                          minLength: 1
+                                          type: string
+                                        privateKey:
+                                          description: The private key for a certificate stored on the file system of the virtual node that the proxy is running on.
+                                          maxLength: 255
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - certificateChain
+                                      - privateKey
+                                      type: object
+                                    sds:
+                                      description: An object that represents a TLS cert via SDS entry
+                                      properties:
+                                        secretName:
+                                          description: The certificate trust chain for a certificate issued via SDS cluster
+                                          type: string
+                                      required:
+                                      - secretName
+                                      type: object
+                                  type: object
+                                enforce:
+                                  description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
+                                  type: boolean
+                                ports:
+                                  description: The range of ports that the policy is enforced for.
+                                  items:
+                                    format: int64
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                  type: array
+                                validation:
+                                  description: A reference to an object that represents a TLS validation context.
+                                  properties:
+                                    subjectAlternativeNames:
+                                      description: Possible Alternative names to consider
+                                      properties:
+                                        match:
+                                          description: Match is a required field
+                                          properties:
+                                            exact:
+                                              description: Exact is a required field
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - exact
+                                          type: object
+                                      required:
+                                      - match
+                                      type: object
+                                    trust:
+                                      description: A reference to an object that represents a TLS validation context trust
+                                      properties:
+                                        acm:
+                                          description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
+                                          properties:
+                                            certificateAuthorityARNs:
+                                              description: One or more ACM Amazon Resource Name (ARN)s.
+                                              items:
+                                                type: string
+                                              maxItems: 3
+                                              minItems: 1
+                                              type: array
+                                          required:
+                                          - certificateAuthorityARNs
+                                          type: object
+                                        file:
+                                          description: An object that represents a TLS validation context trust for a local file.
+                                          properties:
+                                            certificateChain:
+                                              description: The certificate trust chain for a certificate stored on the file system of the virtual node that the proxy is running on.
+                                              maxLength: 255
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - certificateChain
+                                          type: object
+                                        sds:
+                                          description: An object that represents a TLS validation context trust for a SDS.
+                                          properties:
+                                            secretName:
+                                              description: The certificate trust chain for a certificate obtained via SDS
+                                              type: string
+                                          required:
+                                          - secretName
+                                          type: object
+                                      type: object
+                                  required:
+                                  - trust
+                                  type: object
+                              required:
+                              - validation
+                              type: object
+                          type: object
+                        virtualServiceARN:
+                          description: Amazon Resource Name to AppMesh VirtualService object that is acting as a virtual node backend. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                          type: string
+                        virtualServiceRef:
+                          description: Reference to Kubernetes VirtualService CR in cluster that is acting as a virtual node backend. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
+                          properties:
+                            name:
+                              description: Name is the name of VirtualService CR
+                              type: string
+                            namespace:
+                              description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - virtualService
+                  type: object
+                type: array
+              listeners:
+                description: The listener that the virtual node is expected to receive inbound traffic from
+                items:
+                  description: Listener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Listener.html
+                  properties:
+                    connectionPool:
+                      description: The connection pool settings for the listener
+                      properties:
+                        grpc:
+                          description: Specifies grpc connection pool settings for the virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        http:
+                          description: Specifies http connection pool settings for the virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                            maxPendingRequests:
+                              description: Represents the number of overflowing requests after max_connections that an envoy will queue to an upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                        http2:
+                          description: Specifies http2 connection pool settings for the virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        tcp:
+                          description: Specifies tcp connection pool settings for the virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                      type: object
+                    healthCheck:
+                      description: The health check information for the listener.
+                      properties:
+                        healthyThreshold:
+                          description: The number of consecutive successful health checks that must occur before declaring listener healthy.
+                          format: int64
+                          maximum: 10
+                          minimum: 2
+                          type: integer
+                        intervalMillis:
+                          description: The time period in milliseconds between each health check execution.
+                          format: int64
+                          maximum: 300000
+                          minimum: 5000
+                          type: integer
+                        path:
+                          description: The destination path for the health check request. This value is only used if the specified protocol is http or http2. For any other protocol, this value is ignored.
+                          type: string
+                        port:
+                          description: The destination port for the health check request.
+                          format: int64
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: The protocol for the health check request
+                          enum:
+                          - grpc
+                          - http
+                          - http2
+                          - tcp
+                          type: string
+                        timeoutMillis:
+                          description: The amount of time to wait when receiving a response from the health check, in milliseconds.
+                          format: int64
+                          maximum: 60000
+                          minimum: 2000
+                          type: integer
+                        unhealthyThreshold:
+                          description: The number of consecutive failed health checks that must occur before declaring a virtual node unhealthy.
+                          format: int64
+                          maximum: 10
+                          minimum: 2
+                          type: integer
+                      required:
+                      - healthyThreshold
+                      - intervalMillis
+                      - protocol
+                      - timeoutMillis
+                      - unhealthyThreshold
+                      type: object
+                    outlierDetection:
+                      description: The outlier detection for the listener
+                      properties:
+                        baseEjectionDuration:
+                          description: The base time that a host is ejected for. The real time is equal to the base time multiplied by the number of times the host has been ejected
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        interval:
+                          description: The time interval between ejection analysis sweeps. This can result in both new ejections as well as hosts being returned to service
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        maxEjectionPercent:
+                          description: The threshold for the max percentage of outlier hosts that can be ejected from the load balancing set. maxEjectionPercent=100 means outlier detection can potentially eject all of the hosts from the upstream service if they are all considered outliers, leaving the load balancing set with zero hosts
+                          format: int64
+                          maximum: 100
+                          minimum: 0
+                          type: integer
+                        maxServerErrors:
+                          description: The threshold for the number of server errors returned by a given host during an outlier detection interval. If the server error count meets/exceeds this threshold the host is ejected. A server error is defined as any HTTP 5xx response (or the equivalent for gRPC and TCP connections)
+                          format: int64
+                          minimum: 1
+                          type: integer
+                      required:
+                      - baseEjectionDuration
+                      - interval
+                      - maxEjectionPercent
+                      - maxServerErrors
+                      type: object
+                    portMapping:
+                      description: The port mapping information for the listener.
+                      properties:
+                        port:
+                          description: The port used for the port mapping.
+                          format: int64
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: The protocol used for the port mapping.
+                          enum:
+                          - grpc
+                          - http
+                          - http2
+                          - tcp
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                    timeout:
+                      description: A reference to an object that represents
+                      properties:
+                        grpc:
+                          description: Specifies grpc timeout information for the virtual node.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            perRequest:
+                              description: An object that represents per request timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                        http:
+                          description: Specifies http timeout information for the virtual node.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            perRequest:
+                              description: An object that represents per request timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                        http2:
+                          description: Specifies http2 information for the virtual node.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            perRequest:
+                              description: An object that represents per request timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                        tcp:
+                          description: Specifies tcp timeout information for the virtual node.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                      type: object
                     tls:
-                      description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
+                      description: A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.
                       properties:
                         certificate:
-                          description: A reference to an object that represents TLS certificate.
+                          description: A reference to an object that represents a listener's TLS certificate.
                           properties:
+                            acm:
+                              description: A reference to an object that represents an AWS Certificate Manager (ACM) certificate.
+                              properties:
+                                certificateARN:
+                                  description: The Amazon Resource Name (ARN) for the certificate.
+                                  type: string
+                              required:
+                              - certificateARN
+                              type: object
                             file:
-                              description: An object that represents a TLS cert via a local file
+                              description: A reference to an object that represents a local file certificate.
                               properties:
                                 certificateChain:
                                   description: The certificate chain for the certificate.
@@ -1424,7 +2019,7 @@ spec:
                               - privateKey
                               type: object
                             sds:
-                              description: An object that represents a TLS cert via SDS entry
+                              description: A reference to an object that represents an SDS certificate.
                               properties:
                                 secretName:
                                   description: The certificate trust chain for a certificate issued via SDS cluster
@@ -1433,22 +2028,18 @@ spec:
                               - secretName
                               type: object
                           type: object
-                        enforce:
-                          description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
-                          type: boolean
-                        ports:
-                          description: The range of ports that the policy is enforced for.
-                          items:
-                            format: int64
-                            maximum: 65535
-                            minimum: 1
-                            type: integer
-                          type: array
+                        mode:
+                          description: ListenerTLS mode
+                          enum:
+                          - DISABLED
+                          - PERMISSIVE
+                          - STRICT
+                          type: string
                         validation:
-                          description: A reference to an object that represents a TLS validation context.
+                          description: A reference to an object that represents an SDS Trust Domain
                           properties:
                             subjectAlternativeNames:
-                              description: Possible Alternative names to consider
+                              description: Possible alternative names to consider
                               properties:
                                 match:
                                   description: Match is a required field
@@ -1465,21 +2056,7 @@ spec:
                               - match
                               type: object
                             trust:
-                              description: A reference to an object that represents a TLS validation context trust
                               properties:
-                                acm:
-                                  description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
-                                  properties:
-                                    certificateAuthorityARNs:
-                                      description: One or more ACM Amazon Resource Name (ARN)s.
-                                      items:
-                                        type: string
-                                      maxItems: 3
-                                      minItems: 1
-                                      type: array
-                                  required:
-                                  - certificateAuthorityARNs
-                                  type: object
                                 file:
                                   description: An object that represents a TLS validation context trust for a local file.
                                   properties:
@@ -1492,7 +2069,7 @@ spec:
                                   - certificateChain
                                   type: object
                                 sds:
-                                  description: An object that represents a TLS validation context trust for a SDS.
+                                  description: An object that represents a TLS validation context trust for an SDS server
                                   properties:
                                     secretName:
                                       description: The certificate trust chain for a certificate obtained via SDS
@@ -1505,747 +2082,175 @@ spec:
                           - trust
                           type: object
                       required:
-                      - validation
+                      - certificate
+                      - mode
                       type: object
+                  required:
+                  - portMapping
                   type: object
-              type: object
-            backends:
-              description: The backends that the virtual node is expected to send outbound traffic to.
-              items:
-                description: Backend refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Backend.html
+                maxItems: 1
+                minItems: 0
+                type: array
+              logging:
+                description: The inbound and outbound access logging information for the virtual node.
                 properties:
-                  virtualService:
-                    description: Specifies a virtual service to use as a backend for a virtual node.
+                  accessLog:
+                    description: The access log configuration for a virtual node.
                     properties:
-                      clientPolicy:
-                        description: A reference to an object that represents the client policy for a backend.
+                      file:
+                        description: The file object to send virtual node access logs to.
                         properties:
-                          tls:
-                            description: A reference to an object that represents a Transport Layer Security (TLS) client policy.
-                            properties:
-                              certificate:
-                                description: A reference to an object that represents TLS certificate.
-                                properties:
-                                  file:
-                                    description: An object that represents a TLS cert via a local file
-                                    properties:
-                                      certificateChain:
-                                        description: The certificate chain for the certificate.
-                                        maxLength: 255
-                                        minLength: 1
-                                        type: string
-                                      privateKey:
-                                        description: The private key for a certificate stored on the file system of the virtual node that the proxy is running on.
-                                        maxLength: 255
-                                        minLength: 1
-                                        type: string
-                                    required:
-                                    - certificateChain
-                                    - privateKey
-                                    type: object
-                                  sds:
-                                    description: An object that represents a TLS cert via SDS entry
-                                    properties:
-                                      secretName:
-                                        description: The certificate trust chain for a certificate issued via SDS cluster
-                                        type: string
-                                    required:
-                                    - secretName
-                                    type: object
-                                type: object
-                              enforce:
-                                description: Whether the policy is enforced. If unspecified, default settings from AWS API will be applied. Refer to AWS Docs for default settings.
-                                type: boolean
-                              ports:
-                                description: The range of ports that the policy is enforced for.
-                                items:
-                                  format: int64
-                                  maximum: 65535
-                                  minimum: 1
-                                  type: integer
-                                type: array
-                              validation:
-                                description: A reference to an object that represents a TLS validation context.
-                                properties:
-                                  subjectAlternativeNames:
-                                    description: Possible Alternative names to consider
-                                    properties:
-                                      match:
-                                        description: Match is a required field
-                                        properties:
-                                          exact:
-                                            description: Exact is a required field
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - exact
-                                        type: object
-                                    required:
-                                    - match
-                                    type: object
-                                  trust:
-                                    description: A reference to an object that represents a TLS validation context trust
-                                    properties:
-                                      acm:
-                                        description: A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM) certificate.
-                                        properties:
-                                          certificateAuthorityARNs:
-                                            description: One or more ACM Amazon Resource Name (ARN)s.
-                                            items:
-                                              type: string
-                                            maxItems: 3
-                                            minItems: 1
-                                            type: array
-                                        required:
-                                        - certificateAuthorityARNs
-                                        type: object
-                                      file:
-                                        description: An object that represents a TLS validation context trust for a local file.
-                                        properties:
-                                          certificateChain:
-                                            description: The certificate trust chain for a certificate stored on the file system of the virtual node that the proxy is running on.
-                                            maxLength: 255
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                        - certificateChain
-                                        type: object
-                                      sds:
-                                        description: An object that represents a TLS validation context trust for a SDS.
-                                        properties:
-                                          secretName:
-                                            description: The certificate trust chain for a certificate obtained via SDS
-                                            type: string
-                                        required:
-                                        - secretName
-                                        type: object
-                                    type: object
-                                required:
-                                - trust
-                                type: object
-                            required:
-                            - validation
-                            type: object
-                        type: object
-                      virtualServiceARN:
-                        description: Amazon Resource Name to AppMesh VirtualService object that is acting as a virtual node backend. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                        type: string
-                      virtualServiceRef:
-                        description: Reference to Kubernetes VirtualService CR in cluster that is acting as a virtual node backend. Exactly one of 'virtualServiceRef' or 'virtualServiceARN' must be specified.
-                        properties:
-                          name:
-                            description: Name is the name of VirtualService CR
-                            type: string
-                          namespace:
-                            description: Namespace is the namespace of VirtualService CR. If unspecified, defaults to the referencing object's namespace
-                            type: string
-                        required:
-                        - name
-                        type: object
-                    type: object
-                required:
-                - virtualService
-                type: object
-              type: array
-            listeners:
-              description: The listener that the virtual node is expected to receive inbound traffic from
-              items:
-                description: Listener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_Listener.html
-                properties:
-                  connectionPool:
-                    description: The connection pool settings for the listener
-                    properties:
-                      grpc:
-                        description: Specifies grpc connection pool settings for the virtual node listener
-                        properties:
-                          maxRequests:
-                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - maxRequests
-                        type: object
-                      http:
-                        description: Specifies http connection pool settings for the virtual node listener
-                        properties:
-                          maxConnections:
-                            description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                          maxPendingRequests:
-                            description: Represents the number of overflowing requests after max_connections that an envoy will queue to an upstream cluster.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - maxConnections
-                        type: object
-                      http2:
-                        description: Specifies http2 connection pool settings for the virtual node listener
-                        properties:
-                          maxRequests:
-                            description: Represents the maximum number of inflight requests that an envoy can concurrently support across all the hosts in the upstream cluster
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - maxRequests
-                        type: object
-                      tcp:
-                        description: Specifies tcp connection pool settings for the virtual node listener
-                        properties:
-                          maxConnections:
-                            description: Represents the maximum number of outbound TCP connections the envoy can establish concurrently with all the hosts in the upstream cluster.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - maxConnections
-                        type: object
-                    type: object
-                  healthCheck:
-                    description: The health check information for the listener.
-                    properties:
-                      healthyThreshold:
-                        description: The number of consecutive successful health checks that must occur before declaring listener healthy.
-                        format: int64
-                        maximum: 10
-                        minimum: 2
-                        type: integer
-                      intervalMillis:
-                        description: The time period in milliseconds between each health check execution.
-                        format: int64
-                        maximum: 300000
-                        minimum: 5000
-                        type: integer
-                      path:
-                        description: The destination path for the health check request. This value is only used if the specified protocol is http or http2. For any other protocol, this value is ignored.
-                        type: string
-                      port:
-                        description: The destination port for the health check request.
-                        format: int64
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: The protocol for the health check request
-                        enum:
-                        - grpc
-                        - http
-                        - http2
-                        - tcp
-                        type: string
-                      timeoutMillis:
-                        description: The amount of time to wait when receiving a response from the health check, in milliseconds.
-                        format: int64
-                        maximum: 60000
-                        minimum: 2000
-                        type: integer
-                      unhealthyThreshold:
-                        description: The number of consecutive failed health checks that must occur before declaring a virtual node unhealthy.
-                        format: int64
-                        maximum: 10
-                        minimum: 2
-                        type: integer
-                    required:
-                    - healthyThreshold
-                    - intervalMillis
-                    - protocol
-                    - timeoutMillis
-                    - unhealthyThreshold
-                    type: object
-                  outlierDetection:
-                    description: The outlier detection for the listener
-                    properties:
-                      baseEjectionDuration:
-                        description: The base time that a host is ejected for. The real time is equal to the base time multiplied by the number of times the host has been ejected
-                        properties:
-                          unit:
-                            description: A unit of time.
-                            enum:
-                            - s
-                            - ms
-                            type: string
-                          value:
-                            description: A number of time units.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                        required:
-                        - unit
-                        - value
-                        type: object
-                      interval:
-                        description: The time interval between ejection analysis sweeps. This can result in both new ejections as well as hosts being returned to service
-                        properties:
-                          unit:
-                            description: A unit of time.
-                            enum:
-                            - s
-                            - ms
-                            type: string
-                          value:
-                            description: A number of time units.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                        required:
-                        - unit
-                        - value
-                        type: object
-                      maxEjectionPercent:
-                        description: The threshold for the max percentage of outlier hosts that can be ejected from the load balancing set. maxEjectionPercent=100 means outlier detection can potentially eject all of the hosts from the upstream service if they are all considered outliers, leaving the load balancing set with zero hosts
-                        format: int64
-                        maximum: 100
-                        minimum: 0
-                        type: integer
-                      maxServerErrors:
-                        description: The threshold for the number of server errors returned by a given host during an outlier detection interval. If the server error count meets/exceeds this threshold the host is ejected. A server error is defined as any HTTP 5xx response (or the equivalent for gRPC and TCP connections)
-                        format: int64
-                        minimum: 1
-                        type: integer
-                    required:
-                    - baseEjectionDuration
-                    - interval
-                    - maxEjectionPercent
-                    - maxServerErrors
-                    type: object
-                  portMapping:
-                    description: The port mapping information for the listener.
-                    properties:
-                      port:
-                        description: The port used for the port mapping.
-                        format: int64
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: The protocol used for the port mapping.
-                        enum:
-                        - grpc
-                        - http
-                        - http2
-                        - tcp
-                        type: string
-                    required:
-                    - port
-                    - protocol
-                    type: object
-                  timeout:
-                    description: A reference to an object that represents
-                    properties:
-                      grpc:
-                        description: Specifies grpc timeout information for the virtual node.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          perRequest:
-                            description: An object that represents per request timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                      http:
-                        description: Specifies http timeout information for the virtual node.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          perRequest:
-                            description: An object that represents per request timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                      http2:
-                        description: Specifies http2 information for the virtual node.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          perRequest:
-                            description: An object that represents per request timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                      tcp:
-                        description: Specifies tcp timeout information for the virtual node.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                    type: object
-                  tls:
-                    description: A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.
-                    properties:
-                      certificate:
-                        description: A reference to an object that represents a listener's TLS certificate.
-                        properties:
-                          acm:
-                            description: A reference to an object that represents an AWS Certificate Manager (ACM) certificate.
-                            properties:
-                              certificateARN:
-                                description: The Amazon Resource Name (ARN) for the certificate.
-                                type: string
-                            required:
-                            - certificateARN
-                            type: object
-                          file:
-                            description: A reference to an object that represents a local file certificate.
-                            properties:
-                              certificateChain:
-                                description: The certificate chain for the certificate.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              privateKey:
-                                description: The private key for a certificate stored on the file system of the virtual node that the proxy is running on.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            required:
-                            - certificateChain
-                            - privateKey
-                            type: object
-                          sds:
-                            description: A reference to an object that represents an SDS certificate.
-                            properties:
-                              secretName:
-                                description: The certificate trust chain for a certificate issued via SDS cluster
-                                type: string
-                            required:
-                            - secretName
-                            type: object
-                        type: object
-                      mode:
-                        description: ListenerTLS mode
-                        enum:
-                        - DISABLED
-                        - PERMISSIVE
-                        - STRICT
-                        type: string
-                      validation:
-                        description: A reference to an object that represents an SDS Trust Domain
-                        properties:
-                          subjectAlternativeNames:
-                            description: Possible alternative names to consider
-                            properties:
-                              match:
-                                description: Match is a required field
-                                properties:
-                                  exact:
-                                    description: Exact is a required field
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - exact
-                                type: object
-                            required:
-                            - match
-                            type: object
-                          trust:
-                            properties:
-                              file:
-                                description: An object that represents a TLS validation context trust for a local file.
-                                properties:
-                                  certificateChain:
-                                    description: The certificate trust chain for a certificate stored on the file system of the virtual node that the proxy is running on.
-                                    maxLength: 255
-                                    minLength: 1
-                                    type: string
-                                required:
-                                - certificateChain
-                                type: object
-                              sds:
-                                description: An object that represents a TLS validation context trust for an SDS server
-                                properties:
-                                  secretName:
-                                    description: The certificate trust chain for a certificate obtained via SDS
-                                    type: string
-                                required:
-                                - secretName
-                                type: object
-                            type: object
-                        required:
-                        - trust
-                        type: object
-                    required:
-                    - certificate
-                    - mode
-                    type: object
-                required:
-                - portMapping
-                type: object
-              maxItems: 1
-              minItems: 0
-              type: array
-            logging:
-              description: The inbound and outbound access logging information for the virtual node.
-              properties:
-                accessLog:
-                  description: The access log configuration for a virtual node.
-                  properties:
-                    file:
-                      description: The file object to send virtual node access logs to.
-                      properties:
-                        path:
-                          description: The file path to write access logs to.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                      required:
-                      - path
-                      type: object
-                  type: object
-              type: object
-            meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualNode belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
-              properties:
-                name:
-                  description: Name is the name of Mesh CR
-                  type: string
-                uid:
-                  description: UID is the UID of Mesh CR
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-            podSelector:
-              description: "PodSelector selects Pods using labels to designate VirtualNode membership. This field follows standard label selector semantics: \tif present but empty, it selects all pods within namespace. \tif absent, it selects no pod."
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-            serviceDiscovery:
-              description: The service discovery information for the virtual node. Optional if there is no inbound traffic(no listeners). Mandatory if a listener is specified.
-              properties:
-                awsCloudMap:
-                  description: Specifies any AWS Cloud Map information for the virtual node.
-                  properties:
-                    attributes:
-                      description: A string map that contains attributes with values that you can use to filter instances by any custom attribute that you specified when you registered the instance
-                      items:
-                        description: AWSCloudMapInstanceAttribute refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_AwsCloudMapInstanceAttribute.html
-                        properties:
-                          key:
-                            description: The name of an AWS Cloud Map service instance attribute key.
+                          path:
+                            description: The file path to write access logs to.
                             maxLength: 255
                             minLength: 1
                             type: string
-                          value:
-                            description: The value of an AWS Cloud Map service instance attribute key.
-                            maxLength: 1024
-                            minLength: 1
-                            type: string
                         required:
-                        - key
-                        - value
+                        - path
                         type: object
-                      type: array
-                    namespaceName:
-                      description: The name of the AWS Cloud Map namespace to use.
-                      maxLength: 1024
-                      minLength: 1
-                      type: string
-                    serviceName:
-                      description: The name of the AWS Cloud Map service to use.
-                      maxLength: 1024
-                      minLength: 1
-                      type: string
-                  required:
-                  - namespaceName
-                  - serviceName
-                  type: object
-                dns:
-                  description: Specifies the DNS information for the virtual node.
-                  properties:
-                    hostname:
-                      description: Specifies the DNS service discovery hostname for the virtual node.
-                      type: string
-                    responseType:
-                      description: Choose between ENDPOINTS (strict DNS) and LOADBALANCER (logical DNS) mode in Envoy sidecar
-                      enum:
-                      - ENDPOINTS
-                      - LOADBALANCER
-                      type: string
-                  required:
-                  - hostname
-                  type: object
-              type: object
-          type: object
-        status:
-          description: VirtualNodeStatus defines the observed state of VirtualNode
-          properties:
-            conditions:
-              description: The current VirtualNode status.
-              items:
+                    type: object
+                type: object
+              meshRef:
+                description: "A reference to k8s Mesh CR that this VirtualNode belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status to another.
-                    format: date-time
+                  name:
+                    description: Name is the name of Mesh CR
                     type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of VirtualNode condition.
+                  uid:
+                    description: UID is the UID of Mesh CR
                     type: string
                 required:
-                - status
-                - type
+                - name
+                - uid
                 type: object
-              type: array
-            observedGeneration:
-              description: The generation observed by the VirtualNode controller.
-              format: int64
-              type: integer
-            virtualNodeARN:
-              description: VirtualNodeARN is the AppMesh VirtualNode object's Amazon Resource Name
-              type: string
-          type: object
-      type: object
-  version: v1beta2
-  versions:
-  - name: v1beta2
+              podSelector:
+                description: "PodSelector selects Pods using labels to designate VirtualNode membership. This field follows standard label selector semantics: \tif present but empty, it selects all pods within namespace. \tif absent, it selects no pod."
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              serviceDiscovery:
+                description: The service discovery information for the virtual node. Optional if there is no inbound traffic(no listeners). Mandatory if a listener is specified.
+                properties:
+                  awsCloudMap:
+                    description: Specifies any AWS Cloud Map information for the virtual node.
+                    properties:
+                      attributes:
+                        description: A string map that contains attributes with values that you can use to filter instances by any custom attribute that you specified when you registered the instance
+                        items:
+                          description: AWSCloudMapInstanceAttribute refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_AwsCloudMapInstanceAttribute.html
+                          properties:
+                            key:
+                              description: The name of an AWS Cloud Map service instance attribute key.
+                              maxLength: 255
+                              minLength: 1
+                              type: string
+                            value:
+                              description: The value of an AWS Cloud Map service instance attribute key.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        type: array
+                      namespaceName:
+                        description: The name of the AWS Cloud Map namespace to use.
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                      serviceName:
+                        description: The name of the AWS Cloud Map service to use.
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                    required:
+                    - namespaceName
+                    - serviceName
+                    type: object
+                  dns:
+                    description: Specifies the DNS information for the virtual node.
+                    properties:
+                      hostname:
+                        description: Specifies the DNS service discovery hostname for the virtual node.
+                        type: string
+                      responseType:
+                        description: Choose between ENDPOINTS (strict DNS) and LOADBALANCER (logical DNS) mode in Envoy sidecar
+                        enum:
+                        - ENDPOINTS
+                        - LOADBALANCER
+                        type: string
+                    required:
+                    - hostname
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualNodeStatus defines the observed state of VirtualNode
+            properties:
+              conditions:
+                description: The current VirtualNode status.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of VirtualNode condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the VirtualNode controller.
+                format: int64
+                type: integer
+              virtualNodeARN:
+                description: VirtualNodeARN is the AppMesh VirtualNode object's Amazon Resource Name
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -2261,14 +2266,6 @@ metadata:
   creationTimestamp: null
   name: virtualrouters.appmesh.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.virtualRouterARN
-    description: The AppMesh VirtualRouter object's Amazon Resource Name
-    name: ARN
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: appmesh.k8s.aws
   names:
     categories:
@@ -2278,923 +2275,928 @@ spec:
     plural: virtualrouters
     singular: virtualrouter
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VirtualRouter is the Schema for the virtualrouters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VirtualRouterSpec defines the desired state of VirtualRouter refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterSpec.html
-          properties:
-            awsName:
-              description: AWSName is the AppMesh VirtualRouter object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualRouter
-              type: string
-            listeners:
-              description: The listeners that the virtual router is expected to receive inbound traffic from
-              items:
-                description: VirtualRouterListener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterListener.html
+  versions:
+  - additionalPrinterColumns:
+    - description: The AppMesh VirtualRouter object's Amazon Resource Name
+      jsonPath: .status.virtualRouterARN
+      name: ARN
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VirtualRouter is the Schema for the virtualrouters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualRouterSpec defines the desired state of VirtualRouter refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterSpec.html
+            properties:
+              awsName:
+                description: AWSName is the AppMesh VirtualRouter object's name. If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualRouter
+                type: string
+              listeners:
+                description: The listeners that the virtual router is expected to receive inbound traffic from
+                items:
+                  description: VirtualRouterListener refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualRouterListener.html
+                  properties:
+                    portMapping:
+                      description: The port mapping information for the listener.
+                      properties:
+                        port:
+                          description: The port used for the port mapping.
+                          format: int64
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: The protocol used for the port mapping.
+                          enum:
+                          - grpc
+                          - http
+                          - http2
+                          - tcp
+                          type: string
+                      required:
+                      - port
+                      - protocol
+                      type: object
+                  required:
+                  - portMapping
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+              meshRef:
+                description: "A reference to k8s Mesh CR that this VirtualRouter belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
                 properties:
-                  portMapping:
-                    description: The port mapping information for the listener.
-                    properties:
-                      port:
-                        description: The port used for the port mapping.
-                        format: int64
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: The protocol used for the port mapping.
-                        enum:
-                        - grpc
-                        - http
-                        - http2
-                        - tcp
-                        type: string
-                    required:
-                    - port
-                    - protocol
-                    type: object
-                required:
-                - portMapping
-                type: object
-              maxItems: 1
-              minItems: 1
-              type: array
-            meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualRouter belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
-              properties:
-                name:
-                  description: Name is the name of Mesh CR
-                  type: string
-                uid:
-                  description: UID is the UID of Mesh CR
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-            routes:
-              description: The routes associated with VirtualRouter
-              items:
-                description: Route refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteSpec.html
-                properties:
-                  grpcRoute:
-                    description: An object that represents the specification of a gRPC route.
-                    properties:
-                      action:
-                        description: An object that represents the action to take if a match is determined.
-                        properties:
-                          weightedTargets:
-                            description: An object that represents the targets that traffic is routed to when a request matches the route.
-                            items:
-                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
-                              properties:
-                                virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  type: string
-                                virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  properties:
-                                    name:
-                                      description: Name is the name of VirtualNode CR
-                                      type: string
-                                    namespace:
-                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                weight:
-                                  description: The relative weight of the weighted target.
-                                  format: int64
-                                  maximum: 100
-                                  minimum: 0
-                                  type: integer
-                              required:
-                              - weight
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                        required:
-                        - weightedTargets
-                        type: object
-                      match:
-                        description: An object that represents the criteria for determining a request match.
-                        properties:
-                          metadata:
-                            description: An object that represents the data to match from the request.
-                            items:
-                              description: GRPCRouteMetadata refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcRouteMetadata.html
-                              properties:
-                                invert:
-                                  description: Specify True to match anything except the match criteria. The default value is False.
-                                  type: boolean
-                                match:
-                                  description: An object that represents the data to match from the request.
-                                  properties:
-                                    exact:
-                                      description: The value sent by the client must match the specified value exactly.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    prefix:
-                                      description: The value sent by the client must begin with the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    range:
-                                      description: An object that represents the range of values to match on
-                                      properties:
-                                        end:
-                                          description: The end of the range.
-                                          format: int64
-                                          type: integer
-                                        start:
-                                          description: The start of the range.
-                                          format: int64
-                                          type: integer
-                                      required:
-                                      - end
-                                      - start
-                                      type: object
-                                    regex:
-                                      description: The value sent by the client must include the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    suffix:
-                                      description: The value sent by the client must end with the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                  type: object
-                                name:
-                                  description: The name of the route.
-                                  maxLength: 50
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                          methodName:
-                            description: The method name to match from the request. If you specify a name, you must also specify a serviceName.
-                            maxLength: 50
-                            minLength: 1
-                            type: string
-                          serviceName:
-                            description: The fully qualified domain name for the service to match from the request.
-                            type: string
-                        type: object
-                      retryPolicy:
-                        description: An object that represents a retry policy.
-                        properties:
-                          grpcRetryEvents:
-                            items:
-                              enum:
-                              - cancelled
-                              - deadline-exceeded
-                              - internal
-                              - resource-exhausted
-                              - unavailable
-                              type: string
-                            maxItems: 5
-                            minItems: 1
-                            type: array
-                          httpRetryEvents:
-                            items:
-                              enum:
-                              - server-error
-                              - gateway-error
-                              - client-error
-                              - stream-error
-                              type: string
-                            maxItems: 25
-                            minItems: 1
-                            type: array
-                          maxRetries:
-                            description: The maximum number of retry attempts.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          perRetryTimeout:
-                            description: An object that represents a duration of time.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          tcpRetryEvents:
-                            items:
-                              enum:
-                              - connection-error
-                              type: string
-                            maxItems: 1
-                            minItems: 1
-                            type: array
-                        required:
-                        - maxRetries
-                        - perRetryTimeout
-                        type: object
-                      timeout:
-                        description: An object that represents a grpc timeout.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          perRequest:
-                            description: An object that represents per request timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                    required:
-                    - action
-                    - match
-                    type: object
-                  http2Route:
-                    description: An object that represents the specification of an HTTP/2 route.
-                    properties:
-                      action:
-                        description: An object that represents the action to take if a match is determined.
-                        properties:
-                          weightedTargets:
-                            description: An object that represents the targets that traffic is routed to when a request matches the route.
-                            items:
-                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
-                              properties:
-                                virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  type: string
-                                virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  properties:
-                                    name:
-                                      description: Name is the name of VirtualNode CR
-                                      type: string
-                                    namespace:
-                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                weight:
-                                  description: The relative weight of the weighted target.
-                                  format: int64
-                                  maximum: 100
-                                  minimum: 0
-                                  type: integer
-                              required:
-                              - weight
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                        required:
-                        - weightedTargets
-                        type: object
-                      match:
-                        description: An object that represents the criteria for determining a request match.
-                        properties:
-                          headers:
-                            description: An object that represents the client request headers to match on.
-                            items:
-                              description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
-                              properties:
-                                invert:
-                                  description: Specify True to match anything except the match criteria. The default value is False.
-                                  type: boolean
-                                match:
-                                  description: The HeaderMatchMethod object.
-                                  properties:
-                                    exact:
-                                      description: The value sent by the client must match the specified value exactly.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    prefix:
-                                      description: The value sent by the client must begin with the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    range:
-                                      description: An object that represents the range of values to match on.
-                                      properties:
-                                        end:
-                                          description: The end of the range.
-                                          format: int64
-                                          type: integer
-                                        start:
-                                          description: The start of the range.
-                                          format: int64
-                                          type: integer
-                                      required:
-                                      - end
-                                      - start
-                                      type: object
-                                    regex:
-                                      description: The value sent by the client must include the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    suffix:
-                                      description: The value sent by the client must end with the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                  type: object
-                                name:
-                                  description: A name for the HTTP header in the client request that will be matched on.
-                                  maxLength: 50
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                          method:
-                            description: The client request method to match on.
-                            enum:
-                            - CONNECT
-                            - DELETE
-                            - GET
-                            - HEAD
-                            - OPTIONS
-                            - PATCH
-                            - POST
-                            - PUT
-                            - TRACE
-                            type: string
-                          path:
-                            description: The client specified Path to match on.
-                            properties:
-                              exact:
-                                description: The value sent by the client must match the specified value exactly.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              regex:
-                                description: The value sent by the client must end with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          prefix:
-                            description: Specifies the prefix to match requests with
-                            type: string
-                          queryParameters:
-                            description: The client specified queryParameters to match on
-                            items:
-                              properties:
-                                match:
-                                  description: The HeaderMatchMethod object.
-                                  properties:
-                                    exact:
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                  type: object
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                          scheme:
-                            description: The client request scheme to match on
-                            enum:
-                            - http
-                            - https
-                            type: string
-                        type: object
-                      retryPolicy:
-                        description: An object that represents a retry policy.
-                        properties:
-                          httpRetryEvents:
-                            items:
-                              enum:
-                              - server-error
-                              - gateway-error
-                              - client-error
-                              - stream-error
-                              type: string
-                            maxItems: 25
-                            minItems: 1
-                            type: array
-                          maxRetries:
-                            description: The maximum number of retry attempts.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          perRetryTimeout:
-                            description: An object that represents a duration of time
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          tcpRetryEvents:
-                            items:
-                              enum:
-                              - connection-error
-                              type: string
-                            maxItems: 1
-                            minItems: 1
-                            type: array
-                        required:
-                        - maxRetries
-                        - perRetryTimeout
-                        type: object
-                      timeout:
-                        description: An object that represents a http timeout.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          perRequest:
-                            description: An object that represents per request timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                    required:
-                    - action
-                    - match
-                    type: object
-                  httpRoute:
-                    description: An object that represents the specification of an HTTP route.
-                    properties:
-                      action:
-                        description: An object that represents the action to take if a match is determined.
-                        properties:
-                          weightedTargets:
-                            description: An object that represents the targets that traffic is routed to when a request matches the route.
-                            items:
-                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
-                              properties:
-                                virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  type: string
-                                virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  properties:
-                                    name:
-                                      description: Name is the name of VirtualNode CR
-                                      type: string
-                                    namespace:
-                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                weight:
-                                  description: The relative weight of the weighted target.
-                                  format: int64
-                                  maximum: 100
-                                  minimum: 0
-                                  type: integer
-                              required:
-                              - weight
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                        required:
-                        - weightedTargets
-                        type: object
-                      match:
-                        description: An object that represents the criteria for determining a request match.
-                        properties:
-                          headers:
-                            description: An object that represents the client request headers to match on.
-                            items:
-                              description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
-                              properties:
-                                invert:
-                                  description: Specify True to match anything except the match criteria. The default value is False.
-                                  type: boolean
-                                match:
-                                  description: The HeaderMatchMethod object.
-                                  properties:
-                                    exact:
-                                      description: The value sent by the client must match the specified value exactly.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    prefix:
-                                      description: The value sent by the client must begin with the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    range:
-                                      description: An object that represents the range of values to match on.
-                                      properties:
-                                        end:
-                                          description: The end of the range.
-                                          format: int64
-                                          type: integer
-                                        start:
-                                          description: The start of the range.
-                                          format: int64
-                                          type: integer
-                                      required:
-                                      - end
-                                      - start
-                                      type: object
-                                    regex:
-                                      description: The value sent by the client must include the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                    suffix:
-                                      description: The value sent by the client must end with the specified characters.
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                  type: object
-                                name:
-                                  description: A name for the HTTP header in the client request that will be matched on.
-                                  maxLength: 50
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                          method:
-                            description: The client request method to match on.
-                            enum:
-                            - CONNECT
-                            - DELETE
-                            - GET
-                            - HEAD
-                            - OPTIONS
-                            - PATCH
-                            - POST
-                            - PUT
-                            - TRACE
-                            type: string
-                          path:
-                            description: The client specified Path to match on.
-                            properties:
-                              exact:
-                                description: The value sent by the client must match the specified value exactly.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              regex:
-                                description: The value sent by the client must end with the specified characters.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            type: object
-                          prefix:
-                            description: Specifies the prefix to match requests with
-                            type: string
-                          queryParameters:
-                            description: The client specified queryParameters to match on
-                            items:
-                              properties:
-                                match:
-                                  description: The HeaderMatchMethod object.
-                                  properties:
-                                    exact:
-                                      maxLength: 255
-                                      minLength: 1
-                                      type: string
-                                  type: object
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                          scheme:
-                            description: The client request scheme to match on
-                            enum:
-                            - http
-                            - https
-                            type: string
-                        type: object
-                      retryPolicy:
-                        description: An object that represents a retry policy.
-                        properties:
-                          httpRetryEvents:
-                            items:
-                              enum:
-                              - server-error
-                              - gateway-error
-                              - client-error
-                              - stream-error
-                              type: string
-                            maxItems: 25
-                            minItems: 1
-                            type: array
-                          maxRetries:
-                            description: The maximum number of retry attempts.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          perRetryTimeout:
-                            description: An object that represents a duration of time
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          tcpRetryEvents:
-                            items:
-                              enum:
-                              - connection-error
-                              type: string
-                            maxItems: 1
-                            minItems: 1
-                            type: array
-                        required:
-                        - maxRetries
-                        - perRetryTimeout
-                        type: object
-                      timeout:
-                        description: An object that represents a http timeout.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                          perRequest:
-                            description: An object that represents per request timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                    required:
-                    - action
-                    - match
-                    type: object
                   name:
-                    description: Route's name
+                    description: Name is the name of Mesh CR
                     type: string
-                  priority:
-                    description: The priority for the route.
-                    format: int64
-                    maximum: 1000
-                    minimum: 0
-                    type: integer
-                  tcpRoute:
-                    description: An object that represents the specification of a TCP route.
-                    properties:
-                      action:
-                        description: The action to take if a match is determined.
-                        properties:
-                          weightedTargets:
-                            description: An object that represents the targets that traffic is routed to when a request matches the route.
-                            items:
-                              description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
-                              properties:
-                                virtualNodeARN:
-                                  description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  type: string
-                                virtualNodeRef:
-                                  description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                                  properties:
-                                    name:
-                                      description: Name is the name of VirtualNode CR
-                                      type: string
-                                    namespace:
-                                      description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                weight:
-                                  description: The relative weight of the weighted target.
-                                  format: int64
-                                  maximum: 100
-                                  minimum: 0
-                                  type: integer
-                              required:
-                              - weight
-                              type: object
-                            maxItems: 10
-                            minItems: 1
-                            type: array
-                        required:
-                        - weightedTargets
-                        type: object
-                      timeout:
-                        description: An object that represents a tcp timeout.
-                        properties:
-                          idle:
-                            description: An object that represents idle timeout duration.
-                            properties:
-                              unit:
-                                description: A unit of time.
-                                enum:
-                                - s
-                                - ms
-                                type: string
-                              value:
-                                description: A number of time units.
-                                format: int64
-                                minimum: 0
-                                type: integer
-                            required:
-                            - unit
-                            - value
-                            type: object
-                        type: object
-                    required:
-                    - action
-                    type: object
+                  uid:
+                    description: UID is the UID of Mesh CR
+                    type: string
                 required:
                 - name
+                - uid
                 type: object
-              type: array
-          type: object
-        status:
-          description: VirtualRouterStatus defines the observed state of VirtualRouter
-          properties:
-            conditions:
-              description: The current VirtualRouter status.
-              items:
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of VirtualRouter condition.
-                    type: string
-                required:
-                - status
-                - type
+              routes:
+                description: The routes associated with VirtualRouter
+                items:
+                  description: Route refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteSpec.html
+                  properties:
+                    grpcRoute:
+                      description: An object that represents the specification of a gRPC route.
+                      properties:
+                        action:
+                          description: An object that represents the action to take if a match is determined.
+                          properties:
+                            weightedTargets:
+                              description: An object that represents the targets that traffic is routed to when a request matches the route.
+                              items:
+                                description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                                properties:
+                                  virtualNodeARN:
+                                    description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    type: string
+                                  virtualNodeRef:
+                                    description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    properties:
+                                      name:
+                                        description: Name is the name of VirtualNode CR
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  weight:
+                                    description: The relative weight of the weighted target.
+                                    format: int64
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - weight
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                          required:
+                          - weightedTargets
+                          type: object
+                        match:
+                          description: An object that represents the criteria for determining a request match.
+                          properties:
+                            metadata:
+                              description: An object that represents the data to match from the request.
+                              items:
+                                description: GRPCRouteMetadata refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_GrpcRouteMetadata.html
+                                properties:
+                                  invert:
+                                    description: Specify True to match anything except the match criteria. The default value is False.
+                                    type: boolean
+                                  match:
+                                    description: An object that represents the data to match from the request.
+                                    properties:
+                                      exact:
+                                        description: The value sent by the client must match the specified value exactly.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      prefix:
+                                        description: The value sent by the client must begin with the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      range:
+                                        description: An object that represents the range of values to match on
+                                        properties:
+                                          end:
+                                            description: The end of the range.
+                                            format: int64
+                                            type: integer
+                                          start:
+                                            description: The start of the range.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - end
+                                        - start
+                                        type: object
+                                      regex:
+                                        description: The value sent by the client must include the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      suffix:
+                                        description: The value sent by the client must end with the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                    type: object
+                                  name:
+                                    description: The name of the route.
+                                    maxLength: 50
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                            methodName:
+                              description: The method name to match from the request. If you specify a name, you must also specify a serviceName.
+                              maxLength: 50
+                              minLength: 1
+                              type: string
+                            serviceName:
+                              description: The fully qualified domain name for the service to match from the request.
+                              type: string
+                          type: object
+                        retryPolicy:
+                          description: An object that represents a retry policy.
+                          properties:
+                            grpcRetryEvents:
+                              items:
+                                enum:
+                                - cancelled
+                                - deadline-exceeded
+                                - internal
+                                - resource-exhausted
+                                - unavailable
+                                type: string
+                              maxItems: 5
+                              minItems: 1
+                              type: array
+                            httpRetryEvents:
+                              items:
+                                enum:
+                                - server-error
+                                - gateway-error
+                                - client-error
+                                - stream-error
+                                type: string
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                            maxRetries:
+                              description: The maximum number of retry attempts.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            perRetryTimeout:
+                              description: An object that represents a duration of time.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            tcpRetryEvents:
+                              items:
+                                enum:
+                                - connection-error
+                                type: string
+                              maxItems: 1
+                              minItems: 1
+                              type: array
+                          required:
+                          - maxRetries
+                          - perRetryTimeout
+                          type: object
+                        timeout:
+                          description: An object that represents a grpc timeout.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            perRequest:
+                              description: An object that represents per request timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      - match
+                      type: object
+                    http2Route:
+                      description: An object that represents the specification of an HTTP/2 route.
+                      properties:
+                        action:
+                          description: An object that represents the action to take if a match is determined.
+                          properties:
+                            weightedTargets:
+                              description: An object that represents the targets that traffic is routed to when a request matches the route.
+                              items:
+                                description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                                properties:
+                                  virtualNodeARN:
+                                    description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    type: string
+                                  virtualNodeRef:
+                                    description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    properties:
+                                      name:
+                                        description: Name is the name of VirtualNode CR
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  weight:
+                                    description: The relative weight of the weighted target.
+                                    format: int64
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - weight
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                          required:
+                          - weightedTargets
+                          type: object
+                        match:
+                          description: An object that represents the criteria for determining a request match.
+                          properties:
+                            headers:
+                              description: An object that represents the client request headers to match on.
+                              items:
+                                description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
+                                properties:
+                                  invert:
+                                    description: Specify True to match anything except the match criteria. The default value is False.
+                                    type: boolean
+                                  match:
+                                    description: The HeaderMatchMethod object.
+                                    properties:
+                                      exact:
+                                        description: The value sent by the client must match the specified value exactly.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      prefix:
+                                        description: The value sent by the client must begin with the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      range:
+                                        description: An object that represents the range of values to match on.
+                                        properties:
+                                          end:
+                                            description: The end of the range.
+                                            format: int64
+                                            type: integer
+                                          start:
+                                            description: The start of the range.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - end
+                                        - start
+                                        type: object
+                                      regex:
+                                        description: The value sent by the client must include the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      suffix:
+                                        description: The value sent by the client must end with the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                    type: object
+                                  name:
+                                    description: A name for the HTTP header in the client request that will be matched on.
+                                    maxLength: 50
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                            method:
+                              description: The client request method to match on.
+                              enum:
+                              - CONNECT
+                              - DELETE
+                              - GET
+                              - HEAD
+                              - OPTIONS
+                              - PATCH
+                              - POST
+                              - PUT
+                              - TRACE
+                              type: string
+                            path:
+                              description: The client specified Path to match on.
+                              properties:
+                                exact:
+                                  description: The value sent by the client must match the specified value exactly.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                regex:
+                                  description: The value sent by the client must end with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            prefix:
+                              description: Specifies the prefix to match requests with
+                              type: string
+                            queryParameters:
+                              description: The client specified queryParameters to match on
+                              items:
+                                description: HTTPQueryParameters refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpQueryParameter.html
+                                properties:
+                                  match:
+                                    description: The QueryMatchMethod object.
+                                    properties:
+                                      exact:
+                                        type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                            scheme:
+                              description: The client request scheme to match on
+                              enum:
+                              - http
+                              - https
+                              type: string
+                          type: object
+                        retryPolicy:
+                          description: An object that represents a retry policy.
+                          properties:
+                            httpRetryEvents:
+                              items:
+                                enum:
+                                - server-error
+                                - gateway-error
+                                - client-error
+                                - stream-error
+                                type: string
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                            maxRetries:
+                              description: The maximum number of retry attempts.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            perRetryTimeout:
+                              description: An object that represents a duration of time
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            tcpRetryEvents:
+                              items:
+                                enum:
+                                - connection-error
+                                type: string
+                              maxItems: 1
+                              minItems: 1
+                              type: array
+                          required:
+                          - maxRetries
+                          - perRetryTimeout
+                          type: object
+                        timeout:
+                          description: An object that represents a http timeout.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            perRequest:
+                              description: An object that represents per request timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      - match
+                      type: object
+                    httpRoute:
+                      description: An object that represents the specification of an HTTP route.
+                      properties:
+                        action:
+                          description: An object that represents the action to take if a match is determined.
+                          properties:
+                            weightedTargets:
+                              description: An object that represents the targets that traffic is routed to when a request matches the route.
+                              items:
+                                description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                                properties:
+                                  virtualNodeARN:
+                                    description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    type: string
+                                  virtualNodeRef:
+                                    description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    properties:
+                                      name:
+                                        description: Name is the name of VirtualNode CR
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  weight:
+                                    description: The relative weight of the weighted target.
+                                    format: int64
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - weight
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                          required:
+                          - weightedTargets
+                          type: object
+                        match:
+                          description: An object that represents the criteria for determining a request match.
+                          properties:
+                            headers:
+                              description: An object that represents the client request headers to match on.
+                              items:
+                                description: HTTPRouteHeader refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteHeader.html
+                                properties:
+                                  invert:
+                                    description: Specify True to match anything except the match criteria. The default value is False.
+                                    type: boolean
+                                  match:
+                                    description: The HeaderMatchMethod object.
+                                    properties:
+                                      exact:
+                                        description: The value sent by the client must match the specified value exactly.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      prefix:
+                                        description: The value sent by the client must begin with the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      range:
+                                        description: An object that represents the range of values to match on.
+                                        properties:
+                                          end:
+                                            description: The end of the range.
+                                            format: int64
+                                            type: integer
+                                          start:
+                                            description: The start of the range.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - end
+                                        - start
+                                        type: object
+                                      regex:
+                                        description: The value sent by the client must include the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                      suffix:
+                                        description: The value sent by the client must end with the specified characters.
+                                        maxLength: 255
+                                        minLength: 1
+                                        type: string
+                                    type: object
+                                  name:
+                                    description: A name for the HTTP header in the client request that will be matched on.
+                                    maxLength: 50
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                            method:
+                              description: The client request method to match on.
+                              enum:
+                              - CONNECT
+                              - DELETE
+                              - GET
+                              - HEAD
+                              - OPTIONS
+                              - PATCH
+                              - POST
+                              - PUT
+                              - TRACE
+                              type: string
+                            path:
+                              description: The client specified Path to match on.
+                              properties:
+                                exact:
+                                  description: The value sent by the client must match the specified value exactly.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                                regex:
+                                  description: The value sent by the client must end with the specified characters.
+                                  maxLength: 255
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            prefix:
+                              description: Specifies the prefix to match requests with
+                              type: string
+                            queryParameters:
+                              description: The client specified queryParameters to match on
+                              items:
+                                description: HTTPQueryParameters refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpQueryParameter.html
+                                properties:
+                                  match:
+                                    description: The QueryMatchMethod object.
+                                    properties:
+                                      exact:
+                                        type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                            scheme:
+                              description: The client request scheme to match on
+                              enum:
+                              - http
+                              - https
+                              type: string
+                          type: object
+                        retryPolicy:
+                          description: An object that represents a retry policy.
+                          properties:
+                            httpRetryEvents:
+                              items:
+                                enum:
+                                - server-error
+                                - gateway-error
+                                - client-error
+                                - stream-error
+                                type: string
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                            maxRetries:
+                              description: The maximum number of retry attempts.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            perRetryTimeout:
+                              description: An object that represents a duration of time
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            tcpRetryEvents:
+                              items:
+                                enum:
+                                - connection-error
+                                type: string
+                              maxItems: 1
+                              minItems: 1
+                              type: array
+                          required:
+                          - maxRetries
+                          - perRetryTimeout
+                          type: object
+                        timeout:
+                          description: An object that represents a http timeout.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                            perRequest:
+                              description: An object that represents per request timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      - match
+                      type: object
+                    name:
+                      description: Route's name
+                      type: string
+                    priority:
+                      description: The priority for the route.
+                      format: int64
+                      maximum: 1000
+                      minimum: 0
+                      type: integer
+                    tcpRoute:
+                      description: An object that represents the specification of a TCP route.
+                      properties:
+                        action:
+                          description: The action to take if a match is determined.
+                          properties:
+                            weightedTargets:
+                              description: An object that represents the targets that traffic is routed to when a request matches the route.
+                              items:
+                                description: WeightedTarget refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_WeightedTarget.html
+                                properties:
+                                  virtualNodeARN:
+                                    description: Amazon Resource Name to AppMesh VirtualNode object to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    type: string
+                                  virtualNodeRef:
+                                    description: Reference to Kubernetes VirtualNode CR in cluster to associate with the weighted target. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                                    properties:
+                                      name:
+                                        description: Name is the name of VirtualNode CR
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  weight:
+                                    description: The relative weight of the weighted target.
+                                    format: int64
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - weight
+                                type: object
+                              maxItems: 10
+                              minItems: 1
+                              type: array
+                          required:
+                          - weightedTargets
+                          type: object
+                        timeout:
+                          description: An object that represents a tcp timeout.
+                          properties:
+                            idle:
+                              description: An object that represents idle timeout duration.
+                              properties:
+                                unit:
+                                  description: A unit of time.
+                                  enum:
+                                  - s
+                                  - ms
+                                  type: string
+                                value:
+                                  description: A number of time units.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - unit
+                              - value
+                              type: object
+                          type: object
+                      required:
+                      - action
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            description: VirtualRouterStatus defines the observed state of VirtualRouter
+            properties:
+              conditions:
+                description: The current VirtualRouter status.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of VirtualRouter condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the VirtualRouter controller.
+                format: int64
+                type: integer
+              routeARNs:
+                additionalProperties:
+                  type: string
+                description: RouteARNs is a map of AppMesh Route objects' Amazon Resource Names, indexed by route name.
                 type: object
-              type: array
-            observedGeneration:
-              description: The generation observed by the VirtualRouter controller.
-              format: int64
-              type: integer
-            routeARNs:
-              additionalProperties:
+              virtualRouterARN:
+                description: VirtualRouterARN is the AppMesh VirtualRouter object's Amazon Resource Name.
                 type: string
-              description: RouteARNs is a map of AppMesh Route objects' Amazon Resource Names, indexed by route name.
-              type: object
-            virtualRouterARN:
-              description: VirtualRouterARN is the AppMesh VirtualRouter object's Amazon Resource Name.
-              type: string
-          type: object
-      type: object
-  version: v1beta2
-  versions:
-  - name: v1beta2
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -3210,14 +3212,6 @@ metadata:
   creationTimestamp: null
   name: virtualservices.appmesh.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.virtualServiceARN
-    description: The AppMesh VirtualService object's Amazon Resource Name
-    name: ARN
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: appmesh.k8s.aws
   names:
     categories:
@@ -3227,124 +3221,131 @@ spec:
     plural: virtualservices
     singular: virtualservice
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VirtualService is the Schema for the virtualservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VirtualServiceSpec defines the desired state of VirtualService refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
-          properties:
-            awsName:
-              description: AWSName is the AppMesh VirtualService object's name. If unspecified or empty, it defaults to be "${name}.${namespace}" of k8s VirtualService
-              type: string
-            meshRef:
-              description: "A reference to k8s Mesh CR that this VirtualService belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
-              properties:
-                name:
-                  description: Name is the name of Mesh CR
-                  type: string
-                uid:
-                  description: UID is the UID of Mesh CR
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-            provider:
-              description: The provider for virtual services. You can specify a single virtual node or virtual router.
-              properties:
-                virtualNode:
-                  description: The virtual node associated with a virtual service.
-                  properties:
-                    virtualNodeARN:
-                      description: Amazon Resource Name to AppMesh VirtualNode object that is acting as a service provider. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                      type: string
-                    virtualNodeRef:
-                      description: Reference to Kubernetes VirtualNode CR in cluster that is acting as a service provider. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
-                      properties:
-                        name:
-                          description: Name is the name of VirtualNode CR
-                          type: string
-                        namespace:
-                          description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  type: object
-                virtualRouter:
-                  description: The virtual router associated with a virtual service.
-                  properties:
-                    virtualRouterARN:
-                      description: Amazon Resource Name to AppMesh VirtualRouter object that is acting as a service provider. Exactly one of 'virtualRouterRef' or 'virtualRouterARN' must be specified.
-                      type: string
-                    virtualRouterRef:
-                      description: Reference to Kubernetes VirtualRouter CR in cluster that is acting as a service provider. Exactly one of 'virtualRouterRef' or 'virtualRouterARN' must be specified.
-                      properties:
-                        name:
-                          description: Name is the name of VirtualRouter CR
-                          type: string
-                        namespace:
-                          description: Namespace is the namespace of VirtualRouter CR. If unspecified, defaults to the referencing object's namespace
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  type: object
-              type: object
-          type: object
-        status:
-          description: VirtualServiceStatus defines the observed state of VirtualService
-          properties:
-            conditions:
-              description: The current VirtualService status.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The AppMesh VirtualService object's Amazon Resource Name
+      jsonPath: .status.virtualServiceARN
+      name: ARN
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VirtualService is the Schema for the virtualservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualServiceSpec defines the desired state of VirtualService refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
+            properties:
+              awsName:
+                description: AWSName is the AppMesh VirtualService object's name. If unspecified or empty, it defaults to be "${name}.${namespace}" of k8s VirtualService
+                type: string
+              meshRef:
+                description: "A reference to k8s Mesh CR that this VirtualService belongs to. The admission controller populates it using Meshes's selector, and prevents users from setting this field. \n Populated by the system. Read-only."
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status to another.
-                    format: date-time
+                  name:
+                    description: Name is the name of Mesh CR
                     type: string
-                  message:
-                    description: A human readable message indicating details about the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of VirtualService condition.
+                  uid:
+                    description: UID is the UID of Mesh CR
                     type: string
                 required:
-                - status
-                - type
+                - name
+                - uid
                 type: object
-              type: array
-            observedGeneration:
-              description: The generation observed by the VirtualService controller.
-              format: int64
-              type: integer
-            virtualServiceARN:
-              description: VirtualServiceARN is the AppMesh VirtualService object's Amazon Resource Name.
-              type: string
-          type: object
-      type: object
-  version: v1beta2
-  versions:
-  - name: v1beta2
+              provider:
+                description: The provider for virtual services. You can specify a single virtual node or virtual router.
+                properties:
+                  virtualNode:
+                    description: The virtual node associated with a virtual service.
+                    properties:
+                      virtualNodeARN:
+                        description: Amazon Resource Name to AppMesh VirtualNode object that is acting as a service provider. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                        type: string
+                      virtualNodeRef:
+                        description: Reference to Kubernetes VirtualNode CR in cluster that is acting as a service provider. Exactly one of 'virtualNodeRef' or 'virtualNodeARN' must be specified.
+                        properties:
+                          name:
+                            description: Name is the name of VirtualNode CR
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of VirtualNode CR. If unspecified, defaults to the referencing object's namespace
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  virtualRouter:
+                    description: The virtual router associated with a virtual service.
+                    properties:
+                      virtualRouterARN:
+                        description: Amazon Resource Name to AppMesh VirtualRouter object that is acting as a service provider. Exactly one of 'virtualRouterRef' or 'virtualRouterARN' must be specified.
+                        type: string
+                      virtualRouterRef:
+                        description: Reference to Kubernetes VirtualRouter CR in cluster that is acting as a service provider. Exactly one of 'virtualRouterRef' or 'virtualRouterARN' must be specified.
+                        properties:
+                          name:
+                            description: Name is the name of VirtualRouter CR
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of VirtualRouter CR. If unspecified, defaults to the referencing object's namespace
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualServiceStatus defines the observed state of VirtualService
+            properties:
+              conditions:
+                description: The current VirtualService status.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of VirtualService condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the VirtualService controller.
+                format: int64
+                type: integer
+              virtualServiceARN:
+                description: VirtualServiceARN is the AppMesh VirtualService object's Amazon Resource Name.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/stable/appmesh-controller/crds/crds.yaml
+++ b/stable/appmesh-controller/crds/crds.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -645,7 +645,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -783,7 +783,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1349,7 +1349,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2253,7 +2253,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -3202,7 +3202,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION

### Issue

https://github.com/aws/eks-charts/issues/560

### Description of changes

Change appmesh-controller  CRDs from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` ahead of its [deprecation in 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122) 

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ X] Manually tested. Describe what testing was done in the testing section below
- [ X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Ran `make verify` command for the whole repo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
