### PR TITLE
add ability to turn PodSecurityPolicy on or off in aws-for-fluent-bit

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.22
+version: 0.1.23
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -32,6 +32,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
 | `image.tag` | Image tag to deploy | `2.21.5`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
+| `rbac.pspEnabled` | Whether a pod security policy should be created | `false`
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |

--- a/stable/aws-for-fluent-bit/templates/psp.yaml
+++ b/stable/aws-for-fluent-bit/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -35,3 +36,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -11,6 +11,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+rbac:
+  # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
+  pspEnabled: false
+  
 service:
   ## Allow the service to be exposed for monitoring
   ## https://docs.fluentbit.io/manual/administration/monitoring


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
In kubernetes 1.25 pod security policies were deprecated - see issue https://github.com/aws/eks-charts/issues/856 and https://github.com/aws/eks-charts/issues/810

### Description of changes

<!-- Please explain the changes you made here. -->
Adding the ability to turn off the pod security policy will allow people to use the chart if they are on kubernetes 1.25+

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
I was able to deploy the chart by setting rbac.pspEnabled=false

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
