### PR TITLE
Add RBAC for endpointslices

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.9
+version: 0.3.10
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/rbac.yaml
+++ b/stable/aws-calico/templates/rbac.yaml
@@ -15,6 +15,14 @@ rules:
       - configmaps
     verbs:
       - get
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch 
+      - list
   - apiGroups: [""]
     resources:
       - endpoints


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

`eks-charts/aws-calico` on EKS 1.21 fails with error `connection is unauthorized: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope` 

### Description of changes
- Updated ClusterRole with permissions to endpointslices API 

<!-- Please explain the changes you made here. -->

### Checklist
- [/] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- Clone forked repository to local machine (that have kubectl, helm installed)
- run below command to install local helm chart on EKS Cluster 1.21

```
helm upgrade --install --recreate-pods --force aws-calico --namespace kube-system aws-calico/
```
- Validate changes for ClusterRole and calico-node, calico-typha with "Running" status

```
$ kubectl get clusterroles calico-node -o yaml | grep -i endpoint
  - endpointslices
  - endpoints
  - hostendpoints


$ kubectl get pods -n kube-system | grep -i calico
calico-node-8kgtj                                     0/1     Running   0          49s
calico-node-f2vqb                                     0/1     Running   0          49s
calico-typha-f7c4d6788-mgzk8                          1/1     Running   0          48s
calico-typha-horizontal-autoscaler-59b7454cd5-46nr5   1/1     Running   0          48s
```

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
