### PR TITLE
fix(aws-cloudwatch-metrics): Add support for annotations

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.7
+version: 0.0.8
 appVersion: "1.247350"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -30,6 +30,6 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `serviceAccount.name` | Service account to be used | | 
 | `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` | 
 | `nodeSelector` | Node labels for pod assignment	 | {} | 
-| `tolerations` | Optional deployment tolerations	 | {} | 
+| `tolerations` | Optional deployment tolerations	 | [] | 
 | `annotations` | Optional pod annotations	 | {} | 
 | `containerdSockPath` | Path to containerd' socket | /run/containerd/containerd.sock

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "aws-cloudwatch-metrics.fullname" . }}
   labels:
     {{- include "aws-cloudwatch-metrics.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -12,6 +16,10 @@ spec:
     metadata:
       labels:
         {{- include "aws-cloudwatch-metrics.selectorLabels" . | nindent 8 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -25,6 +25,8 @@ tolerations: []
 
 affinity: {}
 
+annotations: {}
+
 # For bottlerocket OS (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-troubleshooting.html#ContainerInsights-troubleshooting-bottlerocket)
 # containerdSockPath: /run/dockershim.sock 
 containerdSockPath: /run/containerd/containerd.sock


### PR DESCRIPTION
### Issue

Annotations are not supported, even if the documentation states so.

### Description of changes

I'm adding support for annotations, and also fixing a typo in the doc.

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Locally tested with `helm template` as follows:

1. Create `defaults.yaml` with the following content:
```yaml
image:
  tag: 1.247349.0b251399
  pullPolicy: IfNotPresent
```
2. Run `helm template` against chart folder passing default.yaml as argument as follows: `helm template aws-cloudwatch-metrics ~/git/eks-charts/stable/aws-cloudwatch-metrics --namespace amazon-cloudwatch --set clusterName=dev -f defaults.yaml`
3. Verify we don't have any annotations in `aws-cloudwatch-metrics/templates/daemonset.yaml` resource.
```yaml
# Source: aws-cloudwatch-metrics/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: aws-cloudwatch-metrics
  labels:
    helm.sh/chart: aws-cloudwatch-metrics-0.0.8
    app.kubernetes.io/name: aws-cloudwatch-metrics
    app.kubernetes.io/version: "1.247350"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: aws-cloudwatch-metrics
  template:
    metadata:
      labels:
        app.kubernetes.io/name: aws-cloudwatch-metrics
    spec:
```
4. Amend the following lines to `defaults.yaml`
```yaml
annotations:
  cluster-autoscaler.kubernetes.io/enable-ds-eviction: false
  cluster-autoscaler.kubernetes.io/safe-to-evict: false
```
5. Run `helm template` command from step 2, now we can see tolerations in both resource's metadata as well as template's metadata.
```yaml
# Source: aws-cloudwatch-metrics/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: aws-cloudwatch-metrics
  labels:
    helm.sh/chart: aws-cloudwatch-metrics-0.0.8
    app.kubernetes.io/name: aws-cloudwatch-metrics
    app.kubernetes.io/version: "1.247350"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cluster-autoscaler.kubernetes.io/enable-ds-eviction: false
    cluster-autoscaler.kubernetes.io/safe-to-evict: false
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: aws-cloudwatch-metrics
  template:
    metadata:
      labels:
        app.kubernetes.io/name: aws-cloudwatch-metrics
      annotations:
        cluster-autoscaler.kubernetes.io/enable-ds-eviction: false
        cluster-autoscaler.kubernetes.io/safe-to-evict: false
    spec:
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
