### PR TITLE
Update SPIRE Version to v1.0.0

### DIFF
--- a/stable/appmesh-spire-agent/Chart.yaml
+++ b/stable/appmesh-spire-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-agent
 description: SPIRE Agent Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-spire-agent/templates/spire-agent-cfg.yaml
+++ b/stable/appmesh-spire-agent/templates/spire-agent-cfg.yaml
@@ -14,7 +14,6 @@ data:
       socket_path = "{{ .Values.config.socketPath }}"
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = "{{ .Values.config.trustDomain }}"
-      enable_sds = true
     }
 
     plugins {

--- a/stable/appmesh-spire-agent/values.yaml
+++ b/stable/appmesh-spire-agent/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gcr.io/spiffe-io/spire-agent
-  tag: 1.4.4
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/appmesh-spire-agent/values.yaml
+++ b/stable/appmesh-spire-agent/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gcr.io/spiffe-io/spire-agent
-  tag: 0.12.0
+  tag: 1.4.4
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/appmesh-spire-server/Chart.yaml
+++ b/stable/appmesh-spire-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-server
 description: SPIRE Server Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.0.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-spire-server/templates/spire-server-cfg.yaml
+++ b/stable/appmesh-spire-server/templates/spire-server-cfg.yaml
@@ -9,7 +9,7 @@ data:
     server {
       bind_address = "{{ .Values.config.bindAddress }}"
       bind_port = "{{ .Values.config.bindPort }}"
-      registration_uds_path = "/tmp/spire-registration.sock"
+      socket_path = "/tmp/spire-server/private/api.sock"
       trust_domain = "{{ .Values.config.trustDomain }}"
       data_dir = "/run/spire/data"
       log_level = "{{ .Values.config.logLevel }}"
@@ -36,14 +36,10 @@ data:
           clusters = {
             "k8s-cluster" = {
               use_token_review_api_validation = true
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }
-      }
-
-      NodeResolver "noop" {
-        plugin_data {}
       }
 
       KeyManager "disk" {

--- a/stable/appmesh-spire-server/values.yaml
+++ b/stable/appmesh-spire-server/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: gcr.io/spiffe-io/spire-server
-  tag: 0.12.0
+  tag: 1.4.4
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/appmesh-spire-server/values.yaml
+++ b/stable/appmesh-spire-server/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: gcr.io/spiffe-io/spire-server
-  tag: 1.4.4
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->
Update charts to be compatible with v1.0.0 SPIRE server and agent images

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Manually tested upgrading server and agents from v0.12 to v1.0 and went through the [mtls walkthrough for appmesh](https://github.com/aws/aws-app-mesh-examples/tree/main/walkthroughs/howto-k8s-mtls-sds-based). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
