### PR TITLE
Change default aws-for-fluent-bit image value to a newer one

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.11
+version: 0.1.12
 appVersion: 2.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
 version: 0.1.12
-appVersion: 2.13.0
+appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -30,7 +30,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | - | - | - | -
 | `global.namespaceOverride` | Override the deployment namespace | Not set (`Release.Namespace`) |
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
-| `image.tag` | Image tag to deploy | `2.12.0`
+| `image.tag` | Image tag to deploy | `2.21.5`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: amazon/aws-for-fluent-bit
-  tag: 2.13.0
+  tag: 2.21.5
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
### Description of changes

The current default image for `aws-for-fluent-bit` contains 95 security vulnerabilities, including 7 critical.

See the output of an image scanning tool against this image here:
```
amazon/aws-for-fluent-bit:2.13.0 (amazon 2 (Karoo))
===================================================
Total: 95 (UNKNOWN: 0, LOW: 2, MEDIUM: 84, HIGH: 2, CRITICAL: 7)

+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
|        LIBRARY         | VULNERABILITY ID | SEVERITY |   INSTALLED VERSION   |     FIXED VERSION      |                 TITLE                 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| bzip2-libs             | CVE-2019-12900   | LOW      | 1.0.6-13.amzn2.0.2    | 1.0.6-13.amzn2.0.3     | bzip2: out-of-bounds write            |
|                        |                  |          |                       |                        | in function BZ2_decompress            |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-12900 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| curl                   | CVE-2020-8231    | MEDIUM   | 7.61.1-12.amzn2.0.2   | 7.76.1-4.amzn2.0.1     | curl: Expired pointer                 |
|                        |                  |          |                       |                        | dereference via multi API with        |
|                        |                  |          |                       |                        | CURLOPT_CONNECT_ONLY option set       |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8231  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-8284    |          |                       |                        | curl: FTP PASV command                |
|                        |                  |          |                       |                        | response can cause curl               |
|                        |                  |          |                       |                        | to connect to arbitrary...            |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8284  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-8285    |          |                       |                        | curl: Malicious FTP server can        |
|                        |                  |          |                       |                        | trigger stack overflow when           |
|                        |                  |          |                       |                        | CURLOPT_CHUNK_BGN_FUNCTION            |
|                        |                  |          |                       |                        | is used...                            |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8285  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-8286    |          |                       |                        | curl: Inferior OCSP verification      |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8286  |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-22876   |          |                       | 7.61.1-12.amzn2.0.4    | curl: Leak of authentication          |
|                        |                  |          |                       |                        | credentials in URL                    |
|                        |                  |          |                       |                        | via automatic Referer                 |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22876 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-22898   |          |                       | 7.76.1-7.amzn2.0.2     | curl: TELNET stack                    |
|                        |                  |          |                       |                        | contents disclosure                   |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22898 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22922   |          |                       |                        | curl: Content not matching hash       |
|                        |                  |          |                       |                        | in Metalink is not being discarded    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22922 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22923   |          |                       |                        | curl: Metalink download               |
|                        |                  |          |                       |                        | sends credentials                     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22923 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22924   |          |                       |                        | curl: Bad connection reuse            |
|                        |                  |          |                       |                        | due to flawed path name checks        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22924 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22925   |          |                       |                        | curl: Incorrect fix for               |
|                        |                  |          |                       |                        | CVE-2021-22898 TELNET                 |
|                        |                  |          |                       |                        | stack contents disclosure             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22925 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-22945   |          |                       | 7.79.1-1.amzn2.0.1     | curl: use-after-free and              |
|                        |                  |          |                       |                        | double-free in MQTT sending           |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22945 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22946   |          |                       |                        | curl: Requirement to use              |
|                        |                  |          |                       |                        | TLS not properly enforced             |
|                        |                  |          |                       |                        | for IMAP, POP3, and...                |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22946 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22947   |          |                       |                        | curl: Server responses                |
|                        |                  |          |                       |                        | received before STARTTLS              |
|                        |                  |          |                       |                        | processed after TLS handshake         |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22947 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| glib2                  | CVE-2021-27219   | HIGH     | 2.56.1-7.amzn2.0.1    | 2.56.1-9.amzn2.0.1     | glib: integer overflow in             |
|                        |                  |          |                       |                        | g_bytes_new function on               |
|                        |                  |          |                       |                        | 64-bit platforms due to an...         |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-27219 |
+                        +------------------+----------+                       +------------------------+---------------------------------------+
|                        | CVE-2021-27218   | MEDIUM   |                       | 2.56.1-9.amzn2.0.2     | glib: integer overflow in             |
|                        |                  |          |                       |                        | g_byte_array_new_take function        |
|                        |                  |          |                       |                        | when called with a buffer of...       |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-27218 |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| glibc                  | CVE-2019-9169    |          | 2.26-43.amzn2         | 2.26-47.amzn2          | glibc: regular-expression             |
|                        |                  |          |                       |                        | match via proceed_next_node           |
|                        |                  |          |                       |                        | in posix/regexec.c leads to           |
|                        |                  |          |                       |                        | heap-based buffer over-read...        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-9169  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-27618   |          |                       |                        | glibc: iconv when processing          |
|                        |                  |          |                       |                        | invalid multi-byte input              |
|                        |                  |          |                       |                        | sequences fails to advance the...     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-27618 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-35942   |          |                       | 2.26-53.amzn2          | glibc: Arbitrary read in wordexp()    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-35942 |
+------------------------+------------------+          +                       +------------------------+---------------------------------------+
| glibc-common           | CVE-2019-9169    |          |                       | 2.26-47.amzn2          | glibc: regular-expression             |
|                        |                  |          |                       |                        | match via proceed_next_node           |
|                        |                  |          |                       |                        | in posix/regexec.c leads to           |
|                        |                  |          |                       |                        | heap-based buffer over-read...        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-9169  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-27618   |          |                       |                        | glibc: iconv when processing          |
|                        |                  |          |                       |                        | invalid multi-byte input              |
|                        |                  |          |                       |                        | sequences fails to advance the...     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-27618 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-35942   |          |                       | 2.26-53.amzn2          | glibc: Arbitrary read in wordexp()    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-35942 |
+------------------------+------------------+          +                       +------------------------+---------------------------------------+
| glibc-langpack-en      | CVE-2019-9169    |          |                       | 2.26-47.amzn2          | glibc: regular-expression             |
|                        |                  |          |                       |                        | match via proceed_next_node           |
|                        |                  |          |                       |                        | in posix/regexec.c leads to           |
|                        |                  |          |                       |                        | heap-based buffer over-read...        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-9169  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-27618   |          |                       |                        | glibc: iconv when processing          |
|                        |                  |          |                       |                        | invalid multi-byte input              |
|                        |                  |          |                       |                        | sequences fails to advance the...     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-27618 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-35942   |          |                       | 2.26-53.amzn2          | glibc: Arbitrary read in wordexp()    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-35942 |
+------------------------+------------------+          +                       +------------------------+---------------------------------------+
| glibc-minimal-langpack | CVE-2019-9169    |          |                       | 2.26-47.amzn2          | glibc: regular-expression             |
|                        |                  |          |                       |                        | match via proceed_next_node           |
|                        |                  |          |                       |                        | in posix/regexec.c leads to           |
|                        |                  |          |                       |                        | heap-based buffer over-read...        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-9169  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-27618   |          |                       |                        | glibc: iconv when processing          |
|                        |                  |          |                       |                        | invalid multi-byte input              |
|                        |                  |          |                       |                        | sequences fails to advance the...     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-27618 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-35942   |          |                       | 2.26-53.amzn2          | glibc: Arbitrary read in wordexp()    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-35942 |
+------------------------+------------------+          +                       +------------------------+---------------------------------------+
| libcrypt               | CVE-2019-9169    |          |                       | 2.26-47.amzn2          | glibc: regular-expression             |
|                        |                  |          |                       |                        | match via proceed_next_node           |
|                        |                  |          |                       |                        | in posix/regexec.c leads to           |
|                        |                  |          |                       |                        | heap-based buffer over-read...        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-9169  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-27618   |          |                       |                        | glibc: iconv when processing          |
|                        |                  |          |                       |                        | invalid multi-byte input              |
|                        |                  |          |                       |                        | sequences fails to advance the...     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-27618 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-35942   |          |                       | 2.26-53.amzn2          | glibc: Arbitrary read in wordexp()    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-35942 |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| libcurl                | CVE-2020-8231    |          | 7.61.1-12.amzn2.0.2   | 7.76.1-4.amzn2.0.1     | curl: Expired pointer                 |
|                        |                  |          |                       |                        | dereference via multi API with        |
|                        |                  |          |                       |                        | CURLOPT_CONNECT_ONLY option set       |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8231  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-8284    |          |                       |                        | curl: FTP PASV command                |
|                        |                  |          |                       |                        | response can cause curl               |
|                        |                  |          |                       |                        | to connect to arbitrary...            |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8284  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-8285    |          |                       |                        | curl: Malicious FTP server can        |
|                        |                  |          |                       |                        | trigger stack overflow when           |
|                        |                  |          |                       |                        | CURLOPT_CHUNK_BGN_FUNCTION            |
|                        |                  |          |                       |                        | is used...                            |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8285  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2020-8286    |          |                       |                        | curl: Inferior OCSP verification      |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-8286  |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-22876   |          |                       | 7.61.1-12.amzn2.0.4    | curl: Leak of authentication          |
|                        |                  |          |                       |                        | credentials in URL                    |
|                        |                  |          |                       |                        | via automatic Referer                 |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22876 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-22898   |          |                       | 7.76.1-7.amzn2.0.2     | curl: TELNET stack                    |
|                        |                  |          |                       |                        | contents disclosure                   |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22898 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22922   |          |                       |                        | curl: Content not matching hash       |
|                        |                  |          |                       |                        | in Metalink is not being discarded    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22922 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22923   |          |                       |                        | curl: Metalink download               |
|                        |                  |          |                       |                        | sends credentials                     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22923 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22924   |          |                       |                        | curl: Bad connection reuse            |
|                        |                  |          |                       |                        | due to flawed path name checks        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22924 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22925   |          |                       |                        | curl: Incorrect fix for               |
|                        |                  |          |                       |                        | CVE-2021-22898 TELNET                 |
|                        |                  |          |                       |                        | stack contents disclosure             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22925 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-22945   |          |                       | 7.79.1-1.amzn2.0.1     | curl: use-after-free and              |
|                        |                  |          |                       |                        | double-free in MQTT sending           |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22945 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22946   |          |                       |                        | curl: Requirement to use              |
|                        |                  |          |                       |                        | TLS not properly enforced             |
|                        |                  |          |                       |                        | for IMAP, POP3, and...                |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22946 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-22947   |          |                       |                        | curl: Server responses                |
|                        |                  |          |                       |                        | received before STARTTLS              |
|                        |                  |          |                       |                        | processed after TLS handshake         |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-22947 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| libxml2                | CVE-2021-3517    | HIGH     | 2.9.1-6.amzn2.5.1     | 2.9.1-6.amzn2.5.3      | libxml2: Heap-based buffer overflow   |
|                        |                  |          |                       |                        | in xmlEncodeEntitiesInternal()        |
|                        |                  |          |                       |                        | in entities.c                         |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3517  |
+                        +------------------+----------+                       +                        +---------------------------------------+
|                        | CVE-2020-24977   | MEDIUM   |                       |                        | libxml2: Buffer overflow              |
|                        |                  |          |                       |                        | vulnerability in                      |
|                        |                  |          |                       |                        | xmlEncodeEntitiesInternal()           |
|                        |                  |          |                       |                        | in entities.c                         |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-24977 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-3516    |          |                       | 2.9.1-6.amzn2.5.4      | libxml2: Use-after-free in            |
|                        |                  |          |                       |                        | xmlEncodeEntitiesInternal()           |
|                        |                  |          |                       |                        | in entities.c                         |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3516  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3518    |          |                       |                        | libxml2: Use-after-free in            |
|                        |                  |          |                       |                        | xmlXIncludeDoProcess() in xinclude.c  |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3518  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3537    |          |                       |                        | libxml2: NULL pointer dereference     |
|                        |                  |          |                       |                        | when post-validating mixed            |
|                        |                  |          |                       |                        | content parsed in recovery mode...    |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3537  |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2021-3541    |          |                       | 2.9.1-6.amzn2.5.3      | libxml2: Exponential entity           |
|                        |                  |          |                       |                        | expansion attack bypasses all         |
|                        |                  |          |                       |                        | existing protection mechanisms        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3541  |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| nspr                   | CVE-2021-43527   | CRITICAL | 4.25.0-2.amzn2        | 4.32.0-1.amzn2         | nss: Memory corruption in             |
|                        |                  |          |                       |                        | decodeECorDsaSignature with           |
|                        |                  |          |                       |                        | DSA signatures (and RSA-PSS)          |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-43527 |
+------------------------+                  +          +-----------------------+------------------------+                                       +
| nss                    |                  |          | 3.53.1-3.amzn2        | 3.67.0-4.amzn2.0.1     |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
+                        +------------------+----------+                       +------------------------+---------------------------------------+
|                        | CVE-2020-25648   | MEDIUM   |                       | 3.53.1-7.amzn2         | nss: TLS 1.3 CCS flood                |
|                        |                  |          |                       |                        | remote DoS Attack                     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-25648 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| nss-softokn            | CVE-2021-43527   | CRITICAL | 3.53.1-6.amzn2        | 3.67.0-3.amzn2         | nss: Memory corruption in             |
|                        |                  |          |                       |                        | decodeECorDsaSignature with           |
|                        |                  |          |                       |                        | DSA signatures (and RSA-PSS)          |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-43527 |
+------------------------+                  +          +                       +                        +                                       +
| nss-softokn-freebl     |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
+------------------------+                  +          +-----------------------+------------------------+                                       +
| nss-sysinit            |                  |          | 3.53.1-3.amzn2        | 3.67.0-4.amzn2.0.1     |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
+                        +------------------+----------+                       +------------------------+---------------------------------------+
|                        | CVE-2020-25648   | MEDIUM   |                       | 3.53.1-7.amzn2         | nss: TLS 1.3 CCS flood                |
|                        |                  |          |                       |                        | remote DoS Attack                     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-25648 |
+------------------------+------------------+----------+                       +------------------------+---------------------------------------+
| nss-tools              | CVE-2021-43527   | CRITICAL |                       | 3.67.0-4.amzn2.0.1     | nss: Memory corruption in             |
|                        |                  |          |                       |                        | decodeECorDsaSignature with           |
|                        |                  |          |                       |                        | DSA signatures (and RSA-PSS)          |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-43527 |
+                        +------------------+----------+                       +------------------------+---------------------------------------+
|                        | CVE-2020-25648   | MEDIUM   |                       | 3.53.1-7.amzn2         | nss: TLS 1.3 CCS flood                |
|                        |                  |          |                       |                        | remote DoS Attack                     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-25648 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| nss-util               | CVE-2021-43527   | CRITICAL | 3.53.1-1.amzn2        | 3.67.0-1.amzn2         | nss: Memory corruption in             |
|                        |                  |          |                       |                        | decodeECorDsaSignature with           |
|                        |                  |          |                       |                        | DSA signatures (and RSA-PSS)          |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-43527 |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| openldap               | CVE-2020-25692   | MEDIUM   | 2.4.44-22.amzn2       | 2.4.44-23.amzn2        | openldap: NULL pointer dereference    |
|                        |                  |          |                       |                        | for unauthenticated packet in slapd   |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-25692 |
+                        +------------------+          +                       +------------------------+---------------------------------------+
|                        | CVE-2020-36225   |          |                       | 2.4.44-23.amzn2.0.2    | openldap: Double free in              |
|                        |                  |          |                       |                        | the saslAuthzTo processing            |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-36225 |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| openssl-libs           | CVE-2021-3712    |          | 1:1.0.2k-19.amzn2.0.6 | 1:1.0.2k-19.amzn2.0.8  | openssl: Read buffer overruns         |
|                        |                  |          |                       |                        | processing ASN.1 strings              |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3712  |
+                        +------------------+----------+                       +------------------------+---------------------------------------+
|                        | CVE-2019-1551    | LOW      |                       | 1:1.0.2k-19.amzn2.0.7  | openssl: Integer overflow in RSAZ     |
|                        |                  |          |                       |                        | modular exponentiation on x86_64      |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-1551  |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+
| openssl11-devel        | CVE-2021-3712    | MEDIUM   | 1:1.1.1g-12.amzn2.0.3 | 1:1.1.1g-12.amzn2.0.4  | openssl: Read buffer overruns         |
|                        |                  |          |                       |                        | processing ASN.1 strings              |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3712  |
+------------------------+                  +          +                       +                        +                                       +
| openssl11-libs         |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| python                 | CVE-2020-26116   |          | 2.7.18-1.amzn2.0.3    | 2.7.18-1.amzn2.0.4     | python: CRLF injection via HTTP       |
|                        |                  |          |                       |                        | request method in httplib/http.client |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2020-26116 |
+------------------------+                  +          +                       +                        +                                       +
| python-libs            |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
|                        |                  |          |                       |                        |                                       |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| python2-rpm            | CVE-2021-20271   |          | 4.11.3-40.amzn2.0.5   | 4.11.3-40.amzn2.0.6    | rpm: Signature checks bypass          |
|                        |                  |          |                       |                        | via corrupted rpm package             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-20271 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3421    |          |                       |                        | rpm: unsigned signature header        |
|                        |                  |          |                       |                        | leads to string injection             |
|                        |                  |          |                       |                        | into an rpm database...               |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3421  |
+------------------------+------------------+          +                       +                        +---------------------------------------+
| rpm                    | CVE-2021-20271   |          |                       |                        | rpm: Signature checks bypass          |
|                        |                  |          |                       |                        | via corrupted rpm package             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-20271 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3421    |          |                       |                        | rpm: unsigned signature header        |
|                        |                  |          |                       |                        | leads to string injection             |
|                        |                  |          |                       |                        | into an rpm database...               |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3421  |
+------------------------+------------------+          +                       +                        +---------------------------------------+
| rpm-build-libs         | CVE-2021-20271   |          |                       |                        | rpm: Signature checks bypass          |
|                        |                  |          |                       |                        | via corrupted rpm package             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-20271 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3421    |          |                       |                        | rpm: unsigned signature header        |
|                        |                  |          |                       |                        | leads to string injection             |
|                        |                  |          |                       |                        | into an rpm database...               |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3421  |
+------------------------+------------------+          +                       +                        +---------------------------------------+
| rpm-libs               | CVE-2021-20271   |          |                       |                        | rpm: Signature checks bypass          |
|                        |                  |          |                       |                        | via corrupted rpm package             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-20271 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3421    |          |                       |                        | rpm: unsigned signature header        |
|                        |                  |          |                       |                        | leads to string injection             |
|                        |                  |          |                       |                        | into an rpm database...               |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3421  |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| systemd                | CVE-2018-15686   |          | 219-57.amzn2.0.12     | 219-78.amzn2.0.14      | systemd: line splitting via           |
|                        |                  |          |                       |                        | fgets() allows for state              |
|                        |                  |          |                       |                        | injection during daemon-reexec        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2018-15686 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2018-16866   |          |                       |                        | systemd: out-of-bounds read when      |
|                        |                  |          |                       |                        | parsing a crafted syslog message      |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2018-16866 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2019-20386   |          |                       |                        | systemd: memory leak in button_open() |
|                        |                  |          |                       |                        | in login/logind-button.c when         |
|                        |                  |          |                       |                        | udev events are received...           |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-20386 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2019-3815    |          |                       |                        | systemd: memory leak in               |
|                        |                  |          |                       |                        | journald-server.c introduced          |
|                        |                  |          |                       |                        | by fix for CVE-2018-16864             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-3815  |
+------------------------+------------------+          +                       +                        +---------------------------------------+
| systemd-devel          | CVE-2018-15686   |          |                       |                        | systemd: line splitting via           |
|                        |                  |          |                       |                        | fgets() allows for state              |
|                        |                  |          |                       |                        | injection during daemon-reexec        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2018-15686 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2018-16866   |          |                       |                        | systemd: out-of-bounds read when      |
|                        |                  |          |                       |                        | parsing a crafted syslog message      |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2018-16866 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2019-20386   |          |                       |                        | systemd: memory leak in button_open() |
|                        |                  |          |                       |                        | in login/logind-button.c when         |
|                        |                  |          |                       |                        | udev events are received...           |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-20386 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2019-3815    |          |                       |                        | systemd: memory leak in               |
|                        |                  |          |                       |                        | journald-server.c introduced          |
|                        |                  |          |                       |                        | by fix for CVE-2018-16864             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-3815  |
+------------------------+------------------+          +                       +                        +---------------------------------------+
| systemd-libs           | CVE-2018-15686   |          |                       |                        | systemd: line splitting via           |
|                        |                  |          |                       |                        | fgets() allows for state              |
|                        |                  |          |                       |                        | injection during daemon-reexec        |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2018-15686 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2018-16866   |          |                       |                        | systemd: out-of-bounds read when      |
|                        |                  |          |                       |                        | parsing a crafted syslog message      |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2018-16866 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2019-20386   |          |                       |                        | systemd: memory leak in button_open() |
|                        |                  |          |                       |                        | in login/logind-button.c when         |
|                        |                  |          |                       |                        | udev events are received...           |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-20386 |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2019-3815    |          |                       |                        | systemd: memory leak in               |
|                        |                  |          |                       |                        | journald-server.c introduced          |
|                        |                  |          |                       |                        | by fix for CVE-2018-16864             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2019-3815  |
+------------------------+------------------+          +-----------------------+------------------------+---------------------------------------+
| vim-minimal            | CVE-2021-3778    |          | 2:8.1.1602-1.amzn2    | 2:8.2.3642-1.amzn2.0.1 | vim: heap-based buffer overflow       |
|                        |                  |          |                       |                        | in utf_ptr2char() in mbyte.c          |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3778  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3796    |          |                       |                        | vim: use-after-free in                |
|                        |                  |          |                       |                        | nv_replace() in normal.c              |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3796  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3872    |          |                       |                        | vim: heap-based buffer overflow in    |
|                        |                  |          |                       |                        | win_redr_status() in drawscreen.c     |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3872  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3875    |          |                       |                        | vim: heap-based buffer overflow       |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3875  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3968    |          |                       |                        | vim: Heap use-after-free              |
|                        |                  |          |                       |                        | in ml_append_int function             |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3968  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3973    |          |                       |                        | vim: Heap based buffer                |
|                        |                  |          |                       |                        | overflow in findfile.c                |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3973  |
+                        +------------------+          +                       +                        +---------------------------------------+
|                        | CVE-2021-3974    |          |                       |                        | vim: Use after free in regexp_nfa.c   |
|                        |                  |          |                       |                        | -->avd.aquasec.com/nvd/cve-2021-3974  |
+------------------------+------------------+----------+-----------------------+------------------------+---------------------------------------+

```

See the output of an image scanning tool against the latest image (2.21.5 at the time of writing) here:
```
amazon/aws-for-fluent-bit:2.21.5 (amazon 2 (Karoo))
===================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```


### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Reviewed the output of `helm template`, reviewed change logs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
