### PR TITLE
🥳 aws-vpc-cni v1.12.0 Automated Release! 🥑

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.21
-appVersion: "v1.11.4"
+version: 1.2.0
+appVersion: "v1.12.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -39,14 +39,14 @@ The following table lists the configurable parameters for this chart and their d
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.11.4`                           |
+| `image.tag`             | Image tag                                               | `v1.10.2`                           |
 | `image.account`         | ECR repository account number                           | `602401143452`                      |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `init.image.tag`        | Image tag                                               | `v1.11.4`                           |
+| `init.image.tag`        | Image tag                                               | `v1.10.2`                           |
 | `init.image.account`    | ECR repository account number                           | `602401143452`                      |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |
@@ -63,7 +63,7 @@ The following table lists the configurable parameters for this chart and their d
 | `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
 | `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
-| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN"`  |
+| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" - "NET_RAW"`  |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
@@ -72,7 +72,6 @@ The following table lists the configurable parameters for this chart and their d
 | `crd.create`            | Specifies whether to create the VPC-CNI CRD             | `true`                              |
 | `tolerations`           | Optional deployment tolerations                         | `[]`                                |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
-| `cri.hostPath`          | Optional use alternative container runtime              | `nil`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -99,13 +99,6 @@ spec:
 {{- end }}
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
-{{- if .Values.cri.hostPath }}
-          - mountPath: /var/run/cri.sock
-            name: cri
-{{- else }}
-          - mountPath: /var/run/dockershim.sock
-            name: dockershim
-{{- end }}
           - mountPath: /var/run/aws-node
             name: run-dir
           - mountPath: /run/xtables.lock
@@ -124,15 +117,6 @@ spec:
       - name: cni-config
         configMap:
           name: {{ include "aws-vpc-cni.fullname" . }}
-{{- end }}
-{{- with .Values.cri.hostPath }}
-      - name: cri
-        hostPath:
-          {{- toYaml . | nindent 10 }}
-{{- else }}
-      - name: dockershim
-        hostPath:
-          path: /var/run/dockershim.sock
 {{- end }}
       - name: log-dir
         hostPath:

--- a/stable/aws-vpc-cni/test.yaml
+++ b/stable/aws-vpc-cni/test.yaml
@@ -1,31 +1,24 @@
 # Test values for aws-vpc-cni.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-# This default name override is to maintain backwards compatability with
-# existing naming
+#
 nameOverride: aws-node
 
 init:
   image:
-    tag: v1.10.2
+    tag: v1.9.0
     region: us-west-2
-    account: "602401143452"   
     pullPolicy: Always
-    domain: "amazonaws.com"  
     # Set to use custom image
     # override: "repo/org/image:tag"
   env:
     DISABLE_TCP_EARLY_DEMUX: "false"
-    ENABLE_IPv6: "false"
   securityContext:
     privileged: true
 
 image:
   region: us-west-2
-  tag: v1.10.2
-  account: "602401143452"   
-  domain: "amazonaws.com"  
+  tag: v1.9.0
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"
@@ -51,15 +44,12 @@ env:
   ENABLE_PREFIX_DELEGATION: "false"
   WARM_ENI_TARGET: "1"
   WARM_PREFIX_TARGET: "1"
-  DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
-  ENABLE_IPv4: "true"
-  ENABLE_IPv6: "false"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release
 originalMatchLabels: false
 
-cniConfig:
+cniConfig: 
   enabled: false
   fileContents: ""
 
@@ -73,12 +63,11 @@ podSecurityContext: {}
 
 podAnnotations: {}
 
-podLabels: {}
-
 securityContext:
   capabilities:
     add:
     - "NET_ADMIN"
+    - "NET_RAW"
 
 crd:
   create: true
@@ -97,22 +86,14 @@ livenessProbe:
     command:
       - /app/grpc-health-probe
       - '-addr=:50051'
-      - '-connect-timeout=5s'
-      - '-rpc-timeout=5s'
   initialDelaySeconds: 60
-
-livenessProbeTimeoutSeconds: 10
 
 readinessProbe:
   exec:
     command:
       - /app/grpc-health-probe
       - '-addr=:50051'
-      - '-connect-timeout=5s'
-      - '-rpc-timeout=5s'
   initialDelaySeconds: 1
-
-readinessProbeTimeoutSeconds: 10
 
 resources:
   requests:
@@ -131,6 +112,20 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
+        - matchExpressions:
+            - key: "beta.kubernetes.io/os"
+              operator: In
+              values:
+                - linux
+            - key: "beta.kubernetes.io/arch"
+              operator: In
+              values:
+                - amd64
+                - arm64
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+                - fargate
         - matchExpressions:
             - key: "kubernetes.io/os"
               operator: In
@@ -165,6 +160,3 @@ eniConfig:
     #   id: subnet-789
     #   securityGroups:
     #   - sg-789
-
-cri:
-  hostPath: # "/var/run/containerd/containerd.sock"

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.11.4
+    tag: v1.12.0
     region: us-west-2
     account: "602401143452"   
     pullPolicy: Always
@@ -23,7 +23,7 @@ init:
 
 image:
   region: us-west-2
-  tag: v1.11.4
+  tag: v1.12.0
   account: "602401143452"   
   domain: "amazonaws.com"  
   pullPolicy: Always
@@ -79,6 +79,7 @@ securityContext:
   capabilities:
     add:
     - "NET_ADMIN"
+    - "NET_RAW"
 
 crd:
   create: true
@@ -153,19 +154,15 @@ eniConfig:
   subnets:
     # Key identifies the AZ
     # Value contains the subnet ID and security group IDs within that AZ
-    # a:
+    # us-west-2a:
     #   id: subnet-123
     #   securityGroups:
     #   - sg-123
-    # b:
+    # us-west-2b:
     #   id: subnet-456
     #   securityGroups:
     #   - sg-456
-    # c:
+    # us-west-2c:
     #   id: subnet-789
     #   securityGroups:
     #   - sg-789
-
-cri:
-  hostPath:
-#     path: /var/run/containerd/containerd.sock


### PR DESCRIPTION
  ## aws-vpc-cni v1.12.0 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v1.12.0

This new version removes dependency on CRI socket(e.g. dockershim.sock).

#### Action Required For Upgrading
🚨 🚨 🚨 to upgrade to >=v1.12.0, you must upgrade to >=v1.7.x first. We recommend that you update one minor version at a time.

#### Changes since v1.11.4:
* Improvement - [switch to use state file for IP allocation pool management](https://github.com/aws/amazon-vpc-cni-k8s/pull/2110) (@M00nF1sh )
* Improvement - [explicitly request NET_RAW capabilities in CNI manifests ](https://github.com/aws/amazon-vpc-cni-k8s/pull/2063) (@JingmingGuo )
* Improvement - [Reduce startup latency by removing some unneeded sleeps](https://github.com/aws/amazon-vpc-cni-k8s/pull/2104) (@bwagner5 )
* Bug - [Remove extra decrement of totalIP count](https://github.com/aws/amazon-vpc-cni-k8s/pull/2042/files) (@jayanthvn )
* New Instance Support - [Add trn1 limits](https://github.com/aws/amazon-vpc-cni-k8s/pull/2092) (@cartermckinnon )
* Documentation - [Update readme with slack channel ](https://github.com/aws/amazon-vpc-cni-k8s/pull/2111) (@jayanthvn )
* Documentation - [Fix ENIConfig keys in values.yaml](https://github.com/aws/amazon-vpc-cni-k8s/pull/1989) (@chotiwat )
* Testing - [fix metrics-helper test to detach role policy early](https://github.com/aws/amazon-vpc-cni-k8s/pull/2121) (@sushrk )
* Testing - [Use GetNodes in metrics-helper; explicitly install latest addon](https://github.com/aws/amazon-vpc-cni-k8s/pull/2093/files) (@jdn5126 )
* Testing - [refine all github workflows](https://github.com/aws/amazon-vpc-cni-k8s/pull/2090) (@M00nF1sh )
* Testing - [Resolve flakiness in IPAMD warm target tests](https://github.com/aws/amazon-vpc-cni-k8s/pull/2112) (@jdn5126 )
* Testing - [VPC CNI Integration Test Fixes](https://github.com/aws/amazon-vpc-cni-k8s/pull/2105)  (@jdn5126 )
* Testing - [Update CNI canary integration test and cleanup for ginkgo v2](https://github.com/aws/amazon-vpc-cni-k8s/pull/2088)  (@jdn5126 )

#### To apply this release: 

```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.12.0/config/master/aws-k8s-cni.yaml
```

#### Verify the update:

```
$ kubectl describe daemonset aws-node -n kube-system | grep Image | cut -d "/" -f 2                                                   
amazon-k8s-cni-init:v1.12.0
amazon-k8s-cni:v1.12.0
```