### PR TITLE
Add support for configuring tags included with auto created log groups

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.18
+version: 0.1.19
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -56,6 +56,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.logFormat` | An optional parameter that can be used to tell CloudWatch the format of the data. A value of json/emf enables CloudWatch to extract custom metrics embedded in a JSON payload. See the Embedded Metric Format. |  |
 | `cloudWatch.roleArn` | ARN of an IAM role to assume (for cross account access). |  |
 | `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
+| `cloudWatch.newLogGroupTags` | Tags to include with auto created log groups. Map of key/value pairs. | {} |
 | `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
 | `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
 | `cloudWatch.extraOutputs` | Append extra outputs with value | `""` |

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -56,7 +56,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.logFormat` | An optional parameter that can be used to tell CloudWatch the format of the data. A value of json/emf enables CloudWatch to extract custom metrics embedded in a JSON payload. See the Embedded Metric Format. |  |
 | `cloudWatch.roleArn` | ARN of an IAM role to assume (for cross account access). |  |
 | `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
-| `cloudWatch.newLogGroupTags` | Tags to include with auto created log groups. Map of key/value pairs. | {} |
+| `cloudWatch.newLogGroupTags` | Tags to include with auto created log groups. These will only be applied when `cloudWatch.autoCreateGroup` is set to `true` and the log group doesn't exist yet. Map of key/value pairs. | {} |
 | `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
 | `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
 | `cloudWatch.extraOutputs` | Append extra outputs with value | `""` |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -82,6 +82,13 @@ data:
         {{- if .Values.cloudWatch.autoCreateGroup }}
         auto_create_group     {{ .Values.cloudWatch.autoCreateGroup }}
         {{- end }}
+        {{- if .Values.cloudWatch.newLogGroupTags }}
+        {{- $tags := list -}}
+        {{- range $key, $value := .Values.cloudWatch.newLogGroupTags -}}
+        {{- $tags = printf "%s=%s" $key $value | append $tags -}}
+        {{- end }}
+        new_log_group_tags    {{ $tags | join "," }}
+        {{- end }}
         {{- if .Values.cloudWatch.endpoint }}
         endpoint              {{ .Values.cloudWatch.endpoint }}
         {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -73,6 +73,7 @@ cloudWatch:
   logRetentionDays:
   roleArn:
   autoCreateGroup: true
+  newLogGroupTags: {}
   endpoint:
   credentialsEndpoint: {}
   # extraOutputs: |


### PR DESCRIPTION
### Issue

n/a

### Description of changes

I've added the ability to set the `new_log_group_tags` option value for Fluent Bit Plugin for CloudWatch Logs. I'm currently starting work on migrating away from the FluentD CloudWatch implementation and this is the only bit of functionality I'm missing - it's already supported by the plugin itself, just not the chart.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I've tested this change by deploying the helm chart to a test cluster, verifying the Fluent Bit logs and checking the tags on log groups in CloudWatch. Note that contrary to the [README of the plugin itself](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/blob/mainline/README.md?plain=1#L38) I had to skip the double quotes as otherwise I was getting the following error back from the API:

    Member must have length less than or equal to 128, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: ^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]+)$

My test tag set didn't not include spaces however I've ran an additional test with spaces in the tag value and it's all worked great!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
