### PR TITLE
fix(extra): handle existing and additional output, filter, extra

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.13
+version: 0.1.14
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -42,7 +42,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `extraInputs` | Append to input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |
 | `filter.*` | Values for kubernetes filter | |
-| `extraFilters` | Append to filters with value |
+| `extraFilters` | Append to filter with value |
 | `additionalFilters` | Adding more filters with value |
 | `cloudWatch.enabled` | Whether this plugin should be enabled or not [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) | `true` | ✔
 | `cloudWatch.match` | The log filter | `*` | ✔
@@ -57,7 +57,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
 | `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
 | `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
-| `cloudWatch.extraParameters` | Append extra outputs with value | `""` |
+| `cloudWatch.extraOutputs` | Append extra outputs with value | `""` |
 | `firehose.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) | `true` | ✔
 | `firehose.match` | The log filter | `"*"` | ✔
 | `firehose.region` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
@@ -67,7 +67,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `firehose.endpoint` | Specify a custom endpoint for the Kinesis Firehose API. | |
 | `firehose.timeKey` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
 | `firehose.timeKeyFormat` | strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
-| `firehose.extraParameters` | Append extra outputs with value | `""` |
+| `firehose.extraOutputs` | Append extra outputs with value | `""` |
 | `kinesis.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) | `true` | ✔
 | `kinesis.match` | The log filter | `"*"` | ✔
 | `kinesis.region` | The region which your Kinesis Data Stream is in. | `"us-east-1"` | ✔
@@ -83,7 +83,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.timeKeyFormat` |  strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
 | `kinesis.aggregation` | Setting aggregation to `true` will enable KPL aggregation of records sent to Kinesis. This feature isn't compatible with the `partitionKey` feature.  See more about KPL aggregation [here](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit#kpl-aggregation). | |
 | `kinesis.compression` | Setting `compression` to `zlib` will enable zlib compression of each record. By default this feature is disabled and records are not compressed. | |
-| `kinesis.extraParameters` | Append extra outputs with value | `""` |
+| `kinesis.extraOutputs` | Append extra outputs with value | `""` |
 | `elasticsearch.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | `true` | ✔
 | `elasticsearch.match` | The log filter | `"*"` | ✔
 | `elasticsearch.awsRegion` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
@@ -93,7 +93,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `elasticsearch.port` | TCP Port of the target service. | 443 |
 | `elasticsearch.retryLimit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
 | `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
-| `elasticsearch.extraParameters` | Append extra outputs with value | `""` |
+| `elasticsearch.extraOutputs` | Append extra outputs with value | `""` |
 | `additionalOutputs` | add outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -35,13 +35,15 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
-| `serviceAccount.create` | Whether a new service account should be created | `true` | 
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
-| `service.extraParsers` | Adding more parsers with this value | `""` |
+| `service.additionalParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
-| `extraInputs` | Adding more inputs with this value | `""` |
+| `extraInputs` | Append to input with this value | `""` |
+| `additionalInputs` | Adding more inputs with this value | `""` |
 | `filter.*` | Values for kubernetes filter | |
-| `extraFilters` | Adding more filters with value |
+| `extraFilters` | Append to filters with value |
+| `additionalFilters` | Adding more filters with value |
 | `cloudWatch.enabled` | Whether this plugin should be enabled or not [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) | `true` | ✔
 | `cloudWatch.match` | The log filter | `*` | ✔
 | `cloudWatch.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔
@@ -55,6 +57,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
 | `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
 | `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
+| `cloudWatch.extraParameters` | Append extra outputs with value | `""` |
 | `firehose.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) | `true` | ✔
 | `firehose.match` | The log filter | `"*"` | ✔
 | `firehose.region` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
@@ -64,13 +67,14 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `firehose.endpoint` | Specify a custom endpoint for the Kinesis Firehose API. | |
 | `firehose.timeKey` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
 | `firehose.timeKeyFormat` | strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
+| `firehose.extraParameters` | Append extra outputs with value | `""` |
 | `kinesis.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) | `true` | ✔
 | `kinesis.match` | The log filter | `"*"` | ✔
 | `kinesis.region` | The region which your Kinesis Data Stream is in. | `"us-east-1"` | ✔
 | `kinesis.stream` | The name of the Kinesis Data Stream that you want log records sent to. | `"my-kinesis-stream-name"` | ✔
-| `kinesis.partitionKey` | A partition key is used to group data by shard within a stream. A Kinesis Data Stream uses the partition key that is associated with each data record to determine which shard a given data record belongs to. For example, if your logs come from Docker containers, you can use container_id as the partition key, and the logs will be grouped and stored on different shards depending upon the id of the container they were generated from. As the data within a shard are coarsely ordered, you will get all your logs from one container in one shard roughly in order. If you don't set a partition key or put an invalid one, a random key will be generated, and the logs will be directed to random shards. If the partition key is invalid, the plugin will print an warning message. | `"container_id"` | 
-| `kinesis.appendNewline` | If you set append_newline as true, a newline will be addded after each log record. | | 
-| `kinesis.replaceDots` | Replace dot characters in key names with the value of this option. | | 
+| `kinesis.partitionKey` | A partition key is used to group data by shard within a stream. A Kinesis Data Stream uses the partition key that is associated with each data record to determine which shard a given data record belongs to. For example, if your logs come from Docker containers, you can use container_id as the partition key, and the logs will be grouped and stored on different shards depending upon the id of the container they were generated from. As the data within a shard are coarsely ordered, you will get all your logs from one container in one shard roughly in order. If you don't set a partition key or put an invalid one, a random key will be generated, and the logs will be directed to random shards. If the partition key is invalid, the plugin will print an warning message. | `"container_id"` |
+| `kinesis.appendNewline` | If you set append_newline as true, a newline will be addded after each log record. | |
+| `kinesis.replaceDots` | Replace dot characters in key names with the value of this option. | |
 | `kinesis.dataKeys` | By default, the whole log record will be sent to Kinesis. If you specify key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited. | |
 | `kinesis.roleArn` | ARN of an IAM role to assume (for cross account access). | |
 | `kinesis.endpoint` | Specify a custom endpoint for the Kinesis Streams API. | |
@@ -79,6 +83,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.timeKeyFormat` |  strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
 | `kinesis.aggregation` | Setting aggregation to `true` will enable KPL aggregation of records sent to Kinesis. This feature isn't compatible with the `partitionKey` feature.  See more about KPL aggregation [here](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit#kpl-aggregation). | |
 | `kinesis.compression` | Setting `compression` to `zlib` will enable zlib compression of each record. By default this feature is disabled and records are not compressed. | |
+| `kinesis.extraParameters` | Append extra outputs with value | `""` |
 | `elasticsearch.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | `true` | ✔
 | `elasticsearch.match` | The log filter | `"*"` | ✔
 | `elasticsearch.awsRegion` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
@@ -88,7 +93,8 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `elasticsearch.port` | TCP Port of the target service. | 443 |
 | `elasticsearch.retryLimit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
 | `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
-| `extraOutputs` | Adding more outputs with value | `""` |
+| `elasticsearch.extraParameters` | Append extra outputs with value | `""` |
+| `additionalOutputs` | add outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |
 | `affinity` | Map of node/pod affinities | `{}` |

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -36,13 +36,14 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
+| `service.extraService` | Append to existing service with this value | `""` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
 | `service.additionalParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
-| `extraInputs` | Append to input with this value | `""` |
+| `extraInputs` | Append to existing input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |
 | `filter.*` | Values for kubernetes filter | |
-| `extraFilters` | Append to filter with value |
+| `filter.extraFilters` | Append to existing filter with value |
 | `additionalFilters` | Adding more filters with value |
 | `cloudWatch.enabled` | Whether this plugin should be enabled or not [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) | `true` | ✔
 | `cloudWatch.match` | The log filter | `*` | ✔

--- a/stable/aws-for-fluent-bit/templates/NOTES.txt
+++ b/stable/aws-for-fluent-bit/templates/NOTES.txt
@@ -1,5 +1,3 @@
 {{ .Release.Name }} has been installed or updated. To check the status of pods, run:
 
 kubectl get pods -n {{ include "aws-for-fluent-bit.namespace" . }}
-
-

--- a/stable/aws-for-fluent-bit/templates/_helpers.tpl
+++ b/stable/aws-for-fluent-bit/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Selector labels
 */}}
 {{- define "aws-for-fluent-bit.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "aws-for-fluent-bit.name" . }}
-app.kubernetes.io/instance: {{ include "aws-for-fluent-bit.namespace" . }}
+app.kubernetes.io/instance: {{ include "aws-for-fluent-bit.fullname" . }}
 {{- end -}}
 
 {{/*

--- a/stable/aws-for-fluent-bit/templates/_helpers.tpl
+++ b/stable/aws-for-fluent-bit/templates/_helpers.tpl
@@ -72,4 +72,3 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- .Release.Namespace -}}
   {{- end -}}
 {{- end -}}
-

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
 data:
   fluent-bit.conf: |
     [SERVICE]
+{{- if .Values.service.extraService }}
+{{ .Values.service.extraService | indent 8 }}
+{{- end }}
 {{- range .Values.service.parsersFiles }}
         Parsers_File {{ . }}
 {{- end }}
@@ -25,12 +28,12 @@ data:
         Mem_Buf_Limit     {{ .Values.input.memBufLimit }}
         Skip_Long_Lines   {{ .Values.input.skipLongLines }}
         Refresh_Interval  {{ .Values.input.refreshInterval }}
-{{- if .Values.extraInputs }}
-{{ .Values.extraInputs | indent 8}}
+{{- if .Values.input.extraInputs }}
+{{ .Values.input.extraInputs | indent 8 }}
 {{- end }}
 
 {{- if .Values.additionalInputs }}
-{{ .Values.additionalInputs | indent 4}}
+{{ .Values.additionalInputs | indent 4 }}
 {{- end }}
 
     [FILTER]
@@ -44,8 +47,8 @@ data:
         Keep_Log            {{ .Values.filter.keepLog }}
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
-{{- if .Values.extraFilters }}
-{{ .Values.extraFilters | indent 8}}
+{{- if .Values.filter.extraFilters }}
+{{ .Values.filter.extraFilters | indent 8 }}
 {{- end }}
 
 {{- if .Values.additionalFilters }}
@@ -86,7 +89,7 @@ data:
         credentials_endpoint  {{ toJson .Values.cloudWatch.credentialsEndpoint }}
         {{- end -}}
         {{- if .Values.cloudWatch.extraOutputs }}
-{{ .Values.cloudWatch.extraOutputs | indent 8}}
+{{ .Values.cloudWatch.extraOutputs | indent 8 }}
         {{- end }}
 {{- end }}
 
@@ -112,7 +115,7 @@ data:
         time_key_format {{ .Values.firehose.timeKeyFormat }}
         {{- end -}}
         {{- if .Values.kinesis.extraOutputs }}
-{{ .Values.kinesis.extraOutputs | indent 8}}
+{{ .Values.kinesis.extraOutputs | indent 8 }}
         {{- end }}
 {{- end }}
 
@@ -163,7 +166,7 @@ data:
         experimental_concurrency_retries  {{ .Values.kinesis.experimental.concurrencyRetries }}
         {{- end -}}
         {{- if .Values.kinesis.extraOutputs }}
-{{ .Values.kinesis.extraOutputs | indent 8}}
+{{ .Values.kinesis.extraOutputs | indent 8 }}
         {{- end }}
 {{- end }}
 
@@ -189,16 +192,16 @@ data:
         Replace_Dots    {{ .Values.elasticsearch.replaceDots }}
         {{- end -}}
         {{- if .Values.elasticsearch.extraOutputs }}
-{{ .Values.elasticsearch.extraOutputs | indent 8}}
+{{ .Values.elasticsearch.extraOutputs | indent 8 }}
         {{- end }}
 {{- end }}
 
 {{- if .Values.additionalOutputs }}
-{{ .Values.additionalOutputs | indent 4}}
+{{ .Values.additionalOutputs | indent 4 }}
 {{- end }}
 
 
 {{- if .Values.service.extraParsers }}
   parser_extra.conf: |-
-{{ .Values.service.extraParsers | indent 4}}
+{{ .Values.service.extraParsers | indent 4 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -25,9 +25,12 @@ data:
         Mem_Buf_Limit     {{ .Values.input.memBufLimit }}
         Skip_Long_Lines   {{ .Values.input.skipLongLines }}
         Refresh_Interval  {{ .Values.input.refreshInterval }}
-
 {{- if .Values.extraInputs }}
 {{ .Values.extraInputs | indent 8}}
+{{- end }}
+
+{{- if .Values.additionalInputs }}
+{{ .Values.additionalInputs | indent 4}}
 {{- end }}
 
     [FILTER]
@@ -41,9 +44,12 @@ data:
         Keep_Log            {{ .Values.filter.keepLog }}
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
-
 {{- if .Values.extraFilters }}
 {{ .Values.extraFilters | indent 8}}
+{{- end }}
+
+{{- if .Values.additionalFilters }}
+{{ .Values.additionalFilters | indent 4}}
 {{- end }}
 
 {{- if .Values.cloudWatch.enabled }}
@@ -78,6 +84,9 @@ data:
         {{- end }}
         {{- if .Values.cloudWatch.credentialsEndpoint }}
         credentials_endpoint  {{ toJson .Values.cloudWatch.credentialsEndpoint }}
+        {{- end -}}
+        {{- if .Values.cloudWatch.extraOutputs }}
+{{ .Values.cloudWatch.extraOutputs | indent 8}}
         {{- end }}
 {{- end }}
 
@@ -101,6 +110,9 @@ data:
         {{- end }}
         {{- if .Values.firehose.timeKeyFormat }}
         time_key_format {{ .Values.firehose.timeKeyFormat }}
+        {{- end -}}
+        {{- if .Values.kinesis.extraOutputs }}
+{{ .Values.kinesis.extraOutputs | indent 8}}
         {{- end }}
 {{- end }}
 
@@ -149,6 +161,9 @@ data:
         {{- end }}
         {{- if .Values.kinesis.experimental.concurrencyRetries }}
         experimental_concurrency_retries  {{ .Values.kinesis.experimental.concurrencyRetries }}
+        {{- end -}}
+        {{- if .Values.kinesis.extraOutputs }}
+{{ .Values.kinesis.extraOutputs | indent 8}}
         {{- end }}
 {{- end }}
 
@@ -172,11 +187,14 @@ data:
         {{- end }}
         {{- if .Values.elasticsearch.replaceDots }}
         Replace_Dots    {{ .Values.elasticsearch.replaceDots }}
+        {{- end -}}
+        {{- if .Values.elasticsearch.extraOutputs }}
+{{ .Values.elasticsearch.extraOutputs | indent 8}}
         {{- end }}
 {{- end }}
 
-{{- if .Values.extraOutputs }}
-{{ .Values.extraOutputs | indent 8}}
+{{- if .Values.additionalOutputs }}
+{{ .Values.additionalOutputs | indent 4}}
 {{- end }}
 
 

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ include "aws-for-fluent-bit.namespace" . }}
   labels:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
@@ -49,7 +51,7 @@ spec:
           configMap:
             name: {{ include "aws-for-fluent-bit.fullname" . }}
         {{- if .Values.volumes }}
-        {{- toYaml .Values.volumes | nindent 8}}
+        {{- toYaml .Values.volumes | nindent 8 }}
         {{- end}}
       {{- if .Values.tolerations }}
       tolerations:

--- a/stable/aws-for-fluent-bit/templates/service.yaml
+++ b/stable/aws-for-fluent-bit/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if $.Values.serviceMonitor }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+spec:
+  ports:
+  - name: monitor-agent
+    port: {{ .Values.serviceMonitor.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.serviceMonitor.service.targetPort }}
+  selector:
+    {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None
+  type: {{ .Values.serviceMonitor.service.type }}
+{{- end }}
+{{- end }}

--- a/stable/aws-for-fluent-bit/templates/serviceaccount.yaml
+++ b/stable/aws-for-fluent-bit/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
-  namespace: {{ include "aws-for-fluent-bit.namespace" . }}  
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
   labels:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/stable/aws-for-fluent-bit/templates/servicemonitor.yaml
+++ b/stable/aws-for-fluent-bit/templates/servicemonitor.yaml
@@ -1,0 +1,49 @@
+{{- if $.Values.serviceMonitor }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - port: monitor-agent
+    scheme: http
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+{{- end }}
+  jobLabel: {{ default "app.kubernetes.io/instance" .Values.serviceMonitor.jobLabel }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -44,7 +44,7 @@ filter:
   keepLog: "On"
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
-  # extraParameters: |
+  # extraFilters: |
   #   ...
 
 # additionalFilters: |
@@ -67,7 +67,7 @@ cloudWatch:
   autoCreateGroup: true
   endpoint:
   credentialsEndpoint: {}
-  # extraParameters: |
+  # extraOutputs: |
   #   ...
 
 firehose:
@@ -79,7 +79,7 @@ firehose:
   roleArn:
   endpoint:
   timeKey:
-  # extraParameters: |
+  # extraOutputs: |
   #   ...
 
 kinesis:
@@ -101,7 +101,7 @@ kinesis:
   experimental:
     concurrency:
     concurrencyRetries:
-  # extraParameters: |
+  # extraOutputs: |
   #   ...
 
 elasticsearch:
@@ -114,7 +114,7 @@ elasticsearch:
   port: "443"
   retryLimit: 6
   replaceDots: "On"
-  # extraParameters: |
+  # extraOutputs: |
   #   Index = my-index
 
 # additionalOutputs: |

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -12,6 +12,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
+  ## Allow the service to be exposed for monitoring
+  ## https://docs.fluentbit.io/manual/administration/monitoring
+  # extraService: |
+  #   HTTP_Server  On
+  #   HTTP_Listen  0.0.0.0
+  #   HTTP_PORT    2020
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
   # additionalParsers: |
@@ -28,6 +34,8 @@ input:
   memBufLimit: 5MB
   skipLongLines: "On"
   refreshInterval: 10
+  # extraInputs: |
+  #   ...
 
 # additionalInputs: |
 #   [INPUT]
@@ -183,3 +191,27 @@ volumeMounts:
   - name: varlibdockercontainers
     mountPath: /var/lib/docker/containers
     readOnly: true
+
+
+serviceMonitor:
+  # service:
+  #   type: ClusterIP
+  #   port: 2020
+  #   targetPort: 2020
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path of metrics, e.g /api/v1/metrics/prometheus
+  # telemetryPath: /api/v1/metrics/prometheus
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # relabelings: []
+  # Set of labels to transfer on the Kubernetes Service onto the target.
+  # targetLabels: []
+  # metricRelabelings: []

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -14,7 +14,8 @@ fullnameOverride: ""
 service:
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
-  # extraParsers: |
+  # additionalParsers: |
+  #   [PARSER]
   #       Name   logfmt
   #       Format logfmt
 
@@ -28,7 +29,8 @@ input:
   skipLongLines: "On"
   refreshInterval: 10
 
-# extraInputs: |
+# additionalInputs: |
+#   [INPUT]
 #       Name         winlog
 #       Channels     Setup,Windows PowerShell
 #       Interval_Sec 1
@@ -42,8 +44,11 @@ filter:
   keepLog: "On"
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
+  # extraParameters: |
+  #   ...
 
-# extraFilters: |
+# additionalFilters: |
+#   [FILTER]
 #       Name   grep
 #       Match  *
 #       Exclude log lvl=debug*
@@ -62,6 +67,8 @@ cloudWatch:
   autoCreateGroup: true
   endpoint:
   credentialsEndpoint: {}
+  # extraParameters: |
+  #   ...
 
 firehose:
   enabled: true
@@ -72,6 +79,8 @@ firehose:
   roleArn:
   endpoint:
   timeKey:
+  # extraParameters: |
+  #   ...
 
 kinesis:
   enabled: true
@@ -92,6 +101,8 @@ kinesis:
   experimental:
     concurrency:
     concurrencyRetries:
+  # extraParameters: |
+  #   ...
 
 elasticsearch:
   enabled: true
@@ -103,8 +114,11 @@ elasticsearch:
   port: "443"
   retryLimit: 6
   replaceDots: "On"
+  # extraParameters: |
+  #   Index = my-index
 
-# extraOutputs: |
+# additionalOutputs: |
+#   [OUTPUT]
 #     Name file
 #     Format template
 #     Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
@@ -135,7 +149,7 @@ affinity: {}
 
 annotations: {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
-  
+
 env: []
 ## To add extra environment variables to the pods, add as below
 # env:
@@ -153,7 +167,7 @@ env: []
 #     valueFrom:
 #       fieldRef:
 #         fieldPath: spec.nodeName
-  
+
 
 volumes:
   - name: varlog


### PR DESCRIPTION
### Issue

To fix https://github.com/aws/eks-charts/issues/657  this PR https://github.com/aws/eks-charts/pull/658 remove the ability to add new output, filter or input.

We need two ways to customize the configmap:
- add extra to existing config
- add additional config

### Description of changes

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Breaking change

To rollback to the behavior previous to #658 but keep the flexibility to add extra parameters to existing input, filter ...
I've nested all extraXXX inside their block, for instance:

```
extraInputs: | 
   foo: bar
```

become

```
input:
  extraInputs: |
   foo: bar
```

And also, previous #658 usage: 

```
extraFilters: |
  [FILTER]
      Name modify
      Match *
      Set src_type kubernetes
```

became:

```
additionalFilters: |
  [FILTER]
      Name modify
      Match *
      Set src_type kubernetes
```


### Testing

I've tested elasticsearch.extraOutputs, serviceMonitor, service.extraService, extraFilters, extraInputs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
