### PR TITLE
Release CNI Metrics Helper helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ helm repo add eks https://aws.github.io/eks-charts
 ### Amazon EC2 Metadata Mock
 * [amazon-ec2-metadata-mock](stable/amazon-ec2-metadata-mock): A tool to simulate Amazon EC2 instance metadata service for local testing
 
+### CNI Metrics Helper
+* [cni-metrics-helper](stable/cni-metrics-helper): A helm chart for [CNI Metrics Helper](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/cmd/cni-metrics-helper/README.md)
+
 
 ## License
 

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: cni-metrics-helper
+version: 0.1.15
+appVersion: v1.12.1
+description: A Helm chart for the AWS VPC CNI Metrics Helper
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+home: https://github.com/aws/amazon-vpc-cni-k8s
+sources:
+  - https://github.com/aws/amazon-vpc-cni-k8s
+keywords:
+  - eks
+  - cni
+  - networking
+  - vpc
+maintainers:
+  - name: Jayanth Varavani
+    url: https://github.com/jayanthvn
+    email: jayanthvn@users.noreply.github.com
+engine: gotpl

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -1,0 +1,82 @@
+# CNI METRICS HELPER
+
+This chart provides a Kubernetes deployment for the Amazon VPC CNI Metrics Helper, which is used to collect metrics for the Amazon VPC CNI plugin for Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.11+ running on AWS
+- Helm 3.0+
+
+## Installing the Chart
+
+First add the EKS repository to Helm:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+To install the chart with the release name `cni-metrics-helper` and default configuration:
+
+```shell
+$ helm install cni-metrics-helper --namespace kube-system eks/cni-metrics-helper
+```
+
+To install manually, clone the Amazon VPC CNI for Kubernetes repository to your local machine:
+
+```shell
+$ git clone https://github.com/aws/amazon-vpc-cni-k8s.git
+```
+
+Use the helm install command to install the chart into your Kubernetes cluster:
+
+```shell
+$ helm install cni-metrics-helper --namespace kube-system ./charts/cni-metrics-helper
+```
+
+To uninstall:
+
+```shell
+$ helm uninstall cni-metrics-helper --namespace kube-system
+```
+
+## Configuration
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter                  | Description                                                   | Default            |
+|----------------------------|---------------------------------------------------------------|--------------------|
+| fullnameOverride           | Override the fullname of the chart                            | cni-metrics-helper |
+| image.region               | ECR repository region to use. Should match your cluster       | us-west-2          |
+| image.tag                  | Image tag                                                     | v1.12.1            |
+| image.account              | ECR repository account number                                 | 602401143452       |
+| image.domain               | ECR repository domain                                         | amazonaws.com      |
+| env.USE_CLOUDWATCH         | Whether to export CNI metrics to CloudWatch                   | true               |
+| env.AWS_CLUSTER_ID         | ID of the cluster to use when exporting metrics to CloudWatch | default            |
+| env.METRIC_UPDATE_INTERVAL | Interval at which to update CloudWatch metrics, in seconds.   |                    |
+|                            | Metrics are published to CloudWatch at 2x the interval        | 30                 |
+| serviceAccount.name        | The name of the ServiceAccount to use                         | nil                |
+| serviceAccount.create      | Specifies whether a ServiceAccount should be created          | true               |
+| serviceAccount.annotations | Specifies the annotations for ServiceAccount                  | {}                 |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```shell
+$ helm install cni-metrics-handler --namespace kube-system eks/cni-metrics-handler --values values.yaml
+```
+
+Manual install:
+```shell
+$ helm install cni-metrics-helper --namespace kube-system ./charts/cni-metrics-helper --values values.yaml
+```
+
+## Resources
+
+| Parameter                 | Description                                    | Default |
+|---------------------------|------------------------------------------------|---------|
+|    resources              | Resources for the pods.                        |   `{}`  |
+
+For example, to set a CPU limit of 200m and a memory limit of 256Mi for the cni-metrics-helper pods, you can use the following command:
+
+```shell
+$ helm install cni-metrics-helper ./charts/cni-metrics-helper --namespace kube-system --set resources.limits.cpu=200m,resources.limits.memory=256Mi
+```

--- a/stable/cni-metrics-helper/templates/NOTES.txt
+++ b/stable/cni-metrics-helper/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+
+kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cni-metrics-helper.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/cni-metrics-helper/templates/_helpers.tpl
+++ b/stable/cni-metrics-helper/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cni-metrics-helper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cni-metrics-helper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cni-metrics-helper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cni-metrics-helper.labels" -}}
+helm.sh/chart: {{ include "cni-metrics-helper.chart" . }}
+{{ include "cni-metrics-helper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cni-metrics-helper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cni-metrics-helper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cni-metrics-helper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cni-metrics-helper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/cni-metrics-helper/templates/clusterrole.yaml
+++ b/stable/cni-metrics-helper/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/proxy
+    verbs: ["get", "watch", "list"]      

--- a/stable/cni-metrics-helper/templates/clusterrolebinding.yaml
+++ b/stable/cni-metrics-helper/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cni-metrics-helper.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/stable/cni-metrics-helper/templates/deployment.yaml
+++ b/stable/cni-metrics-helper/templates/deployment.yaml
@@ -1,0 +1,28 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cni-metrics-helper
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cni-metrics-helper
+  template:
+    metadata:
+      labels:
+        k8s-app: cni-metrics-helper
+    spec:
+      containers:
+      - env:
+{{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+{{- end }}
+{{- if .Values.resources }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
+{{- end }}
+        name: cni-metrics-helper
+        image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
+      serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }} 

--- a/stable/cni-metrics-helper/templates/serviceaccount.yaml
+++ b/stable/cni-metrics-helper/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+{{- end -}}

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -1,0 +1,28 @@
+# This default name override is to maintain backwards compatability with
+# existing naming
+nameOverride: cni-metrics-helper
+
+image:
+  region: us-west-2
+  tag: v1.12.1
+  account: "602401143452"
+  domain: "amazonaws.com"   
+  # Set to use custom image
+  # override: "repo/org/image:tag"
+
+env:
+  USE_CLOUDWATCH: "true"
+  AWS_CLUSTER_ID: ""
+
+fullnameOverride: "cni-metrics-helper"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  
+
+resources: {}


### PR DESCRIPTION
### Issue
#155 

### Description of changes
This PR adds the CNI Metrics Helper chart to eks-charts repo. The chart is synced from here: https://github.com/aws/amazon-vpc-cni-k8s/tree/master/charts/cni-metrics-helper

This is done so that customers can install CNI Metrics Helper from eks-charts repo.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Verified that chart can be installed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
