### PR TITLE
[aws-load-balancer-controller] Add IngressClass

### DIFF
--- a/stable/aws-load-balancer-controller/templates/ingressclass.yaml
+++ b/stable/aws-load-balancer-controller/templates/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ .Values.ingressClass }}
+spec:
+  controller: ingress.k8s.aws/alb


### PR DESCRIPTION
### Issue

Current helm code has "ingressClass: alb" in values.yaml, but don't create the ingressClass. I think it would be convenient to create ingress Class here, instead of forcing customers to create they own.

### Description of changes

Add helm template to create IngressClass.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Deployed on stage environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
