### PR TITLE
Allow for Enable/Disable default input and filter options

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.22
+version: 0.1.23
 appVersion: 2.21.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
         Parsers_File /fluent-bit/etc/parser_extra.conf
 {{- end }}
 
+{{- if .Values.input.enabled }}
     [INPUT]
         Name              tail
         Tag               {{ .Values.input.tag }}
@@ -28,6 +29,7 @@ data:
         Mem_Buf_Limit     {{ .Values.input.memBufLimit }}
         Skip_Long_Lines   {{ .Values.input.skipLongLines }}
         Refresh_Interval  {{ .Values.input.refreshInterval }}
+{{- end }}
 {{- if .Values.input.extraInputs }}
 {{ .Values.input.extraInputs | indent 8 }}
 {{- end }}
@@ -36,6 +38,7 @@ data:
 {{ .Values.additionalInputs | indent 4 }}
 {{- end }}
 
+{{- if .Values.filter.enabled }}
     [FILTER]
         Name                kubernetes
         Match               {{ .Values.filter.match }}
@@ -48,6 +51,8 @@ data:
         K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
         K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
         Buffer_Size         {{ .Values.filter.bufferSize }}
+{{- end }}
+
 {{- if .Values.filter.extraFilters }}
 {{ .Values.filter.extraFilters | indent 8 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -26,6 +26,7 @@ service:
   #       Format logfmt
 
 input:
+  enabled: true
   tag: "kube.*"
   path: "/var/log/containers/*.log"
   db: "/var/log/flb_kube.db"
@@ -45,6 +46,7 @@ input:
 #       DB           winlog.sqlite
 
 filter:
+  enabled: true
   match: "kube.*"
   kubeURL: "https://kubernetes.default.svc.cluster.local:443"
   mergeLog: "On"


### PR DESCRIPTION
### Issue

The default inputs and filters options don't work for us and we'd like to not have to enable them by default. Currently we're repacking the chart and removing these snippets of code which is a bit irritating to do :)

### Description of changes

For the default `input` and `filter` options add an `enabled` flag, much like is done throughout the rest of this file, to allow developers to optionally not put them in. We'll enable by default of course for backwards compatibility sake.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
