### PR TITLE
Fix wrong indentation when exposing the http metrics ports in aws-node-termination-handler

### DIFF
--- a/stable/aws-node-termination-handler/Chart.yaml
+++ b/stable/aws-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler.
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: 1.14.1
 kubeVersion: ">= 1.16-0"
 keywords:

--- a/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -147,9 +147,9 @@ spec:
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
           {{- if .Values.enableProbesServer }}
-           - name: liveness-probe
-             protocol: TCP
-             containerPort: {{ .Values.probes.httpGet.port }}
+            - name: liveness-probe
+              protocol: TCP
+              containerPort: {{ .Values.probes.httpGet.port }}
           {{- end }}
           {{- if .Values.enablePrometheusServer }}
             - name: http-metrics

--- a/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/stable/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -145,10 +145,10 @@ spec:
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
           {{- if .Values.enableProbesServer }}
-           - name: liveness-probe
-             protocol: TCP
-             containerPort: {{ .Values.probes.httpGet.port }}
-             hostPort: {{ .Values.probes.httpGet.port }}
+            - name: liveness-probe
+              protocol: TCP
+              containerPort: {{ .Values.probes.httpGet.port }}
+              hostPort: {{ .Values.probes.httpGet.port }}
           {{- end }}
           {{- if .Values.enablePrometheusServer }}
             - name: http-metrics

--- a/stable/aws-node-termination-handler/templates/deployment.yaml
+++ b/stable/aws-node-termination-handler/templates/deployment.yaml
@@ -161,9 +161,9 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-           - name: liveness-probe
-             protocol: TCP
-             containerPort: {{ .Values.probes.httpGet.port }}
+            - name: liveness-probe
+              protocol: TCP
+              containerPort: {{ .Values.probes.httpGet.port }}
           {{- if .Values.enablePrometheusServer }}
             - name: http-metrics
               protocol: TCP


### PR DESCRIPTION
### Issue

The latest release of the aws-node-termination-handler chart erroneously sets different indentations to the ports of the deployments. This is not an issue if metrics are not exposed, as there is only one port, but if the metrics port is exposed, the rendering of the yaml fails with:

```
  Error: YAML parse error on aws-node-termination-handler/templates/deployment.yaml: error converting YAML to JSON: yaml: line 127: did not find expected '-' indicator
  helm.go:88: [debug] error converting YAML to JSON: yaml: line 127: did not find expected '-' indicator
```

### Description of changes

Change the indentation of the first port in all deployments and daemonsets so that both have the same indentation.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Ran the following command:

```
helm template test ./stable/aws-node-termination-handler/ --set enablePrometheusServer=true --set enableProbesServer=true
```

The generated YAML was valid and Helm no longer complains of invalid yaml.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
