### PR TITLE
[aws-for-fluent-bit] Support extra Configuration to the pods

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.12
+version: 0.1.13
 appVersion: 2.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.11
+version: 0.1.12
 appVersion: 2.13.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -35,8 +35,9 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
-| `serviceAccount.create` | Whether a new service account should be created | `true` | 
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
+| `service.extraKeys` | Adding more configuration keys to the service section | `""` |
 | `service.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
 | `extraInputs` | Adding more inputs with this value | `""` |
@@ -68,9 +69,9 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.match` | The log filter | `"*"` | ✔
 | `kinesis.region` | The region which your Kinesis Data Stream is in. | `"us-east-1"` | ✔
 | `kinesis.stream` | The name of the Kinesis Data Stream that you want log records sent to. | `"my-kinesis-stream-name"` | ✔
-| `kinesis.partitionKey` | A partition key is used to group data by shard within a stream. A Kinesis Data Stream uses the partition key that is associated with each data record to determine which shard a given data record belongs to. For example, if your logs come from Docker containers, you can use container_id as the partition key, and the logs will be grouped and stored on different shards depending upon the id of the container they were generated from. As the data within a shard are coarsely ordered, you will get all your logs from one container in one shard roughly in order. If you don't set a partition key or put an invalid one, a random key will be generated, and the logs will be directed to random shards. If the partition key is invalid, the plugin will print an warning message. | `"container_id"` | 
-| `kinesis.appendNewline` | If you set append_newline as true, a newline will be addded after each log record. | | 
-| `kinesis.replaceDots` | Replace dot characters in key names with the value of this option. | | 
+| `kinesis.partitionKey` | A partition key is used to group data by shard within a stream. A Kinesis Data Stream uses the partition key that is associated with each data record to determine which shard a given data record belongs to. For example, if your logs come from Docker containers, you can use container_id as the partition key, and the logs will be grouped and stored on different shards depending upon the id of the container they were generated from. As the data within a shard are coarsely ordered, you will get all your logs from one container in one shard roughly in order. If you don't set a partition key or put an invalid one, a random key will be generated, and the logs will be directed to random shards. If the partition key is invalid, the plugin will print an warning message. | `"container_id"` |
+| `kinesis.appendNewline` | If you set append_newline as true, a newline will be addded after each log record. | |
+| `kinesis.replaceDots` | Replace dot characters in key names with the value of this option. | |
 | `kinesis.dataKeys` | By default, the whole log record will be sent to Kinesis. If you specify key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited. | |
 | `kinesis.roleArn` | ARN of an IAM role to assume (for cross account access). | |
 | `kinesis.endpoint` | Specify a custom endpoint for the Kinesis Streams API. | |

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -94,6 +94,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |
 | `affinity` | Map of node/pod affinities | `{}` |
 | `env` | Optional List of pod environment variables for the pods | `[]` |
+| `extraContainerConfig` | Optional Extra pod configurations variables |
 | `tolerations` | Optional deployment tolerations | `[]` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `annotations` | Optional pod annotations | `{}` |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -15,6 +15,10 @@ data:
         Parsers_File /fluent-bit/etc/parser_extra.conf
 {{- end }}
 
+{{- if .Values.service.extraKeys }}
+{{ .Values.service.extraKeys | indent 8}}
+{{- end }}
+
     [INPUT]
         Name              tail
         Tag               {{ .Values.input.tag }}

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -32,6 +32,9 @@ spec:
         - name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- if .Values.extraContainerConfig }}
+          {{- toYaml .Values.extraContainerConfig | nindent 10 }}
+          {{- end }}
           {{- if .Values.env }}
           env:
             {{- toYaml .Values.env | nindent 12 }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -14,6 +14,8 @@ fullnameOverride: ""
 service:
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
+  # extraKeys: |
+  #   HTTP_Server  On
   # extraParsers: |
   #   [PARSER]
   #       Name   logfmt
@@ -139,7 +141,7 @@ affinity: {}
 
 annotations: {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
-  
+
 env: []
 ## To add extra environment variables to the pods, add as below
 # env:
@@ -157,7 +159,7 @@ env: []
 #     valueFrom:
 #       fieldRef:
 #         fieldPath: spec.nodeName
-  
+
 
 volumes:
   - name: varlog

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -2,6 +2,12 @@ global:
 ## Override the deployment namespace
 #   namespaceOverride:
 
+extraContainerConfig:
+    #    ports:
+    #    - containerPort: 2020
+    #      name: metrics
+    #      protocol: TCP
+
 image:
   repository: amazon/aws-for-fluent-bit
   tag: 2.13.0

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -2,12 +2,6 @@ global:
 ## Override the deployment namespace
 #   namespaceOverride:
 
-extraContainerConfig:
-    #    ports:
-    #    - containerPort: 2020
-    #      name: metrics
-    #      protocol: TCP
-
 image:
   repository: amazon/aws-for-fluent-bit
   tag: 2.13.0
@@ -26,6 +20,12 @@ service:
   #   [PARSER]
   #       Name   logfmt
   #       Format logfmt
+
+extraContainerConfig: {}
+    #    ports:
+    #    - containerPort: 2020
+    #      name: metrics
+    #      protocol: TCP
 
 input:
   tag: "kube.*"


### PR DESCRIPTION
### Issue

This PR depends on this [PR](https://github.com/aws/eks-charts/pull/655). (I cherry-picked the commit.)

### Description of changes

This PR allow to add extra configuration to the pod. This will allow, for example, the pod to expose a port.

I need to access the HTTP server from outside the pods to retrieve fluentbit metrics. To do it I need the port to be exposed.  

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

1. No changes to values.yaml. Helm apply produced no change to the configmap or daemonset.
2. Updated values.yaml with extraKeys and extraContainerConfig to activate HTTP server and expose the port
```yaml
service:
  extraKeys: |
     HTTP_Server  On

extraContainerConfig:
  ports:
  - containerPort: 2020
    name: metrics
    protocol: TCP
```
Helm apply added the following parts (+)
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: RELEASE-NAME-aws-for-fluent-bit
  namespace: logging
  labels:
    helm.sh/chart: aws-for-fluent-bit-0.1.13
    app.kubernetes.io/name: aws-for-fluent-bit
    app.kubernetes.io/instance: logging
    app.kubernetes.io/version: "2.13.0"
    app.kubernetes.io/managed-by: Helm
data:
  fluent-bit.conf: |
    [SERVICE]
        Parsers_File /fluent-bit/parsers/parsers.conf
+       HTTP_Server  On
+       

    [INPUT]
        Name              tail
        Tag               kube.*
        Path              /var/log/containers/*.log
        DB                /var/log/flb_kube.db
        Parser            docker
        Docker_Mode       On
        Mem_Buf_Limit     5MB
        Skip_Long_Lines   On
        Refresh_Interval  10

 ```
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: RELEASE-NAME-aws-for-fluent-bit
  namespace: logging
  labels:
    helm.sh/chart: aws-for-fluent-bit-0.1.13
    app.kubernetes.io/name: aws-for-fluent-bit
    app.kubernetes.io/instance: logging
    app.kubernetes.io/version: "2.13.0"
    app.kubernetes.io/managed-by: Helm
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/name: aws-for-fluent-bit
      app.kubernetes.io/instance: logging
  template:
    metadata:
      labels:
        app.kubernetes.io/name: aws-for-fluent-bit
        app.kubernetes.io/instance: logging
    spec:
      serviceAccountName: RELEASE-NAME-aws-for-fluent-bit
      containers:
        - name: aws-for-fluent-bit
          imagePullPolicy: IfNotPresent
          image: "amazon/aws-for-fluent-bit:2.13.0"
+         ports:
+         - containerPort: 2020
+           name: metrics
+           protocol: TCP
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
