### PR TITLE
🥳 aws-load-balancer-controller v2.4.3 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.4.3
-appVersion: v2.4.2
+version: 1.4.4
+appVersion: v2.4.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.4.2
+  tag: v2.4.3
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.4.3 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.4.3 (requires Kubernetes 1.19+)
## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/)
Image: docker.io/amazon/aws-alb-ingress-controller:v2.4.3

Thanks to all our contributors! 😊
 
## What's new
1. This release introduces a new feature gate `SubnetsClusterTagCheck`, if set to `false` the controller ignores the cluster tag `kubernetes.io/cluster/${cluster-name}` during subnet auto-discovery.  This featureGate is set to `true` by default, you can disable via the controller flag `--feature-gates=SubnetsClusterTagCheck=false`.
2. A new feature gate `EnableIPTargetType`, if set to false, disables IP target support. 
3. Allow negative and duplicate group.orders for ingress group
4. Update the base container image
5. Helm chart changes
 
## Fixes
1. Set correct precedence for ingress rules in case of multiple matches
2. enhance handling for InvalidIngressClass case
3. fix failures during upgrade when using the default provided IngressClass and IngressClassParam
4. CVE-2022-28948

## Changelog since v2.4.2
* enhance handling for InvalidIngressClass case ([#2750](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2750), @M00nF1sh)
* add docs for NLB TLS termination ([#2680](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2680), @geoffcline)
* revise install guide ([#2704](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2704), @geoffcline)
* bump chart version to 1.4.3 ([#2746](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2746), @M00nF1sh)
* add HELM support for aws-api-throttle ([#2745](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2745), @M00nF1sh)
* use a dedicated config to disable default pod affinity ([#2743](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2743), @kishorj)
*  fix failures during upgrade when using the default provided IngressClass and IngressClassParam [#2732, @M00nF1sh]
* Helm: Add field for Webhook namespace selector ([#2724](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2724), @Volatus)
* Update go pkg dependencies ([#2742](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2742), @kishorj)
* Enhance client side throttling information ([#2739](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2739), @orsenthil)
* e2e test changes to support china regions ([#2723](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2723), @cgchinmay)
* Update default cluster version for e2e tests ([#2659](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2659), @kishorj)
* Do not set caBundle for webhooks if CertManager is used ([#2649](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2649), @mikael-lindstrom)
* Fix Dockerfile go dependency caching ([#2626](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2626), @hintofbasil)
* Add docs for example of gRPC health check success codes ([#2700](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2700), @ugwis)
* docs: update versions in instructions to match official AWS docs ([#2714](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2714), @Volatus)
* Fixed typo: Listner => Listener ([#2712](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2712), @PrajwalBorkar)
* Add clusterName as debug info for troubleshooting ([#2696](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2696), @guessi)
* Updated run-e2e-test script to remove eksctl iamserviceaccount creation ([#2664](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2664), @cgchinmay)
* Fix for failing Ingress tests ([#2658](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2658), @cgchinmay)
* Add support to disable cluster tag check during subnet auto-discovery ([#2635](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2635), @oliviassss)
* Added EnableIPTargetType flag to controller ([#2587](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2587), @thejasn)
* Allow negative and duplicate group.orders ([#2634](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2634), @jtdoepke)
* Migrate to ginkgo v2 ([#2639](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2639), @cgchinmay)
* Add imagePullSecrets option to ServiceAccount in helm chart ([#2624](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2624), @BrianKopp)
* feat: add optional service monitor namespace ([#2609](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2609), @shalom-cyera)
* helm: Add additionalLabels to all components ([#2618](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2618), @jdheyburn)
* fix log level ([#2598](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2598), @mikutas)
* helm: add deployment annotation ([#2611](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2611), @krrrr38)
* Format clusterSecretsPermissions.allowAllSecrets ([#2620](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2620), @orsenthil)
* [minor] - print the env variable name in the output ([#2610](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2610), @orsenthil)
* Sort ingress rules by path length and pathType ([#2409](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2409), @oliviassss)
* helm chart update ; adding support to set affinity in podSpec to the empty map ([#2576](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2576), @stensonb)
* adding optional support for topologySpreadConstraints to helm chart ([#2575](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2575), @stensonb)
* separate target for helm chart crds generation ([#2577](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2577), @kishorj)
* [Doc] Update migrate_v1_v2 document ([#2573](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2573), @yws-ss)
* Auto generate CRDs for the Helm chart ([#2517](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2517), @kishorj)
* fix default value in the service annotation doc ([#2569](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2569), @kishorj)
* Misc minor fixes to docs ([#2568](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2568), @prasadkatti)
* fix formatting ([#2567](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2567), @prasadkatti)
* minor fix ([#2566](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2566), @prasadkatti)
* docs cleanup in ingress spec ([#2565](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2565), @prasadkatti)

## ECR images
- 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.3
- 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/amazon/aws-load-balancer-controller:v2.4.3
- 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-load-balancer-controller:v2.4.3