### PR TITLE
Adding Mechanism to Avoid Deadlock

### DIFF
--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-sigv4-proxy-admission-controller
 description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -27,6 +27,12 @@ webhooks:
     sideEffects: None
     admissionReviewVersions:
     - v1beta1
+    objectSelector:
+      matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+        - {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
### Issue
#822 Avoiding Deadlock in aws-sigv4-proxy-admission-controller Chart.

### Description of changes
Adding an objectSelector to avoid webhook lock it self out in case of crashing or evicting situation. 
This will allow webhook to skip applying mutation webhhok on pods with lable `app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}`

### Checklist
- [x ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x ] Manually tested. Describe what testing was done in the testing section below
- [x ] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Manually deployed modified Chart and the pod can now avoid locking itself out after crashing/evicting/scaling event.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
