### PR TITLE
[appmesh-jaeger] bump jaeger version to 1.29

### DIFF
--- a/stable/appmesh-jaeger/Chart.yaml
+++ b/stable/appmesh-jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-jaeger
 description: App Mesh Jaeger Helm chart for Kubernetes
-version: 1.0.2
-appVersion: 1.19.0
+version: 1.0.3
+appVersion: 1.29.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-jaeger/README.md
+++ b/stable/appmesh-jaeger/README.md
@@ -44,7 +44,7 @@ The [configuration](#configuration) section lists the parameters that can be con
 To uninstall/delete the `appmesh-jaeger` deployment:
 
 ```console
-helm delete --purge appmesh-jaeger
+helm delete appmesh-jaeger -n appmesh-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/stable/appmesh-jaeger/templates/deployment.yaml
+++ b/stable/appmesh-jaeger/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           env:
             - name: MEMORY_MAX_TRACES
               value: "{{ .Values.memory.maxTraces }}"
-            - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            - name: COLLECTOR_ZIPKIN_HOST_PORT
               value: "9411"
             - name: BADGER_EPHEMERAL
               value: "false"

--- a/stable/appmesh-jaeger/values.yaml
+++ b/stable/appmesh-jaeger/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: jaegertracing/all-in-one
-  tag: 1.19
+  tag: 1.29
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
### Description of changes

For v1.29 to work we replace env variable `COLLECTOR_ZIPKIN_HTTP_PORT` (deprecated) with `COLLECTOR_ZIPKIN_HOST_PORT` as this deprecated field `collector.zipkin.http-port` was removed in jaegertracing [release v1.22](https://github.com/jaegertracing/jaeger/releases/tag/v1.22.0). This change is to make sure that Jaeger collector continue to listen for Zipkin HTTP traffic on port 9411. If not we would hit the error show below from jaegertracing/all-in-one v1.22 onwards.

```
+ {"level":"info","ts":1640841770.2606688,"caller":"server/zipkin.go:48","msg":"Not listening for Zipkin HTTP traffic, port not configured"}
```

[1] https://www.jaegertracing.io/docs/1.29/getting-started/
[2] https://www.jaegertracing.io/docs/1.29/deployment/

### Issue
https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/536

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I manually verified that Jaeger App Mesh [walkthrough](https://github.com/aws/aws-app-mesh-examples/blob/main/walkthroughs/eks/o11y-jaeger.md) works with changes made in this PR.


&nbsp;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
