### PR TITLE
Add imagePullSecrets to the Helm Chart

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.8
+version: 0.0.9
 appVersion: "1.247350"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -34,3 +34,4 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `annotations` | Optional pod annotations	 | {} | 
 | `containerdSockPath` | Path to containerd' socket | /run/containerd/containerd.sock |
 | `priorityClassName` | Optional priorityClassName	 | | 
+| `imagePullSecrets` | Secrets to authenticate with an image repository | [] |

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         {{- include "aws-cloudwatch-metrics.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
       containers:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -3,6 +3,8 @@ image:
   tag: 1.247350.0b251780
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 clusterName: cluster_name
 
 resources:


### PR DESCRIPTION
### Issue

This is not an issue, it is an improvement.

### Description of changes

Added imagePullSecrets to the daemonset to use if you need a secret to authenticate with a container repository.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

This change was deployed to an EKS cluster using the chart locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.