### PR TITLE
Update default App Mesh Proxy Route Manager image version to v4-prod

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -39,7 +39,7 @@ sidecar:
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
-    tag: v3-prod
+    tag: v4-prod
 
 xray:
   image:

--- a/stable/appmesh-inject/Chart.yaml
+++ b/stable/appmesh-inject/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-inject
 description: App Mesh Inject Helm chart for Kubernetes
-version: 0.14.8
+version: 0.14.9
 appVersion: 0.5.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-inject/values.yaml
+++ b/stable/appmesh-inject/values.yaml
@@ -24,7 +24,7 @@ sidecar:
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
-    tag: v3-prod
+    tag: v4-prod
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Description of changes:
Update Default App Mesh Proxy Route Manager Image version to v3-prod to fix above issue

### Checklist
- [n] Added/modified documentation as required (such as the `README.md` for modified charts)
- [y] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [y] Manually tested. Describe what testing was done in the testing section below
- [y] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually tested EKS walkthrough to confirm this new v4-prod image is working as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
