### PR TITLE
publish chart do not overwrite existing packages

### DIFF
--- a/scripts/publish-charts.sh
+++ b/scripts/publish-charts.sh
@@ -14,7 +14,7 @@ if echo "${CIRCLE_TAG}" | grep -Eq "^v[0-9]+(\.[0-9]+){2}$"; then
     git config user.name eks-bot
     git remote set-url origin ${REPOSITORY}
     git checkout gh-pages
-    mv -f $PACKAGE_DIR/stable/*.tgz .
+    mv -n $PACKAGE_DIR/stable/*.tgz .
     helmv3 repo index . --url https://aws.github.io/eks-charts
     git add .
     git commit -m "Publish stable charts ${CIRCLE_TAG}"


### PR DESCRIPTION
### Issue
Fixes: #726

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
Modify the publish charts script to invoke the `mv` command with `-n` aka `--no-clobber` option instead of the current `-f` (`--force`) option. This will prevent the release process from overwriting existing tarballs.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Pending new charts release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
