### PR TITLE
🥳 aws-load-balancer-controller v2.4.6 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/.helmignore
+++ b/stable/aws-load-balancer-controller/.helmignore
@@ -22,3 +22,4 @@
 *.tmproj
 .vscode/
 crds/kustomization.yaml
+test.yaml

--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.4.6
-appVersion: v2.4.5
+version: 1.4.7
+appVersion: v2.4.6
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -169,7 +169,7 @@ The default values set by the application itself can be confirmed [here](https:/
 
 | Parameter                                      | Description                                                                                              | Default                                                                            |
 |------------------------------------------------| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `image.repository`                             | image repository                                                                                         | `602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller` |
+| `image.repository`                             | image repository                                                                                         | `public.ecr.aws/eks/aws-load-balancer-controller` |
 | `image.tag`                                    | image tag                                                                                                | `<VERSION>`                                                                        |
 | `image.pullPolicy`                             | image pull policy                                                                                        | `IfNotPresent`                                                                     |
 | `clusterName`                                  | Kubernetes cluster name                                                                                  | None                                                                               |

--- a/stable/aws-load-balancer-controller/ci/values.yaml
+++ b/stable/aws-load-balancer-controller/ci/values.yaml
@@ -2,6 +2,6 @@
 
 region: us-west-2
 image:
-  repository: kishorj/aws-load-balancer-controller
-  tag: v2.0.0-rc1
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
+  tag: v2.4.5
   pullPolicy: Always

--- a/stable/aws-load-balancer-controller/crds/crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: ingressclassparams.elbv2.k8s.aws
 spec:
@@ -36,10 +36,14 @@ spec:
         description: IngressClassParams is the Schema for the IngressClassParams API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -47,7 +51,8 @@ spec:
             description: IngressClassParamsSpec defines the desired state of IngressClassParams
             properties:
               group:
-                description: Group defines the IngressGroup for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Group defines the IngressGroup for all Ingresses that
+                  belong to IngressClass with this IngressClassParams.
                 properties:
                   name:
                     description: Name is the name of IngressGroup.
@@ -56,13 +61,16 @@ spec:
                 - name
                 type: object
               ipAddressType:
-                description: IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: IPAddressType defines the ip address type for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
                 enum:
                 - ipv4
                 - dualstack
                 type: string
               loadBalancerAttributes:
-                description: LoadBalancerAttributes define the custom attributes to LoadBalancers for all Ingress that that belong to IngressClass with this IngressClassParams.
+                description: LoadBalancerAttributes define the custom attributes to
+                  LoadBalancers for all Ingress that that belong to IngressClass with
+                  this IngressClassParams.
                 items:
                   description: Attributes defines custom attributes on resources.
                   properties:
@@ -78,21 +86,33 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                description: NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams. * if absent or present but empty, it selects all namespaces.
+                description: NamespaceSelector restrict the namespaces of Ingresses
+                  that are allowed to specify the IngressClass with this IngressClassParams.
+                  * if absent or present but empty, it selects all namespaces.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -104,17 +124,24 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               scheme:
-                description: Scheme defines the scheme for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Scheme defines the scheme for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
                 enum:
                 - internal
                 - internet-facing
                 type: string
               tags:
-                description: Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Tags defines list of Tags on AWS resources provisioned
+                  for Ingresses that belong to IngressClass with this IngressClassParams.
                 items:
                   description: Tag defines a AWS Tag on resources.
                   properties:
@@ -134,18 +161,12 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
@@ -184,10 +205,14 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -195,28 +220,37 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               networking:
-                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking provides the networking setup for ELBV2 LoadBalancer
+                  to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: List of peers which should be able to access
+                            the targets in TargetGroup. At least one NetworkingPeer
+                            should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: IPBlock defines an IPBlock peer. If specified,
+                                  none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: CIDR is the network CIDR. Both IPV4
+                                      or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: SecurityGroup defines a SecurityGroup
+                                  peer. If specified, none of the other fields can
+                                  be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -227,17 +261,25 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: List of ports which should be made accessible
+                            on the targets in TargetGroup. If ports is empty or unspecified,
+                            it defaults to all ports with TCP.
                           items:
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: The port which traffic must match. When
+                                  NodePort endpoints(instance TargetType) is used,
+                                  this must be a numerical port. When Port endpoints(ip
+                                  TargetType) is used, this can be either numerical
+                                  or named port on pods. if port is unspecified, it
+                                  defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -251,7 +293,8 @@ spec:
                     type: array
                 type: object
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -267,10 +310,12 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
@@ -319,10 +364,14 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -330,35 +379,46 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               ipAddressType:
-                description: ipAddressType specifies whether the target group is of type IPv4 or IPv6. If unspecified, it will be automatically inferred.
+                description: ipAddressType specifies whether the target group is of
+                  type IPv4 or IPv6. If unspecified, it will be automatically inferred.
                 enum:
                 - ipv4
                 - ipv6
                 type: string
               networking:
-                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking defines the networking rules to allow ELBV2
+                  LoadBalancer to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
-                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      description: NetworkingIngressRule defines a particular set
+                        of traffic that is allowed to access TargetGroup's targets.
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: List of peers which should be able to access
+                            the targets in TargetGroup. At least one NetworkingPeer
+                            should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: IPBlock defines an IPBlock peer. If specified,
+                                  none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: CIDR is the network CIDR. Both IPV4
+                                      or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: SecurityGroup defines a SecurityGroup
+                                  peer. If specified, none of the other fields can
+                                  be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -369,18 +429,27 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: List of ports which should be made accessible
+                            on the targets in TargetGroup. If ports is empty or unspecified,
+                            it defaults to all ports with TCP.
                           items:
-                            description: NetworkingPort defines the port and protocol for networking rules.
+                            description: NetworkingPort defines the port and protocol
+                              for networking rules.
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: The port which traffic must match. When
+                                  NodePort endpoints(instance TargetType) is used,
+                                  this must be a numerical port. When Port endpoints(ip
+                                  TargetType) is used, this can be either numerical
+                                  or named port on pods. if port is unspecified, it
+                                  defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -394,21 +463,32 @@ spec:
                     type: array
                 type: object
               nodeSelector:
-                description: node selector for instance type target groups to only register certain nodes
+                description: node selector for instance type target groups to only
+                  register certain nodes
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -420,11 +500,17 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -440,11 +526,13 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 minLength: 1
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
@@ -466,9 +554,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -5,8 +5,8 @@
 replicaCount: 2
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.4.5
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
+  tag: v2.4.6
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 2
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.4.5
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
+  tag: v2.4.6
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.4.6 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.4.6 (requires Kubernetes 1.19+)
## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/)
Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.4.6

Thanks to all our contributors! 😊
 
## Whats new
1. This release introduces new annotation `service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes` to configure the HTTP success codes for NLB target group health check for http/https healthcheck protocol
2. Controller doesn't delete existing NLB target group to reconfigure health check configuration with default configuration. You can revert to the earlier behavior by setting the feature gate `NLBHealthCheckAdvancedConfiguration` to `false`
3. Controller configures the NLB target group health check timeout based on the annotation `service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout`.  You can disable this by setting the feature gate `NLBHealthCheckAdvancedConfiguration` to `false`
 
## Changelog since v2.4.5
* add example of blue/green deployment ([#2911](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2911), @geoffcline)
* Ability to reconfigure NLB target group health check ([#2967](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2967), @kishorj)
* Replace "SSL" with "TLS" where possible in documentation ([#2962](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2962), @johngmyers)
* docs: update contibutor docs ([#2961](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2961), @prasadkatti)
* Update eksctl and eks default versions for e2e tests ([#2960](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2960), @kishorj)
* Update index.md ([#2959](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2959), @Kostavro)
* docs: fix gRPCServer example ([#2954](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2954), @prasadkatti)
* update controller-gen to v0.11.1 ([#2953](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2953), @kishorj)
* fix typos in doc about self managed lb ([#2947](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2947), @Kostavro)
* docs: make external-dns optional in echoserver walkthrough ([#2950](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2950), @prasadkatti)
* fix: typo in synthesizer test ([#2941](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2941), @yasinlachiny)
* use multi-arch image for service e2e test ([#2943](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2943), @kishorj)
* Update installation.md (nit) ([#2937](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2937), @mtulio)
* move test images to ecr public ([#2935](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2935), @kishorj)
* Use public ECR repository by default ([#2907](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2907), @kishorj)
* fix: health check timeout for services/NLB ([#2899](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2899), @project0)
* update external dns manifest and docs ([#2895](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2895), @kishorj)
* update external dns manifest url ([#2892](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2892), @kishorj)
* update go packages and dependencies ([#2887](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2887), @kishorj)
* update filename from the set-version script ([#2889](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2889), @kishorj)
* Stop restricting branches for unit test action ([#2879](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2879), @johngmyers)
* Improve echo server example documentation ([#2853](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2853), @kevin85421)
* Fix consistency of version references in documentation, etc. ([#2880](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2880), @johngmyers)
* Documentation update to warn of Access Control bypass when conversion from IPv4 to IPv6 on NLBs ([#2868](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2868), @wilief)
* Fix to use a code block in the guide of ingress annotations ([#2877](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2877), @hadusam)
* Fix typo of a comment in pkg/networking/subnet_resolver.go ([#2876](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2876), @hadusam)
