### PR TITLE
add missing configuration options to fluentbit chart

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.16
+version: 0.1.17
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -58,6 +58,9 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
 | `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
 | `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
+| `cloudWatch.defaultLogGroupName` | Fallback in case any variables in logGroupName fail to parse. |  |
+| `cloudWatch.defaultLogStreamName` | Fallback in case any variables in logStreamName fail to parse. |  |
+| `cloudWatch.newLogGroupTags` |Comma/equal delimited string of tags to include with auto created log groups. Example: `--set cloudWatch.newLogGroupTags="tag1=test\,tag2=test"` |  |
 | `cloudWatch.extraOutputs` | Append extra outputs with value | `""` |
 | `firehose.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) | `true` | ✔
 | `firehose.match` | The log filter | `"*"` | ✔

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -57,36 +57,45 @@ data:
 
 {{- if .Values.cloudWatch.enabled }}
     [OUTPUT]
-        Name                  cloudwatch
-        Match                 {{ .Values.cloudWatch.match }}
-        region                {{ .Values.cloudWatch.region }}
-        log_group_name        {{ .Values.cloudWatch.logGroupName }}
+        Name                    cloudwatch
+        Match                   {{ .Values.cloudWatch.match }}
+        region                  {{ .Values.cloudWatch.region }}
+        log_group_name          {{ .Values.cloudWatch.logGroupName }}
         {{- if .Values.cloudWatch.logStreamName }}
-        log_stream_name       {{ .Values.cloudWatch.logStreamName }}
+        log_stream_name         {{ .Values.cloudWatch.logStreamName }}
         {{- end }}
         {{- if .Values.cloudWatch.logStreamPrefix }}
-        log_stream_prefix     {{ .Values.cloudWatch.logStreamPrefix }}
+        log_stream_prefix       {{ .Values.cloudWatch.logStreamPrefix }}
         {{- end }}
         {{- if .Values.cloudWatch.logKey }}
-        log_key               {{ .Values.cloudWatch.logKey }}
+        log_key                 {{ .Values.cloudWatch.logKey }}
         {{- end }}
         {{- if .Values.cloudWatch.logFormat }}
-        log_format            {{ .Values.cloudWatch.logFormat }}
+        log_format              {{ .Values.cloudWatch.logFormat }}
         {{- end }}
         {{- if .Values.cloudWatch.logRetentionDays }}
-        log_retention_days    {{ .Values.cloudWatch.logRetentionDays }}
+        log_retention_days      {{ .Values.cloudWatch.logRetentionDays }}
         {{- end }}
         {{- if .Values.cloudWatch.roleArn }}
-        role_arn              {{ .Values.cloudWatch.roleArn }}
+        role_arn                {{ .Values.cloudWatch.roleArn }}
         {{- end }}
         {{- if .Values.cloudWatch.autoCreateGroup }}
-        auto_create_group     {{ .Values.cloudWatch.autoCreateGroup }}
+        auto_create_group       {{ .Values.cloudWatch.autoCreateGroup }}
         {{- end }}
         {{- if .Values.cloudWatch.endpoint }}
-        endpoint              {{ .Values.cloudWatch.endpoint }}
+        endpoint                {{ .Values.cloudWatch.endpoint }}
         {{- end }}
         {{- if .Values.cloudWatch.credentialsEndpoint }}
-        credentials_endpoint  {{ toJson .Values.cloudWatch.credentialsEndpoint }}
+        credentials_endpoint    {{ toJson .Values.cloudWatch.credentialsEndpoint }}
+        {{- end }}
+        {{- if .Values.cloudWatch.defaultLogGroupName }}
+        default_log_group_name  {{ .Values.cloudWatch.defaultLogGroupName }}
+        {{- end }}
+        {{- if .Values.cloudWatch.defaultLogStreamName }}
+        default_log_stream_name {{ .Values.cloudWatch.defaultLogStreamName }}
+        {{- end }}
+        {{- if .Values.cloudWatch.newLogGroupTags }}
+        new_log_group_tags      {{ .Values.cloudWatch.newLogGroupTags }}
         {{- end -}}
         {{- if .Values.cloudWatch.extraOutputs }}
 {{ .Values.cloudWatch.extraOutputs | indent 8 }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -75,6 +75,9 @@ cloudWatch:
   autoCreateGroup: true
   endpoint:
   credentialsEndpoint: {}
+  defaultLogGroupName:
+  defaultLogStreamName:
+  newLogGroupTags:
   # extraOutputs: |
   #   ...
 


### PR DESCRIPTION
### Issue

n/a

### Description of changes

Adds a few missing options from the cloudwatch plugin to the fluentbit chart, see https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit#plugin-options

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

helm lint passed
`helm template fluentbit . --set cloudWatch.defaultLogGroupName=test --set cloudWatch.defaultLogStreamName=test --set cloudWatch.newLogGroupTags="^Cg1=test\,tag2=test" --validate` helm template passed
`helm install fluentbit . --set cloudWatch.defaultLogGroupName=test --set cloudWatch.defaultLogStreamName=test --set cloudWatch.newLogGroupTags="tag1=test\,tag2=test"` installed and verified in the config map the the desired configurations were present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
