### PR TITLE
Added replaceDots to firehose also

### DIFF
--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -99,6 +99,9 @@ data:
         Match           {{ .Values.firehose.match }}
         region          {{ .Values.firehose.region }}
         delivery_stream {{ .Values.firehose.deliveryStream }}
+        {{- if .Values.kinesis.replaceDots }}
+        replace_dots    {{ .Values.kinesis.replaceDots }}
+        {{- end }}
         {{- if .Values.firehose.dataKeys }}
         data_keys       {{ .Values.firehose.dataKeys }}
         {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -83,6 +83,7 @@ firehose:
   match: "*"
   region: "us-east-1"
   deliveryStream: "my-stream"
+  replaceDots:
   dataKeys:
   roleArn:
   endpoint:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

I have added the replce_dots function to kinesis firehose also.

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
I have tested this by adding in values but the configmap didn't get updated for kinesis firehose with replace_dots. If I edit manually the configmap works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
