### PR TITLE
Add hostNetwork option for aws-for-fluent-bit

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.16
+version: 0.1.17
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -105,3 +105,4 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `annotations` | Optional pod annotations | `{}` |
 | `volumes` | Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
 | `volumeMounts` | Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
+| `hostNetwork` | If true, use hostNetwork | `false` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -158,6 +158,13 @@ affinity: {}
 annotations: {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
 
+# Specifies if aws-for-fluent-bit should be started in hostNetwork mode.
+#
+# This is required if using a custom CNI where the managed control plane nodes are unable to initiate
+# network connections to the pods, for example using Calico CNI plugin on EKS. This is not required or
+# recommended if using the Amazon VPC CNI plugin.
+hostNetwork: false
+
 env: []
 ## To add extra environment variables to the pods, add as below
 # env:


### PR DESCRIPTION
### Description of changes

I'm using the native VPC networking with the Amazon VPC Container Network Interface (CNI) plugin for Kubernetes but unfortunately there is no option to deploy aws-for-fluent-bit with hostNetwork.

This PR adds the option `hostNetwork`.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I forked the repo and I'm currently using it on my EKS cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
