### PR TITLE
Fluentbit update for configuring Use_kubelet feature

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
 version: 0.1.19
-appVersion: 2.21.5
+appVersion: 2.21.6
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.19
-appVersion: 2.21.6
+version: 0.1.20
+appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -105,4 +105,5 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `annotations` | Optional pod annotations | `{}` |
 | `volumes` | Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
 | `volumeMounts` | Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
+| `dnsPolicy` | Optional dnsPolicy | `ClusterFirst` |
 | `hostNetwork` | If true, use hostNetwork | `false` |

--- a/stable/aws-for-fluent-bit/templates/clusterrole.yaml
+++ b/stable/aws-for-fluent-bit/templates/clusterrole.yaml
@@ -7,6 +7,9 @@ rules:
     resources:
       - namespaces
       - pods
+      - pods/logs
+      - nodes
+      - nodes/proxy
     verbs: ["get", "list", "watch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -48,24 +48,6 @@ data:
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
         Buffer_Size         {{ .Values.filter.bufferSize }}
-        {{- if .Values.filter.labels }}
-        Labels       {{ .Values.filter.labels }}
-        {{- end }}
-        {{- if .Values.filter.annotations }}
-        Annotations       {{ .Values.filter.annotations }}
-        {{- end }}
-        {{- if .Values.filter.useKubelet }}
-        Use_Kubelet       {{ .Values.filter.useKubelet }}
-        {{- end }}
-        {{- if .Values.filter.kubeletPort }}
-        Kubelet_Port       {{ .Values.filter.kubeletPort }}
-        {{- end }}
-        {{- if .Values.filter.KubeCA_File }}
-        Kube_CA_File       {{ .Values.filter.KubeCA_File }}
-        {{- end }}
-        {{- if .Values.filter.KubeTokenFile }}
-        Kube_Token_File       {{ .Values.filter.KubeTokenFile }}
-        {{- end }}
 {{- if .Values.filter.extraFilters }}
 {{ .Values.filter.extraFilters | indent 8 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -48,6 +48,24 @@ data:
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
         Buffer_Size         {{ .Values.filter.bufferSize }}
+        {{- if .Values.filter.labels }}
+        Labels       {{ .Values.filter.labels }}
+        {{- end }}
+        {{- if .Values.filter.annotations }}
+        Annotations       {{ .Values.filter.annotations }}
+        {{- end }}
+        {{- if .Values.filter.useKubelet }}
+        Use_Kubelet       {{ .Values.filter.useKubelet }}
+        {{- end }}
+        {{- if .Values.filter.kubeletPort }}
+        Kubelet_Port       {{ .Values.filter.kubeletPort }}
+        {{- end }}
+        {{- if .Values.filter.KubeCA_File }}
+        Kube_CA_File       {{ .Values.filter.KubeCA_File }}
+        {{- end }}
+        {{- if .Values.filter.KubeTokenFile }}
+        Kube_Token_File       {{ .Values.filter.KubeTokenFile }}
+        {{- end }}
 {{- if .Values.filter.extraFilters }}
 {{ .Values.filter.extraFilters | indent 8 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -30,8 +30,11 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       {{- if .Values.hostNetwork }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.hostNetwork }}
       {{- end }}
+      { { - if .Values.dnsPolicy } }
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      { { - end } }
       containers:
         - name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -53,6 +53,15 @@ filter:
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
   bufferSize: "32k"
+  # Uncomment the following filters to Enable the Use_Kubelet feature for large clusters
+  # Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
+#  labels: "Off"
+#  annotations: "Off"
+#  useKubelet: "true"
+#  kubeletPort: "10250"
+#  KubeCA_File: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+#  KubeTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
   # extraFilters: |
   #   ...
 

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -53,7 +53,6 @@ filter:
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
   bufferSize: "32k"
-
 # Uncomment the extraFilters to use Kubelet to get the Metadata instead of talking to API server for large clusters
 # Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
 #  extraFilters: |
@@ -64,7 +63,6 @@ filter:
 #    Kubelet_Port        10250
 #    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 #    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-
 
 # additionalFilters: |
 #   [FILTER]

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -164,7 +164,13 @@ annotations: {}
 # This is required if using a custom CNI where the managed control plane nodes are unable to initiate
 # network connections to the pods, for example using Calico CNI plugin on EKS. This is not required or
 # recommended if using the Amazon VPC CNI plugin.
+
+# To use Kubelet to get the Metadata instead of talking to API server then set the following
+#  hostNetwork: true
+#  dnsPolicy: ClusterFirstWithHostNet  # For Pods running with hostNetwork, you should explicitly set its DNS policy
+
 hostNetwork: false
+dnsPolicy: ClusterFirst
 
 env: []
 ## To add extra environment variables to the pods, add as below

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -53,17 +53,18 @@ filter:
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
   bufferSize: "32k"
-  # Uncomment the following filters to Enable the Use_Kubelet feature for large clusters
-  # Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
-#  labels: "Off"
-#  annotations: "Off"
-#  useKubelet: "true"
-#  kubeletPort: "10250"
-#  KubeCA_File: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-#  KubeTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
-  # extraFilters: |
-  #   ...
+# Uncomment the extraFilters to use Kubelet to get the Metadata instead of talking to API server for large clusters
+# Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
+#  extraFilters: |
+#    Kube_Tag_Prefix     application.var.log.containers.
+#    Labels              Off
+#    Annotations         Off
+#    Use_Kubelet         true
+#    Kubelet_Port        10250
+#    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+#    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+
 
 # additionalFilters: |
 #   [FILTER]
@@ -174,10 +175,8 @@ annotations: {}
 # network connections to the pods, for example using Calico CNI plugin on EKS. This is not required or
 # recommended if using the Amazon VPC CNI plugin.
 
-# To use Kubelet to get the Metadata instead of talking to API server then set the following
-#  hostNetwork: true
-#  dnsPolicy: ClusterFirstWithHostNet  # For Pods running with hostNetwork, you should explicitly set its DNS policy
-
+# Set hostNetwork to true and dnsPolicy to ClusterFirstWithHostNet to use Kubelet to get the Metadata for large clusters
+# Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
 hostNetwork: false
 dnsPolicy: ClusterFirst
 

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
-  tag: 2.21.5
+  tag: 2.21.6
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
-  tag: 2.21.6
+  tag: 2.21.5
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
### Issue

Currently this Helm Chart doesn't provide support for configuring `Use_Kubelet` feature.  

Why do we need `Use_Kubelet` feature?  See the details below

Using Kubelet to Get Metadata is a Optional Feature in FluentBit 
There is an [issue](https://github.com/fluent/fluent-bit/issues/1948) reported about kube-apiserver fall over and become unresponsive when cluster is too large and too many requests are sent to it. For this feature, fluent bit Kubernetes filter will send the request to kubelet /pods endpoint instead of kube-apiserver to retrieve the pods information and use it to enrich the log. Since Kubelet is running locally in nodes, the request would be responded faster and each node would only get one request one time. This could save kube-apiserver power to handle other requests. When this feature is enabled, you should see no difference in the kubernetes metadata added to logs, but the Kube-apiserver bottleneck should be avoided when cluster is large.

Checkout the AWS guidance here -> https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

- Updated cluster role with the required permissions to read metadata using kubelet
- Daemonset config updated to use dnsPolicy
- Additional config for ConfigMap filters
- Finally new values in values.yaml

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

I used the following config to enable the `Kubelet` to get Metadata instead of using API server. This will help to reduce the number of calls to API server and not to overwhelm the API server for large clusters

```yaml
filter:
  name: "kubernetes"
  match: "kube.*"
  kubeURL: "https://kubernetes.default.svc.cluster.local:443"
  mergeLog: "On"
  mergeLogKey: "log_processed"
  keepLog: "On"
  k8sLoggingParser: "On"
  k8sLoggingExclude: "Off"
  bufferSize: "0"
  extraFilters: |
    Kube_Tag_Prefix     application.var.log.containers.
    Labels              Off
    Annotations         Off
    Use_Kubelet         true
    Kubelet_Port        10250
    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token

hostNetwork: true
dnsPolicy: ClusterFirstWithHostNet
```

Test Result

```
Fluent Bit v1.8.11
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/14 18:21:01] [ info] [engine] started (pid=1)
[2022/08/14 18:21:01] [ info] [storage] version=1.1.5, initializing...
[2022/08/14 18:21:01] [ info] [storage] in-memory
[2022/08/14 18:21:01] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/08/14 18:21:01] [ info] [cmetrics] version=0.2.2
[2022/08/14 18:21:01] [ info] [filter:kubernetes:kubernetes.0] https=1 host=127.0.0.1 port=10250
[2022/08/14 18:21:01] [ info] [filter:kubernetes:kubernetes.0] local POD info OK
[2022/08/14 18:21:01] [ info] [filter:kubernetes:kubernetes.0] testing connectivity with Kubelet...
[2022/08/14 18:21:01] [ warn] [filter:kubernetes:kubernetes.0] could not get meta for POD ip-10-1-2-134.us-west-2.compute.internal
AWS for Fluent Bit Container Image Version 2.21.5time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter log_group_name = '/spark-k8s-operator/worker-fluentbit-logs'"
time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter default_log_group_name = 'fluentbit-default'"
time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter log_stream_prefix = 'fluentbit-'"
time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter log_stream_name = ''"
time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter default_log_stream_name = '/fluentbit-default'"
time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter region = 'us-west-2'"
time="2022-08-14T18:21:01Z" level=info msg="[cloudwatch 0] plugin parameter log_key = ''"
[2022/08/14 18:21:01] [ info] [sp] stream processor started
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
