### PR TITLE
[aws-for-fluent-bit] Added support for hostNetwork

### DIFF
--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -19,6 +19,8 @@ service:
   #       Name   logfmt
   #       Format logfmt
 
+hostNetwork: false
+
 input:
   tag: "kube.*"
   path: "/var/log/containers/*.log"


### PR DESCRIPTION
Add support for running pods in host network to avoid NAT of the logging traffic.

Resolves #607 