### PR TITLE
[aws-for-fluent-bit] Replaced docker.io image repo by public ECR

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.15
+version: 0.1.16
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -3,7 +3,7 @@ global:
 #   namespaceOverride:
 
 image:
-  repository: amazon/aws-for-fluent-bit
+  repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
   tag: 2.21.5
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
It would make sense that all EKS charts now use the ECR Public
repository. [re #356]

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

-  #356
- You can find the image [here](https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit)

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- Tested on an internal k8s cluster.

```bash
helm upgrade --install aws-for-fluent-bit eks/aws-for-fluent-bit 
    -n kube-system \
    -f helm/fluent-bit.yml \
    --debug \
```

Way of checking which image is being used
```bash
kubectl get pods -l app.kubernetes.io/name=aws-for-fluent-bit \
-n kube-system -o jsonpath="{.items[].spec.containers[].image}" \
 | tr -s '[[:space:]]' '\n' \
 | sort \
 | uniq -c

1 public.ecr.aws/aws-observability/aws-for-fluent-bit:2.21.5
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
