### PR TITLE
[aws-for-fluent-bit] Trigger DaemonSet rolling update on configmap change

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.17
+version: 0.1.18
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: {{ include "aws-for-fluent-bit.namespace" . }}
   labels:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
-  annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
@@ -15,8 +13,9 @@ spec:
       {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- if .Values.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.annotations }}
         {{- toYaml .Values.annotations | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
### Issue

The DaemonSet rolling update is not triggered on configmap updates due to misplaced annotation.

### Description of changes

As per the official [helm documentation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) I have moved the sha256sum annotation to `spec.template.metadata.annotations` to trigger an update upon ConfigMap changes.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually tested locally.
The annotation was already properly updated on ConfigMap changes but it was misplaced.
Moving it from `metadata.annotations` to `spec.template.metadata.annotations` solved the issue and the DaemonSet rolling update is successfully triggered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
