### PR TITLE
Add cni-metrics-helper as a separate chart

### DIFF
--- a/stable/cni-metrics-helper/.helmignore
+++ b/stable/cni-metrics-helper/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: cni-metrics-helper
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: v1.9.0

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -1,0 +1,43 @@
+# AWS VPC CNI Metrics Helper
+
+This chart installs the AWS CNI Metrics Helper: https://github.com/aws/amazon-vpc-cni-k8s
+
+## Prerequisites
+
+- Kubernetes 1.11+ running on AWS
+
+## Installing the Chart
+
+First add the EKS repository to Helm:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+To install the chart with the release name `cni-metrics-helper` and default configuration:
+
+```shell
+$ helm install --name cni-metrics-helper --namespace kube-system eks/aws-vpc-cni
+```
+
+## Configuration
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter               | Description                                             | Default                             |
+| ------------------------|---------------------------------------------------------|-------------------------------------|
+| `env`                   | List of environment variables.                          | (see `values.yaml`)                 |
+| `fullnameOverride`      | Override the fullname of the chart                      | `cni-metrics-helper`                |
+| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
+| `image.tag`             | Image tag                                               | `v1.8.0`                            |
+| `image.override`        | A custom docker image to use                            | `nil`                               |
+| `nameOverride`          | Override the name of the chart                          | `cni-metrics-helper`                |
+| `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
+| `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```shell
+$ helm install --name cni-metrics-helper --namespace kube-system eks/aws-vpc-cni --values values.yaml
+```

--- a/stable/cni-metrics-helper/templates/NOTES.txt
+++ b/stable/cni-metrics-helper/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+
+kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cni-metrics-helper.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/cni-metrics-helper/templates/_helpers.tpl
+++ b/stable/cni-metrics-helper/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cni-metrics-helper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cni-metrics-helper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cni-metrics-helper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cni-metrics-helper.labels" -}}
+helm.sh/chart: {{ include "cni-metrics-helper.chart" . }}
+{{ include "cni-metrics-helper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cni-metrics-helper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cni-metrics-helper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cni-metrics-helper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cni-metrics-helper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/cni-metrics-helper/templates/clusterrole.yaml
+++ b/stable/cni-metrics-helper/templates/clusterrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - pods/proxy
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]

--- a/stable/cni-metrics-helper/templates/clusterrolebinding.yaml
+++ b/stable/cni-metrics-helper/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cni-metrics-helper.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/stable/cni-metrics-helper/templates/deployment.yaml
+++ b/stable/cni-metrics-helper/templates/deployment.yaml
@@ -1,0 +1,25 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cni-metrics-helper
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cni-metrics-helper
+  template:
+    metadata:
+      labels:
+        k8s-app: cni-metrics-helper
+    spec:
+      containers:
+      - env:
+{{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+{{- end }}
+        name: cni-metrics-helper
+        image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.image.region }}.amazonaws.com/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
+      serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }} 

--- a/stable/cni-metrics-helper/templates/serviceaccount.yaml
+++ b/stable/cni-metrics-helper/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+{{- end -}}

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -1,0 +1,23 @@
+# This default name override is to maintain backwards compatability with
+# existing naming
+nameOverride: cni-metrics-helper
+
+image:
+  region: us-west-2
+  tag: v1.8.0
+  # Set to use custom image
+  # override: "repo/org/image:tag"
+
+env:
+  USE_CLOUDWATCH: "true"
+
+fullnameOverride: "cni-metrics-helper"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  


### PR DESCRIPTION
Signed-off-by: Majid Azimi <s.azimigehraz@reply.de>

### Issue

There is currently an inactive [PR ](https://github.com/aws/eks-charts/pull/169) to merge `cni-metrics-helper` into `aws-vpc-cni` chart. However it has introduced some custom templates that is not available in upstream which makes it hard to constantly pull changes from upstream.

### Description of changes

This PR add `cni-metrics-helper` as a separate chart. It is a copy/paste of upstream chart (master branch) which makes it pretty easy to constantly pull upstream changes.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

This is a copy paste of upstream chart. Not much testing is needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
