### PR TITLE
[appmesh-spire-server] Add support for configuring SPIRE server plugins

### DIFF
--- a/stable/appmesh-spire-server/Chart.yaml
+++ b/stable/appmesh-spire-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-server
 description: SPIRE Server Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.5
+version: 1.0.6
 appVersion: 1.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-spire-server/README.md
+++ b/stable/appmesh-spire-server/README.md
@@ -42,3 +42,18 @@ Parameter | Description | Default
 `config.bindPort` | SPIRE Server Bind Port | `8081`
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | `spire-server`
+`config.plugin`| SPIRE Plugin(s) | `null`
+
+
+To add plugins to the SPIRE server according to the [documentation](https://spiffe.io/docs/latest/planning/extending/), use the following convention
+``` yaml
+config:
+    plugin: |
+        NodeAttestor "tpm" {
+            plugin_cmd = "/path/to/plugin_cmd"
+            plugin_checksum = "sha256 of the plugin binary"
+            plugin_data {
+                ca_path = "/opt/spire/.data/certs"
+            }
+        }       
+```

--- a/stable/appmesh-spire-server/templates/spire-server-cfg.yaml
+++ b/stable/appmesh-spire-server/templates/spire-server-cfg.yaml
@@ -52,4 +52,8 @@ data:
         plugin_data {
         }
       }
+      
+    {{- if .Values.config.plugin -}}
+    {{- .Values.config.plugin | nindent 6 -}}
+    {{- end -}}
     }

--- a/stable/appmesh-spire-server/values.yaml
+++ b/stable/appmesh-spire-server/values.yaml
@@ -51,5 +51,7 @@ config:
   svidTTL: 1h
   # SPIRE Server Bind Address
   bindAddress: 0.0.0.0
-  #SPIRE Server Bind Port
+  # SPIRE Server Bind Port
   bindPort: 8081
+  # SPIRE Plugins
+  plugin: ""


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/aws/eks-charts/issues/851

### Description of changes

Adds support for configuring SPIRE server plugins. Allows the ability to inject one or more formatted plugins to spire-server configmap.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
