### PR TITLE
Updating Without-IRSA controller installation instructions

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -144,9 +144,9 @@ Use below command to download the policy if not already
 curl -o envoy-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/envoy-iam-policy.json
 ```
 
-Apply the IAM policy directly to the worker nodes by replacing the `ROLE_NAME` and `<policy-filename>` in below command:
+Apply the IAM policy directly to the worker nodes by replacing the `ROLE_NAME`, `<policy-name>`, and `<policy-filename>` in below command:
 ```sh
-aws iam put-role-policy --role-name $ROLE_NAME --policy-name AWSAppMeshEnvoyIAMPolicy --policy-document file://<policy-filename>
+aws iam put-role-policy --role-name $ROLE_NAME --policy-name <policy-name> --policy-document file://<policy-filename>
 ```
 
 Deploy appmesh-controller

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -128,13 +128,13 @@ https://github.com/aws/aws-app-mesh-examples/blob/5a2d04227593d292d52e5e2ca638d8
 
 #### Without IRSA   
 If not setting up IAM role for service account, apply the IAM policies manually to your eks worker nodes. 
-**Note:** You can use the service account for controller iam policy from above steps, but directly apply the envoy iam policy to the worker nodes.
+**Note:** You can use the service account for controller iam policy from above steps or directly apply the controller iam policy to the worker nodes as you would for the envoy iam policy.
 
 Controller IAM policy
 - https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
 Use below command to download the policy if not already
 ```sh
-curl -o envoy-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
+curl -o controller-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
 ```
 
 Envoy IAM policy

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -127,13 +127,27 @@ https://github.com/aws/aws-app-mesh-examples/blob/5a2d04227593d292d52e5e2ca638d8
 ``` 
 
 #### Without IRSA   
-If not setting up IAM role for service account, apply the IAM policies manually to your worker nodes:
+If not setting up IAM role for service account, apply the IAM policies manually to your eks worker nodes. 
+**Note:** You can use the service account for controller iam policy from above steps, but directly apply the envoy iam policy to the worker nodes.
 
 Controller IAM policy
 - https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
+Use below command to download the policy if not already
+```sh
+curl -o envoy-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
+```
 
 Envoy IAM policy
 - https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/envoy-iam-policy.json  
+Use below command to download the policy if not already
+```sh
+curl -o envoy-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/envoy-iam-policy.json
+```
+
+Apply the IAM policy directly to the worker nodes by replacing the `ROLE_NAME` and `<policy-filename>` in below command:
+```sh
+aws iam put-role-policy --role-name $ROLE_NAME --policy-name AWSAppMeshEnvoyIAMPolicy --policy-document file://<policy-filename>
+```
 
 Deploy appmesh-controller
 ```sh


### PR DESCRIPTION
### Issue

Some of the appmesh controller installation Instructions are not clear for the following:
- why the controller iam policy in without-irsa section needs to be applied separately when already using service account from earlier steps while installing the appmesh controller
- How to apply the iam policies to the eks worker nodes

### Description of changes

- Adding commands to download and apply respective IAM policies directly to the worker nodes
- Specifying that customer can use service account for controller iam policy and directly apply the envoy iam policy to the worker nodes

### Checklist
- [Y] Added/modified documentation as required (such as the `README.md` for modified charts)
- [N/A] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [N/A] Manually tested. Describe what testing was done in the testing section below
- [Y] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
