### PR TITLE
csi-secrets-store-provider-aws: update secrets-store-csi-driver to >=1.2; allow to specify service account role-arn annotation

### DIFF
--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-aws
-version: 0.0.3
+version: 0.0.4
 appVersion: 1.0.r2-6-gee95299-2022.04.14.21.07
 kubeVersion: ">=1.17.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster.

--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 dependencies:
 - name: secrets-store-csi-driver
   repository: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
-  version: 1.2.4
+  version: ~1.2
   condition: secrets-store-csi-driver.install
 keywords:
   - eks

--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 dependencies:
 - name: secrets-store-csi-driver
   repository: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
-  version: 1.1
+  version: 1.2.4
   condition: secrets-store-csi-driver.install
 keywords:
   - eks

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -44,6 +44,8 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `podAnnotations` | Additional pod annotations| `{}` |
 | `updateStrategy` | Configure a custom update strategy for the daemonset on nodes | `RollingUpdate`|
 | `secrets-store-csi-driver.install` | Secrets Store CSI Driver chart install | `true`
+| `secrets-store-csi-driver.syncSecret.enabled` | Enable rbac roles and bindings required for syncing to Kubernetes native secrets | `false`
 | `rbac.install` | Install default service account | true |
 | `rbac.pspEnabled` | Pod Security Pods | false |
 | `rbac.serviceAccount.name` | Service account to be used. If not set and serviceAccount.create is true a name is generated using the fullname template. | |
+| `rbac.serviceAccount.roleArn` | Amazon Resource Name (ARN) of the IAM role that you want the service account to assume. | `""` |

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -44,7 +44,6 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `podAnnotations` | Additional pod annotations| `{}` |
 | `updateStrategy` | Configure a custom update strategy for the daemonset on nodes | `RollingUpdate`|
 | `secrets-store-csi-driver.install` | Secrets Store CSI Driver chart install | `true`
-| `secrets-store-csi-driver.syncSecret.enabled` | Enable rbac roles and bindings required for syncing to Kubernetes native secrets | `false`
 | `rbac.install` | Install default service account | true |
 | `rbac.pspEnabled` | Pod Security Pods | false |
 | `rbac.serviceAccount.name` | Service account to be used. If not set and serviceAccount.create is true a name is generated using the fullname template. | |

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -23,7 +23,7 @@ Follow the [Usage](https://github.com/aws/secrets-store-csi-driver-provider-aws#
 
 The following table lists the configurable parameters of the csi-secrets-store-provider-aws chart and their default values.
 
-> Refer to [doc](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/charts/secrets-store-csi-driver/README.md) for configurable parameters of the secrets-store-csi-driver chart.
+> Refer to [doc](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/charts/secrets-store-csi-driver/README.md) for configurable parameters of the secrets-store-csi-driver chart. Override values inside of the secrets-store-csi-driver section.
 
 | Parameter | Description | Default |
 | --- | --- | --- |

--- a/stable/csi-secrets-store-provider-aws/templates/serviceaccount.yaml
+++ b/stable/csi-secrets-store-provider-aws/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "sscdpa.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{ include "sscdpa.labels" . | indent 2 }}
+{{- if .Values.rbac.serviceAccount.roleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.rbac.serviceAccount.roleArn | quote }}
+{{- end }}
 {{ end }}

--- a/stable/csi-secrets-store-provider-aws/values.yaml
+++ b/stable/csi-secrets-store-provider-aws/values.yaml
@@ -29,13 +29,8 @@ podAnnotations: {}
 updateStrategy:
   type: RollingUpdate
 
-## Configuration values for the secrets-store-csi-driver dependency.
-## ref: https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/charts/secrets-store-csi-driver/README.md
-##
 secrets-store-csi-driver:
   install: true
-  syncSecret:
-    enabled: false
 
 ## Install default service account
 rbac:

--- a/stable/csi-secrets-store-provider-aws/values.yaml
+++ b/stable/csi-secrets-store-provider-aws/values.yaml
@@ -29,8 +29,13 @@ podAnnotations: {}
 updateStrategy:
   type: RollingUpdate
 
+## Configuration values for the secrets-store-csi-driver dependency.
+## ref: https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/charts/secrets-store-csi-driver/README.md
+##
 secrets-store-csi-driver:
   install: true
+  syncSecret:
+    enabled: false
 
 ## Install default service account
 rbac:
@@ -38,5 +43,6 @@ rbac:
   pspEnabled: false
   serviceAccount:
     name:
+    roleArn: ""
 
 priorityClassName: ""


### PR DESCRIPTION
Update secrets-store-csi-driver to >=1.2
New parameter added:
- rbac.serviceAccount.roleArn (Amazon Resource Name (ARN) of the IAM role that you want the service account to assume.)

### Issue

https://github.com/aws/eks-charts/issues/815

### Description of changes

Update subchart

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
