### PR TITLE
[appmesh spire server] Limit spire configmap access to namespace

### DIFF
--- a/stable/appmesh-spire-server/Chart.yaml
+++ b/stable/appmesh-spire-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-server
 description: SPIRE Server Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-spire-server/templates/rbac.yaml
+++ b/stable/appmesh-spire-server/templates/rbac.yaml
@@ -1,14 +1,39 @@
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "appmesh-spire-server.fullname" . }}-configmap-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-spire-server.labels" . | indent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["patch", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "appmesh-spire-server.fullname" . }}-configmap-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-spire-server.labels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "appmesh-spire-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "appmesh-spire-server.fullname" . }}-configmap-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "appmesh-spire-server.fullname" . }}-role
   labels:
 {{ include "appmesh-spire-server.labels" . | indent 4 }}
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["patch", "get", "list"]
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

Moving the configmap permission for spire-server account from ClusterRole to Role. Role scopes the configmap access down to a single namespace. Spire only needs to read config maps in its own namespace.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

1. Removed the configmap permission and confirmed that spire server broke upon pod restart.
2. Added role and role binding in to confirm that spire server worked once more.
3. Set up some new certificates. Confirmed that App Mesh was able to consume them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
