### PR TITLE
Add back region to eniConfig name

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.16
+version: 1.1.17
 appVersion: "v1.11.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/templates/eniconfig.yaml
+++ b/stable/aws-vpc-cni/templates/eniconfig.yaml
@@ -3,7 +3,7 @@
 apiVersion: crd.k8s.amazonaws.com/v1alpha1
 kind: ENIConfig
 metadata:
-  name: {{ $key }}
+  name: {{ required ".Values.eniConfig.region must be specified" $.Values.eniConfig.region }}{{ $key }}
 spec:
   {{- if $value.securityGroups }}
   securityGroups:


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/pull/730#pullrequestreview-949123485

### Description of changes

values.yaml and all other documentation seem to reference region. This may not be as flexible as specifying region as a name, but we should either remove all remaining region references or switch back to the old behavior for consistency across documentation and examples.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
