### PR TITLE
🥳 aws-load-balancer-controller v2.4.7 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.4.7
-appVersion: v2.4.6
+version: 1.4.8
+appVersion: v2.4.7
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.4.6
+  tag: v2.4.7
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.4.6
+  tag: v2.4.7
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.4.7 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.4.7 (requires Kubernetes 1.19+)
## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/)
Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.4.7

Thanks to all our contributors! 😊
 
## Action Requrired
🚨 🚨 🚨 We've updated the reference IAM policies to explicitly add the `AddTag` permission for creating load balancer and listener resources. We recommend updating your controller IAM policies with the new permissions for existing installations as well.

## Whats new
* This patch release updates the controller to use discovery.k8s.io/v1 version of EndpointSlice for compatibility with k8s 1.25 and later releases. Starting this patch release, the controller will be able to support EndpointSlice in k8s 1.21 and later clusters only.
* We have also updated the reference IAM policies to explicitly allow the AddTag permission for the ELBv2 `CreateTargetGroup` and `CreateLoadBalancer`. You will have to update the existing controller IAM permissions if you encounter the AccessDenied errors for the elbv2 APIs

## Changelog since v2.4.5
* update IAM policy template ([#3046](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3046), @kishorj, @jdn5126, @Apollorion)
* update to discovery.k8s.io/v1 ([#3073](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3073), @kishorj)