### PR TITLE
[aws-calico] Switch from a hardcoded value to a templated service name on the daemonset

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.10
+version: 0.3.11
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -70,7 +70,7 @@ spec:
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: FELIX_TYPHAK8SSERVICENAME
-              value: "calico-typha"
+              value: "{{ include "aws-calico.fullname" . }}-typha"
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"


### PR DESCRIPTION
[aws-calico] Switch from a hardcoded value to a templated service name on the daemonset

### Issue
Using any other fullnameOverride other than 'calico' would break the reference from the node daemonset as it is a hardcoded string

### Description of changes

Switch from a hardcoded value to a templated service name for FELIX_TYPHAK8SSERVICENAME referenced by the calico node daemonset

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
