### PR TITLE
aws-cloudwatch-metrics - Allow configuration to be configurable

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.5
+version: 0.0.6
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -26,6 +26,7 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `image.tag` | Image tag to deploy | `1.247345.36b249270`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
-| `serviceAccount.create` | Whether a new service account should be created | `true` | 
-| `serviceAccount.name` | Service account to be used | | 
-| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
+| `serviceAccount.name` | Service account to be used | |
+| `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` |
+| `agentConfig` | The config to pass to the agent | See `values.yaml` |

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -6,14 +6,4 @@ metadata:
     {{- include "aws-cloudwatch-metrics.labels" . | nindent 4 }}
 data:
   cwagentconfig.json: |
-    {
-      "logs": {
-        "metrics_collected": {
-          "kubernetes": {
-            "cluster_name": "{{ .Values.clusterName }}",
-            "metrics_collection_interval": 60
-          }
-        },
-        "force_flush_interval": 5
-      }
-    }
+{{ .Values.agentConfig | indent 4 }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -18,3 +18,16 @@ serviceAccount:
   name:
 
 hostNetwork: false
+
+agentConfig: |
+  {
+    "logs": {
+      "metrics_collected": {
+        "kubernetes": {
+          "cluster_name": "{{ .Values.clusterName }}",
+          "metrics_collection_interval": 60
+        }
+      },
+      "force_flush_interval": 5
+    }
+  }


### PR DESCRIPTION
### Issue

N/A

### Description of changes

We need to set the 'endpoint_override' parameter in the config.  Instead of
allowing a single config option to be set it makes sense to allow the entire
configuration to be overridden.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually templated and output verified by eye.  Output not applied to a cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
