### PR TITLE
Set app mesh code as owner for app mesh charts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,7 @@
 # the repo. Unless a later match takes precedence,
 *       @bwagner5 @kishorj @fawadkhaliq @jaypipes
 
-/stable/appmesh-controller/ @achevuru @fawadkhaliq
-/stable/appmesh-gateway/ @stefanprodan
-/stable/appmesh-grafana/ @achevuru @fawadkhaliq
-/stable/appmesh-inject/ @achevuru @fawadkhaliq
-/stable/appmesh-jaeger/ @achevuru @fawadkhaliq
-/stable/appmesh-prometheus/ @achevuru @fawadkhaliq
+/stable/appmesh-*/ @aws/app-mesh-eks-admin
 
 /stable/aws-load-balancer-controller/ @kishorj @M00nF1sh
 


### PR DESCRIPTION
### Issue

None

### Description of changes
Updating the codeowner for app mesh related charts to App Mesh team.

### Checklist
- [n/a ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [n/a ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [n/a ] Manually tested. Describe what testing was done in the testing section below
- [n/a ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
