### PR TITLE
Update README with correct default image repository for appmesh-controller

### DIFF
--- a/stable/appmesh-controller/README.md
+++ b/stable/appmesh-controller/README.md
@@ -374,7 +374,7 @@ The following tables lists the configurable parameters of the chart and their de
 
 Parameter | Description | Default
 --- | --- | ---
-`image.repository` | image repository | ` 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller`
+`image.repository` | image repository | ` 840364872350.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller`
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
 `log.level` | controller log level, possible values are `info` and `debug`  | `info`


### PR DESCRIPTION
### Issue

- https://github.com/aws/eks-charts/issues/871

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
- Updated README with correct default image repository for appmesh-controller

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- Installed controller without specifying the image repository.
```
helm upgrade -i appmesh-controller eks/appmesh-controller \
    --namespace appmesh-system
```

```
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  52s   default-scheduler  Successfully assigned appmesh-system/appmesh-controller-5b44d8bdfd-v2nvc to ip-192-168-14-147.us-west-2.compute.internal
  Normal  Pulled     51s   kubelet            Container image "840364872350.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:v1.10.0" already present on machine
  Normal  Created    51s   kubelet            Created container controller
  Normal  Started    51s   kubelet            Started container controller
```

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
