### PR TITLE
Add support for metricsCollectionInterval variable to allow custom se…

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.7
+version: 0.0.8
 appVersion: "1.247350"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -33,3 +33,4 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `tolerations` | Optional deployment tolerations	 | {} | 
 | `annotations` | Optional pod annotations	 | {} | 
 | `containerdSockPath` | Path to containerd' socket | /run/containerd/containerd.sock
+| `metricsCollectionInterval` | Metrics collection interval | 60 | 

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": {{ .Values.metricsCollectionInterval | default 60 }}
           }
         },
         "force_flush_interval": 5

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -28,3 +28,5 @@ affinity: {}
 # For bottlerocket OS (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-troubleshooting.html#ContainerInsights-troubleshooting-bottlerocket)
 # containerdSockPath: /run/dockershim.sock 
 containerdSockPath: /run/containerd/containerd.sock
+
+metricsCollectionInterval: {}


### PR DESCRIPTION
### Description of changes

Adds metricsCollectionInterval configurable variable to aws-cloudwatch-metrics configmap.
Default is still 60 as it was statically set before. 

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

Tested module with the following setup:
- Terraform version: 0.13.7
- Kubernetes version: 1.22.2
- Gitlab Helm Registry


Testing the module without setting the variable, it should default to 60:
```
resource "helm_release" "aws-cloudwatch-metrics" {
  name       = "aws-cloudwatch-metrics"
  repository = "https://gitlab.com/api/v4/projects/myprojectid/packages/helm/stable"
  repository_username = "dummyusername"
  repository_password = "dummypassword"
  chart      = "aws-cloudwatch-metrics"
  version    = "0.0.8"
  namespace  = "amazon-cloudwatch"
  values = [
    templatefile("${path.module}/values.tpl", {
      cluster_name                = var.cluster_name
      aws_account_id              = var.aws_account_id
      image_tag                   = var.image_tag
      cluster_oidc_issuer_url     = var.cluster_oidc_issuer_url
  })]

  depends_on = [
    aws_iam_role.cloudwatch-agent,
    aws_iam_role_policy_attachment.cloudwatch-agent,
    kubernetes_namespace.amazon-cloudwatch
  ]
}
```

Output:
```
➜  test003 k get all -n amazon-cloudwatch                              
NAME                                      READY   STATUS    RESTARTS   AGE
pod/aws-cloudwatch-metrics-cmpq9          1/1     Running   0          11m
pod/fluent-bit-aws-for-fluent-bit-kq7ds   1/1     Running   0          11m

NAME                                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/aws-cloudwatch-metrics          1         1         1       1            1           <none>          11m
daemonset.apps/fluent-bit-aws-for-fluent-bit   1         1         1       1            1           <none>          11m
➜  test003 k get cm -n amazon-cloudwatch aws-cloudwatch-metrics -o yaml
apiVersion: v1
data:
  cwagentconfig.json: |
    {
      "logs": {
        "metrics_collected": {
          "kubernetes": {
            "cluster_name": "test003",
            "metrics_collection_interval": 60
          }
        },
        "force_flush_interval": 5
      }
    }
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: aws-cloudwatch-metrics
    meta.helm.sh/release-namespace: amazon-cloudwatch
  creationTimestamp: "2022-08-16T13:10:51Z"
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: aws-cloudwatch-metrics
    app.kubernetes.io/version: "1.247350"
    helm.sh/chart: aws-cloudwatch-metrics-0.0.8
  name: aws-cloudwatch-metrics
  namespace: amazon-cloudwatch
  resourceVersion: "361788"
  uid: 57b4bf65-3337-46ee-af3b-60fefa6f59f8
```



Testing the module while setting the variable, it should be 300 in the deployed configmap:
```
➜  test003 k get all -n amazon-cloudwatch                              
NAME                                      READY   STATUS    RESTARTS   AGE
pod/aws-cloudwatch-metrics-cmpq9          1/1     Running   0          2m19s
pod/fluent-bit-aws-for-fluent-bit-kq7ds   1/1     Running   0          2m17s

NAME                                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/aws-cloudwatch-metrics          1         1         1       1            1           <none>          2m19s
daemonset.apps/fluent-bit-aws-for-fluent-bit   1         1         1       1            1           <none>          2m17s
➜  test003 k get cm -n amazon-cloudwatch aws-cloudwatch-metrics -o yaml
apiVersion: v1
data:
  cwagentconfig.json: |
    {
      "logs": {
        "metrics_collected": {
          "kubernetes": {
            "cluster_name": "test003",
            "metrics_collection_interval": 300
          }
        },
        "force_flush_interval": 5
      }
    }
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: aws-cloudwatch-metrics
    meta.helm.sh/release-namespace: amazon-cloudwatch
  creationTimestamp: "2022-08-16T13:10:51Z"
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: aws-cloudwatch-metrics
    app.kubernetes.io/version: "1.247350"
    helm.sh/chart: aws-cloudwatch-metrics-0.0.8
  name: aws-cloudwatch-metrics
  namespace: amazon-cloudwatch
  resourceVersion: "359128"
  uid: 57b4bf65-3337-46ee-af3b-60fefa6f59f8
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
