### PR TITLE
Add priority class to csi-secrets-store-provider-aws and update image tag

### DIFF
--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-aws
-version: 0.0.2
+version: 0.0.3
 appVersion: 1.0.r2
 kubeVersion: ">=1.17.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster.

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `resources`| Resource limit for provider pods on nodes | `requests.cpu: 50m`<br>`requests.memory: 100Mi`<br>`limits.cpu: 50m`<br>`limits.memory: 100Mi` |
 | `podLabels`| Additional pod labels | `{}` |
 | `podAnnotations` | Additional pod annotations| `{}` |
+| `priorityClassName` | Indicates the importance of a Pod relative to other Pods | `""` |
 | `updateStrategy` | Configure a custom update strategy for the daemonset on nodes | `RollingUpdate`|
 | `secrets-store-csi-driver.install` | Secrets Store CSI Driver chart install | `false`
 | `rbac.install` | Install default service account | true |

--- a/stable/csi-secrets-store-provider-aws/templates/daemonset.yaml
+++ b/stable/csi-secrets-store-provider-aws/templates/daemonset.yaml
@@ -45,6 +45,9 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: HostToContainer
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       volumes:
         - name: provider-vol
           hostPath:

--- a/stable/csi-secrets-store-provider-aws/values.yaml
+++ b/stable/csi-secrets-store-provider-aws/values.yaml
@@ -3,7 +3,7 @@ imagePullSecrets: []
 
 image:
   repository: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws
-  tag: 1.0.r2-2021.08.13.20.34-linux-amd64
+  tag: 1.0.r2-6-gee95299-2022.04.14.21.07
   pullPolicy: IfNotPresent
 
 nodeSelector: {}
@@ -12,6 +12,8 @@ tolerations: []
 port: 8989
 
 privileged: false
+
+priorityClassName: ""
 
 resources:
   requests:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->
Added priorityClassName to the Daemonset of csi-secrets-store-provider-aws. This is needed as when it is installed into a cluster we want this to run on each node. Without it pods are in pending state waiting to be scheduled.

Also bumped the image tag being used as it was out of date and bumped the chart version.
### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Was able to install into my cluster with a priorityClass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
