### PR TITLE
Include resources in init container for aws-vpc-cni chart

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.10
+version: 1.1.11
 appVersion: "v1.9.3"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters for this chart and their d
 | `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |
 | `init.image.override`   | A custom docker image to use                            | `nil`                               |
 | `init.env`              | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
+| `init.resources`        | Resources for the init containers                       | `{}`                                |
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -46,8 +46,10 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
 {{- end }}
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         securityContext:
-          {{- toYaml .Values.init.securityContext | nindent 12 }}
+          {{- toYaml .Values.init.securityContext | nindent 10 }}
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -17,6 +17,7 @@ init:
     DISABLE_TCP_EARLY_DEMUX: "false"
   securityContext:
     privileged: true
+  resources: {}
 
 image:
   region: us-west-2


### PR DESCRIPTION
### Issue
We wanted to configure `aws-node` pods as Guaranteed following instructions present in https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/ in order to avoid system critical pods to be evicted (more details present in https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#evicting-end-user-pods).

However, as indicated in `quality-service-pod` page:
>For a Pod to be given a QoS class of Guaranteed:

>Every Container in the Pod must have a memory limit and a memory request.
>For every Container in the Pod, the memory limit must equal the memory request.
>Every Container in the Pod must have a CPU limit and a CPU request.
>For every Container in the Pod, the CPU limit must equal the CPU request.
>These restrictions apply to init containers and app containers equally.

This means that we should configure `resources` in both, init and containers in pods. However, current chart version does not support this configuration.

### Description of changes
* Added init resources. It's retro-compatible, and it will not change current resources behaviour (as it only adds an empty dict)
* Fixed indent spaces on `init.securityContext`

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Tested using `helm template` and also deploying to our testing environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
