### PR TITLE
[aws-cloudwatch-metrics] Updated cw agent image to version 1.247350.0b251780 and introduced bottlerocket support

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.6
-appVersion: "1.247345"
+version: 0.0.7
+appVersion: "1.247350"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -32,3 +32,4 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `nodeSelector` | Node labels for pod assignment	 | {} | 
 | `tolerations` | Optional deployment tolerations	 | {} | 
 | `annotations` | Optional pod annotations	 | {} | 
+| `bottlerocket` | `true` if the data-plane of the EKS cluster is backed by [Bottlerocket](https://aws.amazon.com/bottlerocket/) AMIs | `false` | 

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -32,4 +32,4 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `nodeSelector` | Node labels for pod assignment	 | {} | 
 | `tolerations` | Optional deployment tolerations	 | {} | 
 | `annotations` | Optional pod annotations	 | {} | 
-| `bottlerocket` | `true` if the data-plane of the EKS cluster is backed by [Bottlerocket](https://aws.amazon.com/bottlerocket/) AMIs | `false` | 
+| `containerdSockPath` | Path to containerd' socket | /run/containerd/containerd.sock

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CI_VERSION
-          value: "k8s/1.2.2"
+          value: "k8s/1.3.9"
         # Please don't change the mountPath
         volumeMounts:
         - name: cwagentconfig
@@ -47,6 +47,9 @@ spec:
           readOnly: true
         - name: varlibdocker
           mountPath: /var/lib/docker
+          readOnly: true
+        - name: containerdsock
+          mountPath: /run/containerd/containerd.sock
           readOnly: true
         - name: sys
           mountPath: /sys
@@ -69,6 +72,14 @@ spec:
       - name: varlibdocker
         hostPath:
           path: /var/lib/docker
+      - name: containerdsock
+        hostPath:
+        {{- if .Values.bottlerocket }}
+          # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-troubleshooting.html#ContainerInsights-troubleshooting-bottlerocket
+          path: /run/dockershim.sock
+        {{- else }}
+          path: /run/containerd/containerd.sock
+        {{- end }}
       - name: sys
         hostPath:
           path: /sys

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -74,12 +74,7 @@ spec:
           path: /var/lib/docker
       - name: containerdsock
         hostPath:
-        {{- if .Values.bottlerocket }}
-          # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-troubleshooting.html#ContainerInsights-troubleshooting-bottlerocket
-          path: /run/dockershim.sock
-        {{- else }}
-          path: /run/containerd/containerd.sock
-        {{- end }}
+          path: {{ .Values.containerdSockPath }}
       - name: sys
         hostPath:
           path: /sys

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: amazon/cloudwatch-agent
-  tag: 1.247345.36b249270
+  tag: 1.247350.0b251780
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name
@@ -24,3 +24,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# true if the EKS cluster is using bottlerocket-backed data plane
+bottlerocket: false

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -25,5 +25,6 @@ tolerations: []
 
 affinity: {}
 
-# true if the EKS cluster is using bottlerocket-backed data plane
-bottlerocket: false
+# For bottlerocket OS (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-troubleshooting.html#ContainerInsights-troubleshooting-bottlerocket)
+# containerdSockPath: /run/dockershim.sock 
+containerdSockPath: /run/containerd/containerd.sock


### PR DESCRIPTION
### Issue

N/A

### Description of changes
The purpose of this PR is mainly to align the chart with the latest version of the [aws samples manifest](https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml) as well as providing bottlrocket support.

- Updated cw agent image to version 1.247350.0b251780
- Introduced bottlerocket support

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

The chart rendering has been tested locally, also it has been installed against an EKS cluster to make sure `ContainerInsights` is working as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
