### PR TITLE
Charts sync from aws-vpc-cni to eks-charts missed few fixes

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.13
+version: 1.1.14
 appVersion: "v1.10.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/templates/clusterrole.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrole.yaml
@@ -14,10 +14,17 @@ rules:
     resources:
       - namespaces
     verbs: ["list", "watch", "get"]
+{{- if .Values.env.ANNOTATE_POD_IP }}
   - apiGroups: [""]
     resources:
       - pods
     verbs: ["list", "watch", "get", "patch"]
+{{- else }}
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get"]
+{{- end }}
   - apiGroups: [""]
     resources:
       - nodes

--- a/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
+++ b/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -2,6 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: {{ include "aws-vpc-cni.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-vpc-cni.labels" . | indent 4 }}
 spec:
@@ -39,8 +40,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.init.image.region }}.amazonaws.com/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
-        imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}{{- .Values.init.image.account }}.dkr.ecr.{{- .Values.init.image.region }}.{{- .Values.init.image.domain }}/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
         env:
 {{- range $key, $value := .Values.init.env }}
           - name: {{ $key }}
@@ -62,14 +62,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: aws-node
-          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.image.region }}.amazonaws.com/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
           ports:
             - containerPort: 61678
               name: metrics
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
-            timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }} 
+            timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }}
           readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 12 }}
             timeoutSeconds: {{ .Values.readinessProbeTimeoutSeconds }}

--- a/stable/aws-vpc-cni/templates/serviceaccount.yaml
+++ b/stable/aws-vpc-cni/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aws-vpc-cni.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -167,4 +167,5 @@ eniConfig:
     #   - sg-789
 
 cri:
-  hostPath: # "/var/run/containerd/containerd.sock"
+  hostPath:
+#     path: /var/run/containerd/containerd.sock


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
Every release we sync aws-vpc-cni with eks-charts but certain fixes had missed.
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
