### PR TITLE
[aws-calico] Fix Typha Autoscaler Pod Annotations Nesting

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.8
+version: 0.3.9
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/deployment.yaml
+++ b/stable/aws-calico/templates/deployment.yaml
@@ -117,9 +117,9 @@ spec:
         {{- if .Values.calico.typha_autoscaler.podLabels }}
 {{ toYaml .Values.calico.typha_autoscaler.podLabels | indent 8 }}
         {{- end }}
-        {{- with .Values.calico.typha_autoscaler.podAnnotations }}
-        annotations: {{- toYaml . | nindent 10 }}
-        {{- end }}
+      {{- with .Values.calico.typha_autoscaler.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:


### PR DESCRIPTION
### Issue

Currently an error is being thrown if you try to a add annotations to the Typha Autoscaler deployment

**values.yaml**
```
calico:
  typha_autoscaler:
    podAnnotations:
      foo: "bar"
```
Error
```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.metadata.labels.annotations): invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels: got "map", expected "string"
```

### Description of changes

The error is thrown because the annotation nesting depth is one level too deep. This change ensures `annotations` is at the same depth as `labels`.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- Using the above `values.yaml` example, invoking `helm template aws-calico ./stable/aws-calico -f path/to/values.yaml` produces properly nested annotations
- Tested a `helm upgrade` on a cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
