### PR TITLE
Adding deprecating announcement into Calico charts README

### DIFF
--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -1,4 +1,4 @@
-# Important Announcement: We have decided to stop maintaining and updating Calico charts in this repository #
+# Important Announcement: AWS EKS will no longer maintain and update Calico charts in this repository #
 - The current Calico charts will not be updated
 - The current Calico charts will be removed from this repository on March 31, 2023
 - Current open requests will be redirected to Calico

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -1,3 +1,12 @@
+# Important Announcement: We have decided to stop maintaining and updating Calico charts in this repository #
+- The current Calico charts will not be updated
+- The current Calico charts will be removed from this repository on March 31, 2023
+- Current open requests will be redirected to Calico
+- You should submit new requests to Calico directly
+    - For Calico, please send issues to [Calico repository](http://github.com/projectcalico/calico)
+    - For Tigera Operator, please send issues to [Operator repository](http://github.com/tigera/operator)
+- We will update and maintain the AWS docs for Calico installation after the deprecation
+
 # Calico on AWS
 **Note**: The recommended way to install calico on EKS is via tigera-opeartor instead of this helm-chart. 
 You can follow https://docs.aws.amazon.com/eks/latest/userguide/calico.html for detailed instructions.

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -5,7 +5,7 @@
 - You should submit new requests to Calico directly
     - For Calico, please send issues to [Calico repository](http://github.com/projectcalico/calico)
     - For Tigera Operator, please send issues to [Operator repository](http://github.com/tigera/operator)
-- We will update and maintain the AWS docs for Calico installation after the deprecation
+- We will update and maintain the [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/calico.html) for Calico installation after the deprecation
 
 # Calico on AWS
 **Note**: The recommended way to install calico on EKS is via tigera-opeartor instead of this helm-chart. 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
This is a PR to update README for an announcement of deprecating Calico charts
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes
README update doesn't need to bump version.
### Testing
Please checking [AWS doc](https://docs.aws.amazon.com/eks/latest/userguide/calico.html) for tests result 
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
