### PR TITLE
Add charts/ to gitignore so that dependency-update works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 
 .idea
 *.iml
+charts/


### PR DESCRIPTION
### Issue
https://app.circleci.com/pipelines/github/aws/eks-charts/1236/workflows/e1c6d338-130b-43c9-a65e-0e95f2d6e782/jobs/3000


### Description of changes

 - Add `charts/` to gitignore so that dependency-update works when packaging charts and switching branches to publish them.


### Testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
