### PR TITLE
[aws-for-fluent-bit] Add `serviceAccount.annotations` parameter to README

### DIFF
--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -35,6 +35,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
+| `serviceAccount.annotations` | Optional service account annotations | `{}` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
 | `service.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/issues/395

### Description of changes

Updated README.md with the following changes:
- Removed duplicate `serviceAccount.create` parameter from the Configuration section
- Added `serviceAccount.annotations` parameter to the Configuration section to reflect the availability of this, ref. https://github.com/aws/eks-charts/blob/master/stable/aws-for-fluent-bit/templates/serviceaccount.yaml#L9-L12

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

This functionality already exists, so I verified that it works with:

```sh
helm upgrade --install aws-for-fluent-bit eks/aws-for-fluent-bit \
    --namespace kube-system \
    --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="dummy-role-arn"
```

And then:

```sh
$ kubectl get serviceaccount aws-for-fluent-bit -n kube-system -o yaml | head -n5
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: dummy-role-arn
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
