### PR TITLE
Add ability to assign env to the csi-secrets-store-provider-aws

### DIFF
--- a/stable/csi-secrets-store-provider-aws/Chart.lock
+++ b/stable/csi-secrets-store-provider-aws/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: secrets-store-csi-driver
   repository: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
-  version: 1.0.0
-digest: sha256:21c9bdbedf3e250bce7e9b4a9eac408b8819f18504b26e8017fe2c8906419271
-generated: "2021-10-14T23:05:12.939759665Z"
+  version: 1.0.1
+digest: sha256:bf0bde14adcdbfa6e9b8379ad9fb13e93ee7682c64ceb5209b45d75244c582b2
+generated: "2022-02-10T18:36:30.139389+01:00"

--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-aws
-version: 0.0.2
+version: 0.0.3
 appVersion: 1.0.r2
 kubeVersion: ">=1.17.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster.

--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 dependencies:
 - name: secrets-store-csi-driver
   repository: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
-  version: 1.0.0
+  version: 1.0.1
   condition: secrets-store-csi-driver.install
 keywords:
   - eks

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -33,7 +33,7 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `image.repository` | Image repository | `public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `image.tag`| Image tag | `1.0.r2-2021.08.13.20.34-linux-amd64` |
-| `env`|  Environment variables to be passed for the daemonset | `[]` |
+| `env`|  Environment variables to be passed for the daemonset | `{}` |
 | `nodeSelector` | Node Selector for the daemonset on nodes | `{}` |
 | `tolerations` | Tolerations for the daemonset on nodes  | `[]` |
 | `ports` | Liveness and readyness tcp probe port  | `8989` |

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `image.repository` | Image repository | `public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `image.tag`| Image tag | `1.0.r2-2021.08.13.20.34-linux-amd64` |
+| `env`|  Environment variables to be passed for the daemonset | `[]` |
 | `nodeSelector` | Node Selector for the daemonset on nodes | `{}` |
 | `tolerations` | Tolerations for the daemonset on nodes  | `[]` |
 | `ports` | Liveness and readyness tcp probe port  | `8989` |

--- a/stable/csi-secrets-store-provider-aws/templates/daemonset.yaml
+++ b/stable/csi-secrets-store-provider-aws/templates/daemonset.yaml
@@ -32,7 +32,10 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-{{ toYaml .Values.env | indent 12 }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           args:
             - --provider-volume=/etc/kubernetes/secrets-store-csi-providers
           resources:

--- a/stable/csi-secrets-store-provider-aws/templates/daemonset.yaml
+++ b/stable/csi-secrets-store-provider-aws/templates/daemonset.yaml
@@ -31,6 +31,8 @@ spec:
         - name: provider-aws-installer
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+{{ toYaml .Values.env | indent 12 }}
           args:
             - --provider-volume=/etc/kubernetes/secrets-store-csi-providers
           resources:

--- a/stable/csi-secrets-store-provider-aws/values.yaml
+++ b/stable/csi-secrets-store-provider-aws/values.yaml
@@ -8,6 +8,7 @@ image:
 
 nodeSelector: {}
 tolerations: []
+env: []
 
 port: 8989
 

--- a/stable/csi-secrets-store-provider-aws/values.yaml
+++ b/stable/csi-secrets-store-provider-aws/values.yaml
@@ -8,7 +8,13 @@ image:
 
 nodeSelector: {}
 tolerations: []
-env: []
+env: {}
+
+#Example
+#env:
+#    http_proxy: http://proxyserver:3128
+#    https_proxy: http://proxyserver:3128
+#    no_proxy: "localhost,127.0.0.1,.cluster.local"
 
 port: 8989
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

This PR adds ability to assign ENV to the secrets store AWS driver. This is required to set HTTPS_PROXY variables in the environment without direct internet connectivity.

It also updates dependency to the latest release.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Tested:

1. With helm by adding new proxy values and removing them.
2. In ArgoCD with a real deployment in proxy-only setup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
