### PR TITLE
Use stable RBAC API on aws-for-fluent-bit

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.11
+version: 0.1.12
 appVersion: 2.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/templates/clusterrole.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "aws-for-fluent-bit.fullname" . }}

--- a/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "aws-for-fluent-bit.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Majid Azimi <s.azimigehraz@reply.de>

### Issue

Using fluent bit chart on modern EKS clusters shows a warning:

`helm.cmd.stderr cmdutil/cmdutil.go:67 W0816 21:07:38.017197 6228 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole`

### Description of changes

Switched to stable API `rbac.authorization.k8s.io/v1`

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I tested on a EKS cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
