### PR TITLE
[aws-vpc-cni] Add extraVolumeMounts and extraVolumes

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.14
+version: 1.1.15
 appVersion: "v1.10.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -26,47 +26,49 @@ To install into an EKS cluster where the CNI is already installed, see [this sec
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter               | Description                                             | Default                             |
-| ------------------------|---------------------------------------------------------|-------------------------------------|
-| `affinity`              | Map of node/pod affinities                              | `{}`                                |
-| `cniConfig.enabled`     | Enable overriding the default 10-aws.conflist file      | `false`                             |
-| `cniConfig.fileContents`| The contents of the custom cni config file              | `nil`                               |
-| `eniConfig.create`      | Specifies whether to create ENIConfig resource(s)       | `false`                             |
-| `eniConfig.region`      | Region to use when generating ENIConfig resource names  | `us-west-2`                         |
-| `eniConfig.subnets`     | A map of AZ identifiers to config per AZ                | `nil`                               |
-| `eniConfig.subnets.id`  | The ID of the subnet within the AZ which will be used in the ENIConfig | `nil`                |
-| `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
-| `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
-| `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.7.5`                            |
-| `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
-| `image.override`        | A custom docker image to use                            | `nil`                               |
-| `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `init.image.tag`        | Image tag                                               | `v1.7.5`                            |
-| `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |
-| `init.image.override`   | A custom docker image to use                            | `nil`                               |
-| `init.env`              | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
-| `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
-| `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
-| `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
-| `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |
-| `podSecurityContext`    | Pod Security Context                                    | `{}`                                |
-| `podAnnotations`        | annotations to add to each pod                          | `{}`                                |
-| `podLabels`             | Labels to add to each pod                               | `{}`                                |
-| `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
-| `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
-| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN"`  |
-| `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
-| `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
-| `livenessProbe`         | Livenness probe settings for daemonset                  | (see `values.yaml`)                 |
-| `readinessProbe`        | Readiness probe settings for daemonset                  | (see `values.yaml`)                 |
-| `crd.create`            | Specifies whether to create the VPC-CNI CRD             | `true`                              |
-| `tolerations`           | Optional deployment tolerations                         | `[]`                                |
-| `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
-| `cri.hostPath`          | Optional use alternative container runtime              | `nil`                               |
+| Parameter                          | Description                                                                                                                                 | Default                            |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| `affinity`                         | Map of node/pod affinities                                                                                                                  | `{}`                               |
+| `cniConfig.enabled`                | Enable overriding the default 10-aws.conflist file                                                                                          | `false`                            |
+| `cniConfig.fileContents`           | The contents of the custom cni config file                                                                                                  | `nil`                              |
+| `eniConfig.create`                 | Specifies whether to create ENIConfig resource(s)                                                                                           | `false`                            |
+| `eniConfig.region`                 | Region to use when generating ENIConfig resource names                                                                                      | `us-west-2`                        |
+| `eniConfig.subnets`                | A map of AZ identifiers to config per AZ                                                                                                    | `nil`                              |
+| `eniConfig.subnets.id`             | The ID of the subnet within the AZ which will be used in the ENIConfig                                                                      | `nil`                              |
+| `eniConfig.subnets.securityGroups` | The IDs of the security groups which will be used in the ENIConfig                                                                          | `nil`                              |
+| `env`                              | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options                | (see `values.yaml`)                |
+| `fullnameOverride`                 | Override the fullname of the chart                                                                                                          | `aws-node`                         |
+| `image.region`                     | ECR repository region to use. Should match your cluster                                                                                     | `us-west-2`                        |
+| `image.tag`                        | Image tag                                                                                                                                   | `v1.7.5`                           |
+| `image.pullPolicy`                 | Container pull policy                                                                                                                       | `IfNotPresent`                     |
+| `image.override`                   | A custom docker image to use                                                                                                                | `nil`                              |
+| `imagePullSecrets`                 | Docker registry pull secret                                                                                                                 | `[]`                               |
+| `init.image.region`                | ECR repository region to use. Should match your cluster                                                                                     | `us-west-2`                        |
+| `init.image.tag`                   | Image tag                                                                                                                                   | `v1.7.5`                           |
+| `init.image.pullPolicy`            | Container pull policy                                                                                                                       | `IfNotPresent`                     |
+| `init.image.override`              | A custom docker image to use                                                                                                                | `nil`                              |
+| `init.env`                         | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`)                |
+| `init.securityContext`             | Init container Security context                                                                                                             | `privileged: true`                 |
+| `originalMatchLabels`              | Use the original daemonset matchLabels                                                                                                      | `false`                            |
+| `nameOverride`                     | Override the name of the chart                                                                                                              | `aws-node`                         |
+| `extraVolumes`                     | Array to add extra volumes                                                                                                                  | `[]`                               |
+| `extraVolumeMounts`                | Array to add extra mount                                                                                                                    | `[]`                               |
+| `nodeSelector`                     | Node labels for pod assignment                                                                                                              | `{}`                               |
+| `podSecurityContext`               | Pod Security Context                                                                                                                        | `{}`                               |
+| `podAnnotations`                   | annotations to add to each pod                                                                                                              | `{}`                               |
+| `podLabels`                        | Labels to add to each pod                                                                                                                   | `{}`                               |
+| `priorityClassName`                | Name of the priorityClass                                                                                                                   | `system-node-critical`             |
+| `resources`                        | Resources for the pods                                                                                                                      | `requests.cpu: 10m`                |
+| `securityContext`                  | Container Security context                                                                                                                  | `capabilities: add: - "NET_ADMIN"` |
+| `serviceAccount.name`              | The name of the ServiceAccount to use                                                                                                       | `nil`                              |
+| `serviceAccount.create`            | Specifies whether a ServiceAccount should be created                                                                                        | `true`                             |
+| `serviceAccount.annotations`       | Specifies the annotations for ServiceAccount                                                                                                | `{}`                               |
+| `livenessProbe`                    | Liveness probe settings for daemonset                                                                                                       | (see `values.yaml`)                |
+| `readinessProbe`                   | Readiness probe settings for daemonset                                                                                                      | (see `values.yaml`)                |
+| `crd.create`                       | Specifies whether to create the VPC-CNI CRD                                                                                                 | `true`                             |
+| `tolerations`                      | Optional deployment tolerations                                                                                                             | `[]`                               |
+| `updateStrategy`                   | Optional update strategy                                                                                                                    | `type: RollingUpdate`              |
+| `cri.hostPath`                     | Optional use alternative container runtime                                                                                                  | `nil`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -110,6 +110,9 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+          {{- with .Values.extraVolumeMounts  }}
+          {{- toYaml .| nindent 10 }}
+          {{- end }}
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -142,6 +145,9 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+      {{- with .Values.extraVolumes  }}
+      {{- toYaml .| nindent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -10,9 +10,9 @@ init:
   image:
     tag: v1.10.2
     region: us-west-2
-    account: "602401143452"   
+    account: "602401143452"
     pullPolicy: Always
-    domain: "amazonaws.com"  
+    domain: "amazonaws.com"
     # Set to use custom image
     # override: "repo/org/image:tag"
   env:
@@ -24,8 +24,8 @@ init:
 image:
   region: us-west-2
   tag: v1.10.2
-  account: "602401143452"   
-  domain: "amazonaws.com"  
+  account: "602401143452"
+  domain: "amazonaws.com"
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"
@@ -122,6 +122,9 @@ updateStrategy:
   type: RollingUpdate
   rollingUpdate:
     maxUnavailable: "10%"
+
+extraVolumes: []
+extraVolumeMounts: []
 
 nodeSelector: {}
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

Adds extraVolumeMounts and extraVolumes to the deamonset. This enables manual configuration of IRSA. While env variables are already supported, there is no option to mount the projected serviceAccount token.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Running `helm template` and inspect the yaml output for the correct indent. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
