### PR TITLE
fix: set proper value name for additional parsers of aws-for-fluent-bit

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.14
+version: 0.1.15
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -38,7 +38,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `service.extraService` | Append to existing service with this value | `""` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
-| `service.additionalParsers` | Adding more parsers with this value | `""` |
+| `service.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
 | `extraInputs` | Append to existing input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -20,7 +20,7 @@ service:
   #   HTTP_PORT    2020
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
-  # additionalParsers: |
+  # extraParsers: |
   #   [PARSER]
   #       Name   logfmt
   #       Format logfmt


### PR DESCRIPTION
### Issue

n/a

### Description of changes

There is a skew between value names between templates and docs/values.yaml for additional parsers of `aws-for-fluent-bit`.

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

not needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
