### PR TITLE
Update eks-charts for vpc-cni release v1.10.2

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.12
-appVersion: "v1.10.1"
+version: 1.1.13
+appVersion: "v1.10.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -69,8 +69,10 @@ spec:
               name: metrics
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
+            timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }} 
           readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 12 }}
+            timeoutSeconds: {{ .Values.readinessProbeTimeoutSeconds }}
           env:
 {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/stable/aws-vpc-cni/test.yaml
+++ b/stable/aws-vpc-cni/test.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.10.1
+    tag: v1.10.2
     region: us-west-2
     account: "602401143452"   
     pullPolicy: Always
@@ -23,7 +23,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.10.1
+  tag: v1.10.2
   account: "602401143452"   
   domain: "amazonaws.com"  
   pullPolicy: Always

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.10.1
+    tag: v1.10.2
     region: us-west-2
     account: "602401143452"   
     pullPolicy: Always
@@ -23,7 +23,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.10.1
+  tag: v1.10.2
   account: "602401143452"   
   domain: "amazonaws.com"  
   pullPolicy: Always


### PR DESCRIPTION
### Issue
N/A
<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
Updated eks-charts to use the vpc-cni release v1.10.2

<!-- Please explain the changes you made here. -->
Updated Chart and values
Added missing liveness and readiness probe timeout values to daemonset.yaml

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
