### PR TITLE
Update Envoy sidecar resources request

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.9.0
-appVersion: 1.9.0
+version: 1.10.0
+appVersion: 1.10.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -387,7 +387,7 @@ Parameter | Description | Default
 `sidecar.logLevel` | Envoy log level | `info`
 `sidecar.envoyAdminAccessPort` | Envoy Admin Access Port | `9901`
 `sidecar.envoyAdminAccessLogFile` | Envoy Admin Access Log File | `/tmp/envoy_admin_access.log`
-`sidecar.resources.requests` | Envoy container resource requests | `requests: cpu 10m memory 32Mi`
+`sidecar.resources.requests` | Envoy container resource requests | `requests: cpu 512 memory 64Mi`
 `sidecar.resources.limits` | Envoy container resource limits | `limits: cpu "" memory ""`
 `sidecar.lifecycleHooks.preStopDelay` | Envoy container PreStop Hook Delay Value | `20s`
 `sidecar.lifecycleHooks.postStartInterval` | Envoy container PostStart Hook Interval Value | `5s`

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -27,8 +27,8 @@ sidecar:
   resources:
     # sidecar.resources.requests: Envoy CPU and memory requests
     requests:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 512
+      memory: 64Mi
     # sidecar.resources/limits: Envoy CPU and memory limits
     limits:
       cpu: ""


### PR DESCRIPTION
### Issue

Per [AWS document](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html) mentioned, AWS App Mesh recommend allocating **512** CPU units and at least **64 MiB** of memory to the Envoy container. On Fargate the lowest amount of memory that you can set is **1024 MiB** of memory.

### Description of changes

Change the helm default resource's value to match recommendation. However, user still need to manually change if deploy it on Fargate.

### Checklist
- [V] Added/modified documentation as required (such as the `README.md` for modified charts)
- [V] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [V] Manually tested. Describe what testing was done in the testing section below
- [V ] Make sure the title of the PR is a good description that can go into the release notes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
