### PR TITLE
[appmesh-controller] Use cert-manager v1 APIs, if available

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.4
+version: 1.4.5
 appVersion: 1.4.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-controller/templates/webhook.yaml
+++ b/stable/appmesh-controller/templates/webhook.yaml
@@ -121,7 +121,11 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-serving-cert
@@ -137,7 +141,11 @@ spec:
     name: {{ template "appmesh-controller.fullname" . }}-selfsigned-issuer
   secretName: {{ template "appmesh-controller.fullname" . }}-webhook-server-cert
 ---
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Issuer
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-selfsigned-issuer


### PR DESCRIPTION
### Issue

The `cert-manager.io/v1alpha2` APIs have been deprecated since v1.4 of cert manager, and have been fully removed as of v1.7 ([link to relevant docs](https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/)).

Because of this, when attempting to use the chart on a cluster that's been upgraded to 1.7.x, the process fails with a error message like:

`Error: unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "Certificate" in version "cert-manager.io/v1alpha2", unable to recognize "": no matches for kind "Issuer" in version "cert-manager.io/v1alpha2"]`

### Description of changes

This PR updates the `appmesh-controller` chart to use the `cert-manager.io/v1` APIs if available, and then falls back to using the `v1alpha2` APIs if not, which should make the chart compatible with both older and newer cert-manager installations.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Tested via tearing down an existing App Mesh installation on a cluster that had been upgraded to use `cert-manager` version 1.7.1 (and was previously failing, with the above error). After deleting, app mesh was re-deployed to the cluster successfully (using a local copy of this branch, rather than the remote repo).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
