### PR TITLE
[aws-for-fluent-bit] S3 output config for AWS for FluentBit Helm Chart

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.21
+version: 0.1.22
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -18,3 +18,5 @@ keywords:
   - cloudwatch
   - firehose
   - kinesis
+  - s3
+  - elasticsearch

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -95,6 +95,31 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `elasticsearch.retryLimit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
 | `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
 | `elasticsearch.extraOutputs` | Append extra outputs with value | `""` |
+| `s3.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/s3) | `false` | ✔
+| `s3.match` | The log filter | `"*"` | ✔
+| `s3.region` | The AWS region of your S3 bucket | `"us-east-1"` | ✔
+| `s3.bucket` | Name of the S3 Bucket | `"my-bucket-name"` | ✔
+| `s3.json_date_key` | Specify the name of the time key in the output record. To disable the time key just set the value to `false`. | |
+| `s3.json_date_format` | Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681) | |
+| `s3.total_file_size` | Specifies the size of files in S3. Maximum size is 50G, minimim is 1M | `"100M"` |
+| `s3.upload_chunk_size` | The size of each 'part' for multipart uploads. Max: 50M | |
+| `s3.upload_timeout` | Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. | |
+| `s3.store_dir` | Directory to locally buffer data before sending. When multipart uploads are used, data will only be buffered until the upload_chunk_size is reached. | `"/tmp/fluent-bit/s3"` |
+| `s3.s3_key_format` | Format string for keys in S3 | `"/fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S"` |
+| `s3.s3_key_format_tag_delimiters` | A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option. | |
+| `s3.static_file_path` | Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true. | `false` |
+| `s3.use_put_object` | Use the S3 PutObject API, instead of the multipart upload API. When this option is on, key extension is only available when $UUID is specified in `s3_key_format` | `false` |
+| `s3.role_arn` | ARN of an IAM role to assume (ex. for cross account access). | |
+| `s3.endpoint` | Custom endpoint for the S3 API. An endpoint can contain scheme and port. | |
+| `s3.sts_endpoint` | Custom endpoint for the STS API. | |
+| `s3.canned_acl` | Predefined Canned ACL policy for S3 objects. | |
+| `s3.compression` | Compression type for S3 objects. `gzip` or `arrow`. Default: None | |
+| `s3.content_type` | A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header. | |
+| `s3.send_content_md5` | Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled. | `false` |
+| `s3.auto_retry_requests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. | `true` |
+| `s3.log_key` | By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3. For example, if you are using Docker, you can specify log_key log and only the log message will be sent to S3. | |
+| `s3.preserve_data_ordering` | Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads. | |
+| `s3.storage_class` | Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class. | |
 | `additionalOutputs` | add outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |
 | `updateStrategy` | Optional update strategy | `type: RollingUpdate` |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -197,6 +197,80 @@ data:
         {{- end }}
 {{- end }}
 
+{{- if .Values.s3.enabled }}
+    [OUTPUT]
+        Name                            s3
+        Match                           {{ .Values.s3.match }}
+        region                          {{ .Values.s3.region }}
+        bucket                          {{ .Values.s3.bucket }}
+        {{- if .Values.s3.json_date_key }}
+        json_date_key                   {{ .Values.s3.json_date_key }}
+        {{- end }}
+        {{- if .Values.s3.json_date_format }}
+        json_date_format                {{ .Values.s3.json_date_format }}
+        {{- end }}
+        {{- if .Values.s3.total_file_size }}
+        total_file_size                 {{ .Values.s3.total_file_size }}
+        {{- end }}
+        {{- if .Values.s3.upload_chunk_size }}
+        upload_chunk_size               {{ .Values.s3.upload_chunk_size }}
+        {{- end }}
+        {{- if .Values.s3.upload_timeout }}
+        upload_timeout                  {{ .Values.s3.upload_timeout }}
+        {{- end }}
+        {{- if .Values.s3.store_dir }}
+        store_dir                       {{ .Values.s3.store_dir }}
+        {{- end }}
+        {{- if .Values.s3.s3_key_format }}
+        s3_key_format                   {{ .Values.s3.s3_key_format }}
+        {{- end }}
+        {{- if .Values.s3.s3_key_format_tag_delimiters }}
+        s3_key_format_tag_delimiters    {{ .Values.s3.s3_key_format_tag_delimiters }}
+        {{- end }}
+        {{- if .Values.s3.static_file_path }}
+        static_file_path                {{ .Values.s3.static_file_path }}
+        {{- end }}
+        {{- if .Values.s3.use_put_object }}
+        use_put_object                  {{ .Values.s3.use_put_object }}
+        {{- end }}
+        {{- if .Values.s3.role_arn }}
+        role_arn                        {{ .Values.s3.role_arn }}
+        {{- end }}
+        {{- if .Values.s3.endpoint }}
+        endpoint                        {{ .Values.s3.endpoint }}
+        {{- end }}
+        {{- if .Values.s3.sts_endpoint }}
+        sts_endpoint                    {{ .Values.s3.sts_endpoint }}
+        {{- end }}
+        {{- if .Values.s3.canned_acl }}
+        canned_acl                      {{ .Values.s3.canned_acl }}
+        {{- end }}
+        {{- if .Values.s3.compression }}
+        compression                     {{ .Values.s3.compression }}
+        {{- end }}
+        {{- if .Values.s3.content_type }}
+        content_type                    {{ .Values.s3.content_type }}
+        {{- end }}
+        {{- if .Values.s3.send_content_md5 }}
+        send_content_md5                {{ .Values.s3.send_content_md5 }}
+        {{- end }}
+        {{- if .Values.s3.auto_retry_requests }}
+        auto_retry_requests             {{ .Values.s3.auto_retry_requests }}
+        {{- end }}
+        {{- if .Values.s3.log_key }}
+        log_key                         {{ .Values.s3.log_key }}
+        {{- end }}
+        {{- if .Values.s3.preserve_data_ordering }}
+        preserve_data_ordering          {{ .Values.s3.preserve_data_ordering }}
+        {{- end }}
+        {{- if .Values.s3.storage_class }}
+        storage_class                   {{ .Values.s3.storage_class }}
+        {{- end }}
+        {{- if .Values.s3.extraOutputs }}
+{{ .Values.s3.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
 {{- if .Values.additionalOutputs }}
 {{ .Values.additionalOutputs | indent 4 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -134,6 +134,36 @@ elasticsearch:
   # extraOutputs: |
   #   Index = my-index
 
+# Check the docs for more S3 config options https://docs.fluentbit.io/manual/pipeline/outputs/s3
+s3:
+  enabled: false
+  match: "*"
+  region: "us-east-1"
+  bucket: "my-bucket-name"
+  json_date_key:
+  json_date_format:
+  total_file_size:
+  upload_chunk_size:
+  upload_timeout:
+  store_dir:
+  s3_key_format:
+  s3_key_format_tag_delimiters:
+  static_file_path:
+  use_put_object:
+  role_arn:
+  endpoint:
+  sts_endpoint:
+  canned_acl:
+  compression:
+  content_type:
+  send_content_md5:
+  auto_retry_requests:
+  log_key:
+  preserve_data_ordering:
+  storage_class:
+  # extraOutputs: |
+  #   ...
+
 # additionalOutputs: |
 #   [OUTPUT]
 #     Name file


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

- Added S3 output support for `aws-for-fluent-bit` Helm Chart 
- Updated `ConfigMap` and `values.yaml` to support writing logs to S3 buckets
- Updated README doc for Helm Chart

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
