### PR TITLE
Fix configmap generation when using extra option

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.11
+version: 0.1.12
 appVersion: 2.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
 version: 0.1.12
-appVersion: 2.13.0
+appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
         Refresh_Interval  {{ .Values.input.refreshInterval }}
 
 {{- if .Values.extraInputs }}
-{{ .Values.extraInputs | indent 4}}
+{{ .Values.extraInputs | indent 8}}
 {{- end }}
 
     [FILTER]
@@ -43,7 +43,7 @@ data:
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
 
 {{- if .Values.extraFilters }}
-{{ .Values.extraFilters | indent 4}}
+{{ .Values.extraFilters | indent 8}}
 {{- end }}
 
 {{- if .Values.cloudWatch.enabled }}
@@ -176,7 +176,7 @@ data:
 {{- end }}
 
 {{- if .Values.extraOutputs }}
-{{ .Values.extraOutputs | indent 4}}
+{{ .Values.extraOutputs | indent 8}}
 {{- end }}
 
 

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -15,7 +15,6 @@ service:
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
   # extraParsers: |
-  #   [PARSER]
   #       Name   logfmt
   #       Format logfmt
 
@@ -30,7 +29,6 @@ input:
   refreshInterval: 10
 
 # extraInputs: |
-#   [INPUT]
 #       Name         winlog
 #       Channels     Setup,Windows PowerShell
 #       Interval_Sec 1
@@ -46,7 +44,6 @@ filter:
   k8sLoggingExclude: "On"
 
 # extraFilters: |
-#   [FILTER]
 #       Name   grep
 #       Match  *
 #       Exclude log lvl=debug*
@@ -108,7 +105,6 @@ elasticsearch:
   replaceDots: "On"
 
 # extraOutputs: |
-#   [OUTPUT]
 #     Name file
 #     Format template
 #     Template {time} used={Mem.used} free={Mem.free} total={Mem.total}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: amazon/aws-for-fluent-bit
-  tag: 2.13.0
+  tag: 2.21.5
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/issues/657

### Description of changes
When you want to use extra `[FILTER]` `[INPUT]` and `[OUTPUT]`  options it is confusing in comments to leave the title itself. See details and examples in https://github.com/aws/eks-charts/issues/657

That's why I want to propose a PR to indent from 4 to 8, any extra option and to remove the block configuration title `[FILTER]` `[INPUT]` and `[OUTPUT]` in comments in values file. 

The only block within I didn't try it is the PARSER so that's why I don't submit any change for this one (but maybe it is needed too).

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested locally with helm template command and on EKS cluster
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I apply it locally and it works, my `values.yaml` file:

```
filter: 
  match: "kube.*"
  kubeURL: "https://kubernetes.default.svc.cluster.local:443"
  mergeLog: "On"
  mergeLogKey: "data"
  keepLog: "On"
  k8sLoggingParser: "On"
  k8sLoggingExclude: "On"

extraFilters: |
   DNS_Retries         3
   DNS_Wait_Time       10
```

Command:
```
helm --debug template -s templates/configmap.yaml aws-for-fluent-bit  aws-for-fluent-bit -f values.yaml
```

Output:
```
    [FILTER]
        Name                kubernetes
        Match               kube.*
        Kube_URL            https://kubernetes.default.svc.cluster.local:443
        Merge_Log           On
        Merge_Log_Key       data
        Keep_Log            On
        K8S-Logging.Parser  On
        K8S-Logging.Exclude On
        DNS_Retries         3
        DNS_Wait_Time       10
```

**I deploy it on my EKS clusters and it works.**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
