### PR TITLE
stop using beta.kubernetes.io/os and arch

### DIFF
--- a/stable/aws-vpc-cni/test.yaml
+++ b/stable/aws-vpc-cni/test.yaml
@@ -113,20 +113,6 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: "beta.kubernetes.io/os"
-              operator: In
-              values:
-                - linux
-            - key: "beta.kubernetes.io/arch"
-              operator: In
-              values:
-                - amd64
-                - arm64
-            - key: "eks.amazonaws.com/compute-type"
-              operator: NotIn
-              values:
-                - fargate
-        - matchExpressions:
             - key: "kubernetes.io/os"
               operator: In
               values:


### PR DESCRIPTION
### Issue
See https://github.com/kubernetes/kubernetes/issues/89477, https://github.com/kubernetes/kubernetes/issues/89477#issuecomment-603911496.
<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

Need confirmation from project owners, if the older kube cluster is still in use.
It is deprecated since v1.14.

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
