### PR TITLE
[aws-for-fluent-bit] Make it possible to overwrite index

### DIFF
--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -173,6 +173,9 @@ data:
         {{- if .Values.elasticsearch.replaceDots }}
         Replace_Dots    {{ .Values.elasticsearch.replaceDots }}
         {{- end }}
+        {{- if .Values.indexName }}
+        Index           {{ .Values.indexName }}
+        {{- end }}
 {{- end }}
 
 {{- if .Values.extraOutputs }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -106,6 +106,7 @@ elasticsearch:
   port: "443"
   retryLimit: 6
   replaceDots: "On"
+  indexName: "fluent-bit"
 
 # extraOutputs: |
 #   [OUTPUT]


### PR DESCRIPTION
### Description of changes

Make it possible to overwrite the index. Right now it always points to "fluent-bit": https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

* Set indexName to some value like "weblogs-00001". 
* Output for ES will be written to weblogs-00001

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
