### PR TITLE
Add `crds/kustomization.yaml` to `.helmignore` for AWS VPC CNI

### DIFF
--- a/stable/aws-vpc-cni/.helmignore
+++ b/stable/aws-vpc-cni/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+crds/kustomization.yaml


### PR DESCRIPTION
### Issue
N/A

### Description of changes
In https://github.com/aws/eks-charts/pull/869, the AWS VPC CNI chart was synced from https://github.com/aws/amazon-vpc-cni-k8s, but an entry was missing in `.helmignore`. This PR adds that entry and the chart will now be manually re-released.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Made sure that chart can be installed manually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
