### PR TITLE
[aws-for-fluentbit] Replaces parameter name <additionalParsers> by <extraParsers> in  docs.

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.16
+version: 0.1.17
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -38,7 +38,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `service.extraService` | Append to existing service with this value | `""` |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
-| `service.additionalParsers` | Adding more parsers with this value | `""` |
+| `service.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
 | `extraInputs` | Append to existing input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -20,7 +20,7 @@ service:
   #   HTTP_PORT    2020
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
-  # additionalParsers: |
+  # extraParsers: |
   #   [PARSER]
   #       Name   logfmt
   #       Format logfmt


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

The helm chart parameter `additionalParsers` was incorrect in the documentation. As we can see in the helm chart, the correct parameter for setting aditional fluent-bit parsers in the aws-for-fluentbit configmap is `extraParsers`.

https://github.com/aws/eks-charts/blob/master/stable/aws-for-fluent-bit/templates/configmap.yaml#L17

https://github.com/aws/eks-charts/blob/master/stable/aws-for-fluent-bit/templates/configmap.yaml#L204

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Executed the values.yaml file with the extraParsers correctly includes the additional parsers in the deployed configmap

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
