### PR TITLE
Update csi-secrets-store-provider-aws version

### DIFF
--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-aws
-version: 0.0.1
+version: 0.0.2
 appVersion: 1.0.r2
 kubeVersion: ">=1.17.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster.

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | --- | --- | --- |
 | `imagePullSecrets` | Secrets to be used when pulling images | `[]` |
 | `image.repository` | Image repository | `public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws` |
-| `image.pullPolicy` | Image pull policy | `Always` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `image.tag`| Image tag | `1.0.r2-2021.08.13.20.34-linux-amd64` |
 | `nodeSelector` | Node Selector for the daemonset on nodes | `{}` |
 | `tolerations` | Tolerations for the daemonset on nodes  | `[]` |

--- a/stable/csi-secrets-store-provider-aws/values.yaml
+++ b/stable/csi-secrets-store-provider-aws/values.yaml
@@ -3,7 +3,7 @@ imagePullSecrets: []
 
 image:
   repository: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws
-  tag: 1.0.r1-10-g1942553-2021.06.04.00.07-linux-amd64
+  tag: 1.0.r2-2021.08.13.20.34-linux-amd64
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
### Description of changes

* Update the image tag to point to the R2 release
* Fix the docs to accurately reflect the ImagePullPolicy default

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Verified that the generated k8s resources looked correct.
