### PR TITLE
Deprecate secrets-store-csi-driver-aws helm chart hosted here

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ helm repo add eks https://aws.github.io/eks-charts
 * [aws-sigv4-proxy-admission-controller](stable/aws-sigv4-proxy-admission-controller): A helm chart for [AWS SIGv4 Proxy Admission Controller](https://github.com/aws-observability/aws-sigv4-proxy-admission-controller)
 
 ### AWS Secrets Manager and Config Provider for Secret Store CSI Driver
+
+**This Helm chart is deprecated, please switch to https://aws.github.io/secrets-store-csi-driver-provider-aws/ which is reviewed, owned and maintained by AWS.**
+
 * [csi-secrets-store-provider-aws](stable/csi-secrets-store-provider-aws): A helm chart for [AWS Secrets Manager and Config Provider](https://github.com/aws/secrets-store-csi-driver-provider-aws)
 
 ### Amazon EC2 Metadata Mock

--- a/stable/csi-secrets-store-provider-aws/Chart.yaml
+++ b/stable/csi-secrets-store-provider-aws/Chart.yaml
@@ -1,13 +1,14 @@
 apiVersion: v2
 name: csi-secrets-store-provider-aws
-version: 0.0.3
+version: 0.0.4
 appVersion: 1.0.r2-6-gee95299-2022.04.14.21.07
 kubeVersion: ">=1.17.0-0"
-description: A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster.
+deprecated: true
+description: This Helm chart is deprecated, please switch to https://aws.github.io/secrets-store-csi-driver-provider-aws/
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
-  - https://github.com/aws/eks-charts/
-home: https://github.com/aws/eks-charts/
+  - "https://github.com/aws/secrets-store-csi-driver-provider-aws"
+home: "https://github.com/aws/secrets-store-csi-driver-provider-aws"
 # I put my name because I did not know who else to insert but
 # more than willingly I pass the burden and honors to someone else.
 maintainers:

--- a/stable/csi-secrets-store-provider-aws/README.md
+++ b/stable/csi-secrets-store-provider-aws/README.md
@@ -1,5 +1,9 @@
 # csi-secrets-store-provider-aws
 
+**This Helm chart is deprecated, please switch to https://aws.github.io/secrets-store-csi-driver-provider-aws/ which is reviewed, owned and maintained by AWS.**
+
+-----------------
+
 AWS Secrets Manager and Config Provider for Secret Store CSI Driver allows you to get secret contents stored in AWS Key Management Service instance and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.
 
 ### Prerequisites


### PR DESCRIPTION
Replacement chart is now hosted directly in the project repository

### Description of changes

### Checklist
- [ x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ x] Manually tested. Describe what testing was done in the testing section below
- [ x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Built chart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
