### PR TITLE
Added elasticsearch.suppressTypeName to values.yaml to support settin…

### DIFF
--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -94,6 +94,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `elasticsearch.port` | TCP Port of the target service. | 443 |
 | `elasticsearch.retryLimit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
 | `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
+| `elasticsearch.suppressTypeName` | OpenSearch 2.0 and above needs to have type option being removed by setting Suppress_Type_Name On  | |
 | `elasticsearch.extraOutputs` | Append extra outputs with value | `""` |
 | `additionalOutputs` | add outputs with value | `""` |
 | `priorityClassName` | Name of Priority Class to assign pods | |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -192,6 +192,9 @@ data:
         {{- if .Values.elasticsearch.replaceDots }}
         Replace_Dots    {{ .Values.elasticsearch.replaceDots }}
         {{- end -}}
+        {{- if .Values.elasticsearch.suppressTypeName }}
+        Suppress_Type_Name    {{ .Values.elasticsearch.suppressTypeName }}
+        {{- end -}}
         {{- if .Values.elasticsearch.extraOutputs }}
 {{ .Values.elasticsearch.extraOutputs | indent 8 }}
         {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -131,6 +131,7 @@ elasticsearch:
   port: "443"
   retryLimit: 6
   replaceDots: "On"
+  suppressTypeName:
   # extraOutputs: |
   #   Index = my-index
 


### PR DESCRIPTION
…g Suppress_Type_Name for Opensearch 2.0 and above

### Issue

https://github.com/aws/eks-charts/issues/861

### Description of changes

Added suppressTypeName to aws-for-fluent-bit's values.yaml and changed configmap template to include Suppress_Type_Name if a value is present.

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [ X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Manually tested including and excluding the value and deployed the chart on an EKS cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
