### PR TITLE
[aws-calico] Template calico-node updateStrategy

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.3.10
+version: 0.3.11
 appVersion: 3.19.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -1,5 +1,5 @@
 # Calico on AWS
-**Note**: The recommended way to install calico on EKS is via tigera-opeartor instead of this helm-chart. 
+**Note**: The recommended way to install calico on EKS is via tigera-opeartor instead of this helm-chart.
 You can follow https://docs.aws.amazon.com/eks/latest/userguide/calico.html for detailed instructions.
 
 
@@ -57,6 +57,7 @@ The following table lists the configurable parameters for this chart and their d
 | `calico.node.nodeSelector`               | Calico Node Node Selector                               | `{ beta.kubernetes.io/os: linux }` |
 | `calico.node.podAnnotations`             | Calico Node Pod Annotations                             | `{}`                            |
 | `calico.node.podLabels`                  | Calico Node Pod Labels                                  | `{}`                            |
+| `calico.node.updateStrategy`             | Calico Node Update Strategy                             | `type: RollingUpdate, rollingUpdate.maxUnavailable: 1` |
 | `calico.typha_autoscaler.resources`      | Calico Typha Autoscaler Resources                       | `requests.memory: 16Mi, requests.cpu: 10m, limits.memory: 32Mi, limits.cpu: 10m` |
 | `calico.typha_autoscaler.nodeSelector`   | Calico Typha Autoscaler Node Selector                   | `{ beta.kubernetes.io/os: linux }` |
 | `calico.typha_autoscaler.podAnnotations` | Calico Typha Autoscaler Pod Annotations                 | `{}`                            |

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -12,10 +12,10 @@ spec:
       {{- if .Values.calico.node.podLabels }}
 {{ toYaml .Values.calico.node.podLabels | indent 6 }}
       {{- end }}
+  {{- if .Values.calico.node.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+{{ toYaml .Values.calico.node.updateStrategy | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -41,6 +41,10 @@ calico:
       beta.kubernetes.io/os: linux
     podAnnotations: {}
     podLabels: {}
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
   typha_autoscaler:
     resources:
       requests:


### PR DESCRIPTION
### Description of changes

Move the `updateStrategy` into the `values.yaml` to allow overriding it on deploys.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Running `helm template stable/aws-calico` before and after these changes to compare:

Master:
```
# Source: aws-calico/templates/daemon-set.yaml
...
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-node"
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
  template:
    metadata:
...
```

With changes:
```
# Source: aws-calico/templates/daemon-set.yaml
...
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: "calico-node"
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
