### PR TITLE
[aws-cloudwatch-metrics] add tolerations, nodeSelector, affinity

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.5
+version: 0.0.6
 appVersion: "1.247345"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -29,3 +29,6 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `serviceAccount.create` | Whether a new service account should be created | `true` | 
 | `serviceAccount.name` | Service account to be used | | 
 | `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 
+| `nodeSelector` | Node labels for pod assignment	 | {} | 
+| `tolerations` | Optional deployment tolerations	 | {} | 
+| `annotations` | Optional pod annotations	 | {} | 

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -76,3 +76,15 @@ spec:
         hostPath:
           path: /dev/disk/
       terminationGracePeriodSeconds: 60
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -18,3 +18,9 @@ serviceAccount:
   name:
 
 hostNetwork: false
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
[aws-cloudwatch-metrics] add node affinity to the chart #427
currently, aws-cloudwatch-metrics chart do not support nodeSelector, tolerations, affinity.

### Description of changes

<!-- Please explain the changes you made here. -->
added tolerations, affinity, nodeSelector options

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
it tested by eks cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
