### PR TITLE
aws-load-balancer-controller: Add app.kubernetes.io/component label to the service account

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.2.7
+version: 1.2.8
 appVersion: v2.2.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/stable/aws-load-balancer-controller/templates/_helpers.tpl
@@ -59,6 +59,7 @@ Selector labels
 {{- define "aws-load-balancer-controller.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "aws-load-balancer-controller.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: controller
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Issue

#518

### Description of changes

The ServiceAccount created by the `aws-load-balancer-controller` helm chart doesn't work without the `app.kubernetes.io/component: controller` label. As evidenced by the documentation at [AWS EKS User Guide][1] (This is the [relevant part][2]).

[1]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
[2]: https://user-images.githubusercontent.com/318668/133919861-4af64ca5-0a98-40e2-8369-eade670be0ce.png


### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
N/A
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
