### PR TITLE
update vpc cni to v1.11.2

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.16
-appVersion: "v1.11.0"
+version: 1.1.17
+appVersion: "v1.11.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -39,14 +39,14 @@ The following table lists the configurable parameters for this chart and their d
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.10.2`                           |
+| `image.tag`             | Image tag                                               | `v1.11.2`                           |
 | `image.account`         | ECR repository account number                           | `602401143452`                      |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `init.image.tag`        | Image tag                                               | `v1.10.2`                           |
+| `init.image.tag`        | Image tag                                               | `v1.11.2`                           |
 | `init.image.account`    | ECR repository account number                           | `602401143452`                      |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.11.0
+    tag: v1.11.2
     region: us-west-2
     account: "602401143452"   
     pullPolicy: Always
@@ -23,7 +23,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.11.0
+  tag: v1.11.2
   account: "602401143452"   
   domain: "amazonaws.com"  
   pullPolicy: Always


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

* Improvement - https://github.com/aws/amazon-vpc-cni-k8s/pull/1991 (@orsenthil)
* Improvement - https://github.com/aws/amazon-vpc-cni-k8s/pull/1996 (@orsenthil)
* Improvement - https://github.com/aws/amazon-vpc-cni-k8s/pull/1997 (@orsenthil)


### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

1. Setup a cluster
```
eksctl create cluster --name senthil-$(date +%d%b)-c2 --version 1.22 --region us-west-2 --with-oidc --ssh-access --nodegroup-name standard-workers --node-type c5.xlarge --nodes 2 --nodes-min 1 --nodes-max 2
```
2. I had to attach `AmazonEKS_CNI_Policy` to NodeGroup IAM policy as it wasn't present.
3. Remove existing CNI
```
kubectl delete -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.10/config/master/aws-k8s-cni.yaml
```
4. Install CNI from charts
```
$ helm install aws-vpc-cni --namespace kube-system ./charts/aws-vpc-cni
NAME: aws-vpc-cni
LAST DEPLOYED: Fri Jun  3 18:11:45 2022
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
aws-vpc-cni has been installed or updated. To check the status of pods, run:

kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni"
```
5. Verify pods are running.
```
$ kubectl get pods --namespace kube-system -l "app.kubernetes.io/name=aws-node,app.kubernetes.io/instance=aws-vpc-cni" -w
NAME             READY   STATUS    RESTARTS        AGE
aws-node-fd66p   1/1     Running   4 (2m48s ago)   9m34s
aws-node-jtlsq   1/1     Running   4 (2m48s ago)   9m34s
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
