### PR TITLE
Add support for spire-controller-manager to appmesh-spire-server

### DIFF
--- a/stable/appmesh-spire-agent/Chart.yaml
+++ b/stable/appmesh-spire-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-agent
 description: SPIRE Agent Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.5.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-spire-agent/README.md
+++ b/stable/appmesh-spire-agent/README.md
@@ -36,6 +36,7 @@ The following tables lists the configurable parameters of the chart and their de
 Parameter | Description | Default
 --- | --- | ---
 `config.trustDomain` | SPIRE Trust Domain | `appmesh.aws`
+`config.clusterName` | Cluster Name | `k8s-cluster`
 `config.logLevel` | Log Level | `DEBUG`
 `config.serverAddress` | SPIRE Server Address | `spire-server`
 `config.serverPort` | SPIRE Server Bind Port | `8081`

--- a/stable/appmesh-spire-agent/templates/spire-agent-cfg.yaml
+++ b/stable/appmesh-spire-agent/templates/spire-agent-cfg.yaml
@@ -19,7 +19,7 @@ data:
     plugins {
       NodeAttestor "k8s_sat" {
         plugin_data {
-          cluster = "k8s-cluster"
+          cluster = "{{ .Values.config.clusterName }}"
         }
       }
 

--- a/stable/appmesh-spire-agent/values.yaml
+++ b/stable/appmesh-spire-agent/values.yaml
@@ -43,6 +43,8 @@ rbac:
 config:
   # SPIRE Trust Domain
   trustDomain: appmesh.aws
+  # Cluster Name
+  clusterName: k8s-cluster
   ## SPIRE Agent Log Level
   logLevel: DEBUG
   # SPIRE Server Bind Address

--- a/stable/appmesh-spire-server/Chart.yaml
+++ b/stable/appmesh-spire-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-spire-server
 description: SPIRE Server Helm chart for AppMesh mTLS support on Kubernetes
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.5.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-spire-server/README.md
+++ b/stable/appmesh-spire-server/README.md
@@ -19,6 +19,17 @@ helm upgrade -i appmesh-spire-server eks/appmesh-spire-server \
 
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+## SPIRE Controller Manager
+
+If you would like the SPIRE Server to dynamically register workloads within your cluster, install the following CRDs:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/spiffe/spire-controller-manager/main/config/crd/bases/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+kubectl apply -f https://raw.githubusercontent.com/spiffe/spire-controller-manager/main/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
+```
+Reference the [spire-controller-manager documentation](https://github.com/spiffe/spire-controller-manager) to learn more. In order to control which workloads the controller manager registers, either add additional namespaces to the `spireControllerManager.ignoreNamespaces` list or deploy a [Cluster SPIFFE ID resource](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) to instruct the controller manager which pods to target for registering workloads.
+
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `appmesh-spire-server` deployment:
@@ -36,6 +47,7 @@ The following tables lists the configurable parameters of the chart and their de
 Parameter | Description | Default
 --- | --- | ---
 `config.trustDomain` | SPIRE Trust Domain | `appmesh.aws`
+`config.clusterName` | Cluster Name | `k8s-cluster`
 `config.logLevel` | Log Level | `DEBUG`
 `config.svidTTL` | SVID TTL value | `1h`
 `config.bindAddress` | SPIRE Server Bind Address | `0.0.0.0`
@@ -44,6 +56,8 @@ Parameter | Description | Default
 `serviceAccount.name` | Service account to be used | `spire-server`
 `config.plugin`| SPIRE Plugin(s) | `null`
 `image.tag` | SPIRE Server image version | `1.5.0`
+`spireControllerManager.enabled` | Enable SPIRE Controller Manager | `false`
+`spireControllerManager.ignoreNamespaces` | List of namespaces for the SPIRE Controller Manager to ignore | `[kube-system, kube-public, spire]`
 
 
 To add plugins to the SPIRE server according to the [documentation](https://spiffe.io/docs/latest/planning/extending/), use the following convention

--- a/stable/appmesh-spire-server/templates/deployment.yaml
+++ b/stable/appmesh-spire-server/templates/deployment.yaml
@@ -23,6 +23,15 @@ spec:
         - name: spire-config
           configMap:
             name: {{ template "appmesh-spire-server.fullname" . }}
+        {{- if .Values.spireControllerManager.enabled}}
+        - name: spire-controller-manager-config
+          configMap:
+            name: spire-controller-manager-config
+        - name: spire-registration-socket
+          hostPath:
+            path: /run/spire/server-sockets
+            type: DirectoryOrCreate
+        {{- end }}
       containers:
         - name: spire-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -48,6 +57,25 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
+          {{- if .Values.spireControllerManager.enabled }}
+            - name: spire-registration-socket
+              mountPath: /tmp/spire-server/private/
+              readOnly: false
+        - name: spire-controller-manager
+          image: "{{ .Values.spireControllerManager.repository }}:{{ .Values.spireControllerManager.tag }}"
+          imagePullPolicy: {{ .Values.spireControllerManager.pullPolicy }}
+          ports:
+            - containerPort: 9443
+          args:
+            - "--config=spire-controller-manager-config.yaml"
+          volumeMounts:
+            - name: spire-registration-socket
+              mountPath: /spire-server
+              readOnly: true
+            - name: spire-controller-manager-config
+              mountPath: /spire-controller-manager-config.yaml
+              subPath: spire-controller-manager-config.yaml
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: spire-data

--- a/stable/appmesh-spire-server/templates/spire-controller-manager.yaml
+++ b/stable/appmesh-spire-server/templates/spire-controller-manager.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.spireControllerManager.enabled -}}
+kind: ConfigMap
+metadata:
+  name: spire-controller-manager-config
+apiVersion: v1
+data:
+  spire-controller-manager-config.yaml: |
+    spire-controller-manager-config.yaml: |
+    apiVersion: spire.spiffe.io/v1alpha1
+    kind: ControllerManagerConfig
+    metrics:
+      bindAddress: 127.0.0.1:8082
+    healthProbe:
+      bindAddress: 127.0.0.1:8083
+    leaderElection:
+      leaderElect: true
+      resourceName: 98c9c988.spiffe.io
+    clusterName: {{ .Values.config.clusterName }}
+    trustDomain: {{ .Values.config.trustDomain }}
+    {{- with .Values.spireControllerManager.ignoreNamespaces }}
+    ignoreNamespaces:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+---
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name:  {{ .Values.serviceAccount.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["spire.spiffe.io"]
+    resources: ["clusterfederatedtrustdomains"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["spire.spiffe.io"]
+    resources: ["clusterfederatedtrustdomains/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["spire.spiffe.io"]
+    resources: ["clusterfederatedtrustdomains/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["spire.spiffe.io"]
+    resources: ["clusterspiffeids"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["spire.spiffe.io"]
+    resources: ["clusterspiffeids/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["spire.spiffe.io"]
+    resources: ["clusterspiffeids/status"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: spire-controller-manager-webhook
+webhooks:
+  - admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: spire-controller-manager-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-spire-spiffe-io-v1alpha1-clusterfederatedtrustdomain
+    failurePolicy: Fail
+    name: vclusterfederatedtrustdomain.kb.io
+    rules:
+      - apiGroups: ["spire.spiffe.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["clusterfederatedtrustdomains"]
+    sideEffects: None
+  - admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: spire-controller-manager-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-spire-spiffe-io-v1alpha1-clusterspiffeid
+    failurePolicy: Fail
+    name: vclusterspiffeid.kb.io
+    rules:
+      - apiGroups: ["spire.spiffe.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["clusterspiffeids"]
+    sideEffects: None
+{{- end}}

--- a/stable/appmesh-spire-server/templates/spire-server-cfg.yaml
+++ b/stable/appmesh-spire-server/templates/spire-server-cfg.yaml
@@ -34,7 +34,7 @@ data:
       NodeAttestor "k8s_sat" {
         plugin_data {
           clusters = {
-            "k8s-cluster" = {
+            "{{ .Values.config.clusterName }}" = {
               use_token_review_api_validation = true
               service_account_allow_list = ["spire:spire-agent"]
             }

--- a/stable/appmesh-spire-server/values.yaml
+++ b/stable/appmesh-spire-server/values.yaml
@@ -42,9 +42,18 @@ rbac:
   # rbac.create: `true` if rbac resources should be created
   create: true
 
+spireControllerManager:
+  enabled: true
+  repository: ghcr.io/spiffe/spire-controller-manager
+  tag: 0.2.1
+  pullPolicy: IfNotPresent
+  ignoreNamespaces: [ kube-system, kube-public, spire ]
+  
 config:
   # SPIRE Trust Domain
   trustDomain: appmesh.aws
+  # Cluster Name
+  clusterName: k8s-cluster
   ## SPIRE Server Log Level
   logLevel: DEBUG
   # SVID TTL value


### PR DESCRIPTION
### Issue

[appmesh-spire-server #895](https://github.com/aws/eks-charts/issues/895)

### Description of changes

* Add optional spire-controller-manager to appmesh-spire-server for dynamic workload registration
* Add ability to configure cluster name in appmesh-spire-server and appmesh-spire-agent
* Bump helm chart version and add documentation

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Installed helm chart to my local cluster to verify spire-server and spire-controller-manager both work in tandem

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
