### PR TITLE
aws-calico: Add probe timeout for calico-node daemon-set

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.7
+version: 0.3.8
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -115,12 +115,14 @@ spec:
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
+            timeoutSeconds: 5
           readinessProbe:
             exec:
               command:
                 - /bin/calico-node
                 - -felix-ready
             periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.calico.node.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
### Issue

#574

### Description of changes

Add probe timeout for daemon-set.
I'd be alternatively totally fine to make the probe section configurable via values.

### Checklist
- [ / ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ x ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ x ] Manually tested. Describe what testing was done in the testing section below
- [ x ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually added the timeoutSeconds to the deployed DaemonSet resource. This solved the problem of crash looping pods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
