### PR TITLE
feat: outdated aws-for-fluent-bit chart updated to use new high performance cloudwatch_logs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ helm repo add eks https://aws.github.io/eks-charts
 ```
 
 ### App Mesh
+
 * [appmesh-controller](stable/appmesh-controller): App Mesh controller Helm chart for Kubernetes
 * [appmesh-prometheus](stable/appmesh-prometheus): App Mesh Prometheus Helm chart for Kubernetes
 * [appmesh-grafana](stable/appmesh-grafana): App Mesh Grafana Helm chart for Kubernetes
@@ -19,39 +20,46 @@ helm repo add eks https://aws.github.io/eks-charts
 * [appmesh-inject](stable/appmesh-inject)(**deprecated**): App Mesh inject Helm chart for Kubernetes
 
 ### AWS Node Termination Handler
-* [aws-node-termination-handler](stable/aws-node-termination-handler): Gracefully handle EC2 instance shutdown within Kubernetes. https://github.com/aws/aws-node-termination-handler
+
+* [aws-node-termination-handler](stable/aws-node-termination-handler): Gracefully handle EC2 instance shutdown within Kubernetes. <https://github.com/aws/aws-node-termination-handler>
 
 ### AWS Calico
 
 **This Helm chart is deprecated**. To install Calico network policy enforcement on AWS, follow the EKS [user guide](https://docs.aws.amazon.com/eks/latest/userguide/calico.html).
 
 ### AWS CloudWatch Metrics
+
 * [aws-cloudwatch-metrics](stable/aws-cloudwatch-metrics): A helm chart for CloudWatch Agent to Collect Cluster Metrics
 
 ### AWS for Fluent Bit
+
 * [aws-for-fluent-bit](stable/aws-for-fluent-bit): A helm chart for [AWS-for-fluent-bit](https://github.com/aws/aws-for-fluent-bit)
 
 ### AWS Load Balancer Controller
+
 * [aws-load-balancer-controller](stable/aws-load-balancer-controller): A helm chart for [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
 
 ### AWS VPC CNI
-* [aws-vpc-cni](stable/aws-vpc-cni): Networking plugin for pod networking in Kubernetes using Elastic Network Interfaces on AWS. https://github.com/aws/amazon-vpc-cni-k8s
+
+* [aws-vpc-cni](stable/aws-vpc-cni): Networking plugin for pod networking in Kubernetes using Elastic Network Interfaces on AWS. <https://github.com/aws/amazon-vpc-cni-k8s>
 
 ### AWS SIGv4 Proxy Admission Controller
+
 * [aws-sigv4-proxy-admission-controller](stable/aws-sigv4-proxy-admission-controller): A helm chart for [AWS SIGv4 Proxy Admission Controller](https://github.com/aws-observability/aws-sigv4-proxy-admission-controller)
 
 ### AWS Secrets Manager and Config Provider for Secret Store CSI Driver
 
-**This Helm chart is deprecated, please switch to https://aws.github.io/secrets-store-csi-driver-provider-aws/ which is reviewed, owned and maintained by AWS.**
+**This Helm chart is deprecated, please switch to <https://aws.github.io/secrets-store-csi-driver-provider-aws/> which is reviewed, owned and maintained by AWS.**
 
 * [csi-secrets-store-provider-aws](stable/csi-secrets-store-provider-aws): A helm chart for [AWS Secrets Manager and Config Provider](https://github.com/aws/secrets-store-csi-driver-provider-aws)
 
 ### Amazon EC2 Metadata Mock
+
 * [amazon-ec2-metadata-mock](stable/amazon-ec2-metadata-mock): A tool to simulate Amazon EC2 instance metadata service for local testing
 
 ### CNI Metrics Helper
-* [cni-metrics-helper](stable/cni-metrics-helper): A helm chart for [CNI Metrics Helper](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/cmd/cni-metrics-helper/README.md)
 
+* [cni-metrics-helper](stable/cni-metrics-helper): A helm chart for [CNI Metrics Helper](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/cmd/cni-metrics-helper/README.md)
 
 ## License
 

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.23
-appVersion: 2.21.5
+version: 0.1.24
+appVersion: 2.31.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
 version: 0.1.24
-appVersion: 2.31.2
+appVersion: 2.28.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -30,7 +30,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | - | - | - | -
 | `global.namespaceOverride` | Override the deployment namespace | Not set (`Release.Namespace`) |
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
-| `image.tag` | Image tag to deploy | `2.21.5`
+| `image.tag` | Image tag to deploy | `2.28.4`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `rbac.pspEnabled` | Whether a pod security policy should be created | `false`
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
@@ -59,6 +59,26 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
 | `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
 | `cloudWatch.extraOutputs` | Append extra outputs with value | `""` |
+| `cloudWatchLogs.enabled` | This section is used to enable new high performance plugin. The Golang plugin was named `cloudwatch`; this new high performance CloudWatch plugin is called `cloudwatch_logs` in fluent bit configuration to prevent conflicts/confusion [details](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch). For guidance on choosing go vs c plugin, please refer to [debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins) | `true` | ✔
+| `cloudWatchLogs.match` | The log filter | `*` | ✔
+| `cloudWatchLogs.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔
+| `cloudWatchLogs.logGroupName` | The name of the CloudWatch Log Group that you want log records sent to. | `"/aws/eks/fluentbit-cloudwatch/logs"` | ✔
+| `cloudWatchLogs.logGroupTemplate` | Template for Log Group name using Fluent Bit [record_accessor](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#log-stream-and-group-name-templating-using-record_accessor-syntax) syntax. This field is optional and if configured it overrides the logGroupName. If the template translation fails, an error is logged and the logGroupName (which is still required) is used instead. |  |
+| `cloudWatchLogs.logStreamName` | The name of the CloudWatch Log Stream that you want log records sent to. |  |
+| `cloudWatchLogs.logStreamPrefix` | Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. Not compatible with the log_stream_name option. | `"fluentbit-"` |
+| `cloudWatchLogs.logStreamTemplate` | Template for Log Stream name using Fluent Bit record_accessor syntax. This field is optional and if configured it overrides the other log stream options. If the template translation fails, an error is logged and the log_stream_name or log_stream_prefix are used instead (and thus one of those fields is still required to be configured). |  |
+| `cloudWatchLogs.logKey` | By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify logKey log and only the log message will be sent to CloudWatch. Check the example [here](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/cloudwatchlogs#what-if-i-just-want-the-raw-log-line-from-the-container-to-appear-in-cloudwatch) |  |
+| `cloudWatchLogs.logFormat` | An optional parameter that can be used to tell CloudWatch the format of the data. A value of json/emf enables CloudWatch to extract custom metrics embedded in a JSON payload. See the Embedded Metric Format. |  |
+| `cloudWatchLogs.roleArn` | ARN of an IAM role to assume (for cross account access). |  |
+| `cloudWatchLogs.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
+| `cloudWatchLogs.logRetentionDays` | If set to a number greater than zero, and newly create log group's retention policy is set to this many days. | |
+| `cloudWatchLogs.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
+| `cloudWatchLogs.metricNamespace` | An optional string representing the CloudWatch namespace for the metrics. Please refer to [tutorial](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#metrics-tutorial) |  |
+| `cloudWatchLogs.metricDimensions` | A list of lists containing the dimension keys that will be applied to all metrics. If you have only one list of dimensions, put the values as a comma separated string. If you want to put list of lists, use the list as semicolon separated strings. |  |
+| `cloudWatchLogs.stsEndpoint` | Specify a custom STS endpoint for the AWS STS API. |  |
+| `cloudWatchLogs.autoRetryRequests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true. |  |
+| `cloudWatchLogs.externalId` | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID. |  |
+| `cloudWatchLogs.extraOutputs` | Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add worker config like `cloudWatchLogs.extraOutputs.Workers=2`  | `""` |
 | `firehose.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) | `true` | ✔
 | `firehose.match` | The log filter | `"*"` | ✔
 | `firehose.region` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
@@ -87,7 +107,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis.extraOutputs` | Append extra outputs with value | `""` |
 | `elasticsearch.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | `true` | ✔
 | `elasticsearch.match` | The log filter | `"*"` | ✔
-| `elasticsearch.awsRegion` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
+| `elasticsearch.awsRegion` | The region in which your Amazon OpenSearch Service is/are in. | `"us-east-1"` | ✔
 | `elasticsearch.host` | The url of the Elastic Search endpoint you want log records sent to. | | ✔
 | `elasticsearch.awsAuth` | Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service | On |
 | `elasticsearch.tls` | Enable or disable TLS support | On |
@@ -96,15 +116,81 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
 | `elasticsearch.suppressTypeName` | OpenSearch 2.0 and above needs to have type option being removed by setting Suppress_Type_Name On  | |
 | `elasticsearch.extraOutputs` | Append extra outputs with value | `""` |
-| `additionalOutputs` | add outputs with value | `""` |
-| `priorityClassName` | Name of Priority Class to assign pods | |
-| `updateStrategy` | Optional update strategy | `type: RollingUpdate` |
-| `affinity` | Map of node/pod affinities | `{}` |
-| `env` | Optional List of pod environment variables for the pods | `[]` |
-| `tolerations` | Optional deployment tolerations | `[]` |
-| `nodeSelector` | Node labels for pod assignment | `{}` |
-| `annotations` | Optional pod annotations | `{}` |
-| `volumes` | Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
-| `volumeMounts` | Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
-| `dnsPolicy` | Optional dnsPolicy | `ClusterFirst` |
-| `hostNetwork` | If true, use hostNetwork | `false` |
+
+| `s3.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/s3) | `true`
+| `s3.match` | The log filter. | `"*"`
+| `s3.bucket` | S3 Bucket name. |
+| `s3.region` | The AWS region of your S3 bucket. | `"us-east-1"`
+| `s3.jsonDateKey` | Specify the name of the time key in the output record. To disable the time key just set the value to false. | `"date"`
+| `s3.jsonDateFormat` | Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681). | `"iso8601"`
+| `s3.totalFileSize` | Specifies the size of files in S3. Maximum size is 50G, minimim is 1M. | `"100M"`
+| `s3.uploadChunkSize` | The size of each 'part' for multipart uploads. Max: 50M | `50M`
+| `s3.uploadTimeout` | Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour. | `"10m"`
+| `s3.storeDir` | Directory to locally buffer data before sending. When multipart uploads are used, data will only be buffered until the `upload_chunk_size` is reached. S3 will also store metadata about in progress multipart uploads in this directory; this allows pending uploads to be completed even if Fluent Bit stops and restarts. It will also store the current $INDEX value if enabled in the S3 key format so that the $INDEX can keep incrementing from its previous value after Fluent Bit restarts. | `"/tmp/fluent-bit/s3"`
+| `s3.storeDirLimitSize` | The size of the limitation for disk usage in S3. Limit the amount of s3 buffers in the `store_dir` to limit disk usage. Note: Use `store_dir_limit_size` instead of `storage.total_limit_size` which can be used to other plugins, because S3 has its own buffering system. | `0`
+| `s3.s3KeyFormat` | Format string for keys in S3. This option supports a UUID, strftime time formatters, a syntax for selecting parts of the Fluent log tag using a syntax inspired by the rewrite_tag filter. Add $TAG in the format string to insert the full log tag; add $TAG[0] to insert the first part of the tag in the s3 key. | `"/fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S"`
+| `s3.s3KeyFormatTagDelimiters` | A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option. See the in depth examples and tutorial in the documentation. |
+| `s3.staticFilePath` | Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true. | `false`
+| `s3.usePutObject` | Use the S3 PutObject API, instead of the multipart upload API. When this option is on, key extension is only available when $UUID is specified in s3_key_format. | `false`
+| `s3.roleArn` | ARN of an IAM role to assume (ex. for cross account access). |
+| `s3.endpoint` | Custom endpoint for the S3 API. An endpoint can contain scheme and port. |
+| `s3.stsEndpoint` | Custom endpoint for the STS API. |
+| `s3.cannedAcl` | Predefined Canned ACL policy for S3 objects. |
+| `s3.compression` | Compression type for S3 objects. 'gzip' is currently the only supported value by default. If Apache Arrow support was enabled at compile time, you can also use 'arrow'. |
+| `s3.contentType` | A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header. |
+| `s3.sendContentMd5` | Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled. | `false`
+| `s3.autoRetryRequests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. | `true`
+| `s3.logKey` | By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3. For example, if you are using Docker, you can specify log_key log and only the log message will be sent to S3. |
+| `s3.preserveDataOrdering` | Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads. | `true`
+| `s3.storageClass` | Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class. |`
+| `s3.retryLimit`| Integer value to set the maximum number of retries allowed. Note: this configuration is released since version 1.9.10 and 2.0.1. For previous version, the number of retries is 5 and is not configurable. | 1
+|`s3.externalId`| Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
+|`s3.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add worker config like`cloudWatchLogs.extraOutputs.Workers=2`|`""`|
+|`opensearch.enabled`| Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch) |`true`| ✔
+|`opensearch.match`| The log filter |`"*"`| ✔
+|`opensearch.host`| The url of the Opensearch Search endpoint you want log records sent to. | | ✔
+|`opensearch.awsRegion`| The region in which your Opensearch search is/are in. |`"us-east-1"`|
+|`opensearch.awsAuth`| Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service. |`"off"`|
+|`opensearch.tls`| Enable or disable TLS support | On |
+|`opensearch.port`| TCP Port of the target service. |`443`|
+|`opensearch.path`| OpenSearch accepts new data on HTTP query path "/_bulk". But it is also possible to serve OpenSearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI. |`""`|
+|`opensearch.bufferSize`| Specify the buffer size used to read the response from the OpenSearch HTTP service. |`"4k"`|
+|`opensearch.pipeline`| OpenSearch allows to setup filters called pipelines. This option allows to define which pipeline the database should use. For performance reasons is strongly suggested to do parsing and filtering on Fluent Bit side, avoid pipelines. | |
+|`opensearch.awsStsEndpoint`| Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service. | |
+|`opensearch.awsRoleArn`| AWS IAM Role to assume to put records to your Amazon cluster. | |
+|`opensearch.awsExternalId`| External ID for the AWS IAM Role specified with aws_role_arn. | |
+|`opensearch.awsServiceName`| Service name to be used in AWS Sigv4 signature. For integration with Amazon OpenSearch Serverless, set to`aoss`. See the [FAQ](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch#faq) section on Amazon OpenSearch Serverless for more information. To use this option: make sure you set`image.tag`to`v2.30.0`or higher. | |
+|`opensearch.httpUser`| Optional username credential for access. | |
+|`opensearch.httpPasswd`| Password for user defined in HTTP_User. | |
+|`opensearch.index`| Index name, supports [Record Accessor syntax](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/record-accessor) |`"aws-fluent-bit"`|
+|`opensearch.type`| Type name |`"_doc"`|
+|`opensearch.logstashFormat`| Enable Logstash format compatibility. This option takes a boolean value: True/False, On/Off |`"on"`|
+|`opensearch.logstashPrefix`| When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date when the data is being generated. |`"logstash"`|
+|`opensearch.logstashDateFormat`| Time format (based on strftime) to generate the second part of the Index name. |`"%Y.%m.%d"`|
+|`opensearch.timeKey`| When Logstash_Format is enabled, each record will get a new timestamp field. The Time_Key property defines the name of that field. |`"@timestamp"`|
+|`opensearch.timeKeyFormat`| When Logstash_Format is enabled, this property defines the format of the timestamp. |`"%Y-%m-%dT%H:%M:%S"`|
+|`opensearch.timeKeyNanos`| When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps. |`"Off"`|
+|`opensearch.includeTagKey`| When enabled, it append the Tag name to the record. |`"Off"`|
+|`opensearch.tagKey`| When Include_Tag_Key is enabled, this property defines the key name for the tag. |`"_flb-key"`|
+|`opensearch.generateId`| When enabled, generate _id for outgoing records. This prevents duplicate records when retrying. |`"Off"`|
+|`opensearch.idKey`| If set, _id will be the value of the key from incoming record and Generate_ID option is ignored. | |
+|`opensearch.writeOperation`| Operation to use to write in bulk requests. |`"create"`|
+|`opensearch.replaceDots`| When enabled, replace field name dots with underscore. |`"Off"`|
+|`opensearch.traceOutput`| When enabled print the OpenSearch API calls to stdout (for diag only) |`"Off"`|
+|`opensearch.traceError`| When enabled print the OpenSearch API calls to stdout when OpenSearch returns an error (for diag only). |`"Off"`|
+|`opensearch.currentTimeIndex`| Use current time for index generation instead of message record |`"Off"`|
+|`opensearch.logstashPrefixKey`| When included: the value in the record that belongs to the key will be looked up and over-write the Logstash_Prefix for index generation. If the key/value is not found in the record then the Logstash_Prefix option will act as a fallback. Nested keys are not supported (if desired, you can use the nest filter plugin to remove nesting) | |
+|`opensearch.suppressTypeName`| When enabled, mapping types is removed and Type option is ignored. |`"Off"`|
+|`opensearch.extraOutputs`| Append extra outputs with value |`""`|
+|`additionalOutputs`| add outputs with value |`""`|
+|`priorityClassName`| Name of Priority Class to assign pods | |
+|`updateStrategy`| Optional update strategy |`type: RollingUpdate`|
+|`affinity`| Map of node/pod affinities |`{}`|
+|`env`| Optional List of pod environment variables for the pods |`[]`|
+|`tolerations`| Optional deployment tolerations |`[]`|
+|`nodeSelector`| Node labels for pod assignment |`{}`|
+|`annotations`| Optional pod annotations |`{}`|
+|`volumes`| Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
+|`volumeMounts`| Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
+|`dnsPolicy`| Optional dnsPolicy |`ClusterFirst`|
+|`hostNetwork`| If true, use hostNetwork |`false` |

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -99,6 +99,62 @@ data:
         {{- end }}
 {{- end }}
 
+{{- if .Values.cloudWatchLogs.enabled }}
+    [OUTPUT]
+        Name                  cloudwatch_logs
+        Match                 {{ .Values.cloudWatchLogs.match }}
+        region                {{ .Values.cloudWatchLogs.region }}
+        log_group_name        {{ .Values.cloudWatchLogs.logGroupName }}
+        {{- if .Values.cloudWatchLogs.logGroupTemplate }}
+        log_group_template    {{ .Values.cloudWatchLogs.logGroupTemplate }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logStreamName }}
+        log_stream_name       {{ .Values.cloudWatchLogs.logStreamName }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logStreamPrefix }}
+        log_stream_prefix     {{ .Values.cloudWatchLogs.logStreamPrefix }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logStreamTemplate }}
+        log_stream_template   {{ .Values.cloudWatchLogs.logStreamTemplate }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logKey }}
+        log_key               {{ .Values.cloudWatchLogs.logKey }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logFormat }}
+        log_format            {{ .Values.cloudWatchLogs.logFormat }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.roleArn }}
+        role_arn              {{ .Values.cloudWatchLogs.roleArn }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.autoCreateGroup }}
+        auto_create_group     {{ .Values.cloudWatchLogs.autoCreateGroup }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logRetentionDays }}
+        log_retention_days    {{ .Values.cloudWatchLogs.logRetentionDays }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.endpoint }}
+        endpoint              {{ .Values.cloudWatchLogs.endpoint }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.metricNamespace }}
+        metric_namespace      {{ .Values.cloudWatchLogs.metricNamespace }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.metricDimensions }}
+        metric_dimensions     {{ .Values.cloudWatchLogs.metricDimensions }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.stsEndpoint }}
+        sts_endpoint          {{ .Values.cloudWatchLogs.stsEndpoint }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.autoRetryRequests }}
+        auto_retry_requests   {{ .Values.cloudWatchLogs.autoRetryRequests }}
+        {{- end -}}
+        {{- if .Values.cloudWatchLogs.externalId }}
+        external_id           {{  .Values.cloudWatchLogs.externalId }}
+        {{- end -}}
+        {{- if .Values.cloudWatchLogs.extraOutputs }}
+{{ .Values.cloudWatchLogs.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
 {{- if .Values.firehose.enabled }}
     [OUTPUT]
         Name            firehose
@@ -205,10 +261,200 @@ data:
         {{- end }}
 {{- end }}
 
+{{- if .Values.s3.enabled }}
+    [OUTPUT]
+        Name                          s3
+        Match                         {{ .Values.s3.match }}
+        bucket                        {{ .Values.s3.bucket }}
+        region                        {{ .Values.s3.region }}
+        {{- if .Values.s3.jsonDateKey }}
+        json_date_key                 {{ .Values.s3.jsonDateKey }}
+        {{- end }}
+        {{- if .Values.s3.jsonDateFormat }}
+        json_date_format              {{ .Values.s3.jsonDateFormat }}
+        {{- end }}
+        {{- if .Values.s3.totalFileSize }}
+        total_file_size               {{ .Values.s3.totalFileSize }}
+        {{- end }}
+        {{- if .Values.s3.uploadChunkSize }}
+        upload_chunk_size             {{ .Values.s3.uploadChunkSize }}
+        {{- end }}
+        {{- if .Values.s3.uploadTimeout }}
+        upload_timeout                {{ .Values.s3.uploadTimeout }}
+        {{- end }}
+        {{- if .Values.s3.storeDir }}
+        store_dir                     {{ .Values.s3.storeDir }}
+        {{- end }}
+        {{- if .Values.s3.storeDirLimitSize }}
+        store_dir_limit_size          {{ .Values.s3.storeDirLimitSize }}
+        {{- end }}
+        {{- if .Values.s3.s3KeyFormat }}
+        s3_key_format                 {{ .Values.s3.s3KeyFormat }}
+        {{- end }}
+        {{- if .Values.s3.s3KeyFormatTagDelimiters }}
+        s3_key_format_tag_delimiters  {{ .Values.s3.s3KeyFormatTagDelimiters }}
+        {{- end }}
+        {{- if .Values.s3.staticFilePath }}
+        static_file_path              {{ .Values.s3.staticFilePath }}
+        {{- end }}
+        {{- if .Values.s3.usePutObject }}
+        use_put_object                {{ .Values.s3.usePutObject }}
+        {{- end }}
+        {{- if .Values.s3.roleArn }}
+        role_arn                      {{ .Values.s3.roleArn }}
+        {{- end }}
+        {{- if .Values.s3.endpoint }}
+        endpoint                      {{ .Values.s3.endpoint }}
+        {{- end }}
+        {{- if .Values.s3.stsEndpoint }}
+        sts_endpoint                  {{ .Values.s3.stsEndpoint }}
+        {{- end }}
+        {{- if .Values.s3.cannedAcl }}
+        canned_acl                    {{ .Values.s3.cannedAcl }}
+        {{- end }}
+        {{- if .Values.s3.compression }}
+        compression                   {{ .Values.s3.compression }}
+        {{- end }}
+        {{- if .Values.s3.contentType }}
+        content_type                  {{ .Values.s3.contentType }}
+        {{- end }}
+        {{- if .Values.s3.sendContentMd5 }}
+        send_content_md5              {{ .Values.s3.sendContentMd5 }}
+        {{- end }}
+        {{- if .Values.s3.autoRetryRequests }}
+        auto_retry_requests           {{ .Values.s3.autoRetryRequests }}
+        {{- end }}
+        {{- if .Values.s3.logKey }}
+        log_key                       {{ .Values.s3.logKey }}
+        {{- end }}
+        {{- if .Values.s3.preserveDataOrdering }}
+        preserve_data_ordering        {{ .Values.s3.preserveDataOrdering }}
+        {{- end }}
+        {{- if .Values.s3.storageClass }}
+        storage_class                 {{ .Values.s3.storageClass }}
+        {{- end }}
+        {{- if .Values.s3.retryLimit }}
+        retry_limit                   {{ .Values.s3.retryLimit }}
+        {{- end }}
+        {{- if .Values.s3.externalId }}
+        external_id                   {{ .Values.s3.externalId }}
+        {{- end }}
+        {{- if .Values.s3.extraOutputs }}
+{{ .Values.s3.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.opensearch.enabled }}
+    [OUTPUT]
+        Name                opensearch
+        Match               {{ .Values.opensearch.match }}
+        {{- if .Values.opensearch.awsRegion }}
+        AWS_Region                {{ .Values.opensearch.awsRegion }}
+        {{- end }}
+        {{- if .Values.opensearch.awsAuth }}
+        AWS_Auth                {{ .Values.opensearch.awsAuth }}
+        {{- end }}
+        {{- if .Values.opensearch.host }}
+        Host                {{ .Values.opensearch.host }}
+        {{- end }}
+        {{- if .Values.opensearch.port }}
+        Port                {{ .Values.opensearch.port }}
+        {{- end }}
+        {{- if .Values.opensearch.tls }}
+        tls                {{ .Values.opensearch.tls }}
+        {{- end }}
+        {{- if .Values.opensearch.path }}
+        Path                {{ .Values.opensearch.path }}
+        {{- end }}
+        {{- if .Values.opensearch.bufferSize }}
+        Buffer_Size         {{ .Values.opensearch.bufferSize }}
+        {{- end }}
+        {{- if .Values.opensearch.pipeline }}
+        Pipeline            {{ .Values.opensearch.pipeline }}
+        {{- end }}
+        {{- if .Values.opensearch.awsStsEndpoint }}
+        AWS_STS_Endpoint    {{ .Values.opensearch.awsStsEndpoint }}
+        {{- end }}
+        {{- if .Values.opensearch.awsRoleArn }}
+        AWS_Role_ARN        {{ .Values.opensearch.awsRoleArn }}
+        {{- end }}
+        {{- if .Values.opensearch.awsExternalId }}
+        AWS_External_ID     {{ .Values.opensearch.awsExternalId }}
+        {{- end }}
+        {{- if .Values.opensearch.awsServiceName }}
+        AWS_Service_Name    {{ .Values.opensearch.awsServiceName }}
+        {{- end }}
+        {{- if .Values.opensearch.httpUser }}
+        HTTP_User           {{ .Values.opensearch.httpUser }}
+        {{- end }}
+        {{- if .Values.opensearch.httpPasswd }}
+        HTTP_Passwd         {{ .Values.opensearch.httpPasswd }}
+        {{- end }}
+        {{- if .Values.opensearch.index }}
+        Index               {{ .Values.opensearch.index }}
+        {{- end }}
+        {{- if .Values.opensearch.type }}
+        Type                {{ .Values.opensearch.type }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashFormat }}
+        Logstash_Format     {{ .Values.opensearch.logstashFormat }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashPrefix }}
+        Logstash_Prefix     {{ .Values.opensearch.logstashPrefix }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashDateFormat }}
+        Logstash_DateFormat {{ .Values.opensearch.logstashDateFormat }}
+        {{- end }}
+        {{- if .Values.opensearch.timeKey }}
+        Time_Key            {{ .Values.opensearch.timeKey }}
+        {{- end }}
+        {{- if .Values.opensearch.timeKeyFormat }}
+        Time_Key_Format     {{ .Values.opensearch.timeKeyFormat }}
+        {{- end }}
+        {{- if .Values.opensearch.timeKeyNanos }}
+        Time_Key_Nanos      {{ .Values.opensearch.timeKeyNanos }}
+        {{- end }}
+        {{- if .Values.opensearch.includeTagKey }}
+        Include_Tag_Key     {{ .Values.opensearch.includeTagKey }}
+        {{- end }}
+        {{- if .Values.opensearch.tagKey }}
+        Tag_Key             {{ .Values.opensearch.tagKey }}
+        {{- end }}
+        {{- if .Values.opensearch.generateId }}
+        Generate_ID         {{ .Values.opensearch.generateId }}
+        {{- end }}
+        {{- if .Values.opensearch.idKey }}
+        Id_Key              {{ .Values.opensearch.idKey }}
+        {{- end }}
+        {{- if .Values.opensearch.writeOperation }}
+        Write_Operation     {{ .Values.opensearch.writeOperation }}
+        {{- end }}
+        {{- if .Values.opensearch.replaceDots }}
+        Replace_Dots        {{ .Values.opensearch.replaceDots }}
+        {{- end }}
+        {{- if .Values.opensearch.traceOutput }}
+        Trace_Output        {{ .Values.opensearch.traceOutput }}
+        {{- end }}
+        {{- if .Values.opensearch.traceError }}
+        Trace_Error         {{ .Values.opensearch.traceError }}
+        {{- end }}
+        {{- if .Values.opensearch.currentTimeIndex }}
+        Current_Time_Index  {{ .Values.opensearch.currentTimeIndex }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashPrefixKey }}
+        Logstash_Prefix_Key {{ .Values.opensearch.logstashPrefixKey }}
+        {{- end }}
+        {{- if .Values.opensearch.suppressTypeName }}
+        Suppress_Type_Name  {{ .Values.opensearch.suppressTypeName }}
+        {{- end }}
+        {{- if .Values.opensearch.extraOutputs }}
+{{ .Values.opensearch.extraOutputsIndent_8 }}
+        {{- end }}
+{{- end }}
+
 {{- if .Values.additionalOutputs }}
 {{ .Values.additionalOutputs | indent 4 }}
 {{- end }}
-
 
 {{- if .Values.service.extraParsers }}
   parser_extra.conf: |-

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
-  tag: 2.21.5
+  tag: 2.28.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -14,7 +14,6 @@ fullnameOverride: ""
 rbac:
   # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
   pspEnabled: false
-  
 service:
   ## Allow the service to be exposed for monitoring
   ## https://docs.fluentbit.io/manual/administration/monitoring
@@ -77,7 +76,7 @@ filter:
 #       Exclude log lvl=debug*
 
 cloudWatch:
-  enabled: true
+  enabled: false
   match: "*"
   region: "us-east-1"
   logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
@@ -92,6 +91,30 @@ cloudWatch:
   credentialsEndpoint: {}
   # extraOutputs: |
   #   ...
+
+cloudWatchLogs:
+  enabled: true
+  match: "*"
+  region: "us-east-1"
+  logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
+  logGroupTemplate: /aws/eks/fluentbit-cloudwatch/workload/$kubernetes['namespace_name']
+  logStreamName:
+  logStreamPrefix: "fluentbit-"
+  logStreamTemplate: $kubernetes['pod_name'].$kubernetes['container_name']
+  logKey:
+  logFormat:
+  roleArn:
+  autoCreateGroup: true
+  logRetentionDays:
+  endpoint:
+  metricNamespace:
+  metricDimensions:
+  stsEndpoint:
+  autoRetryRequests:
+  externalId:
+  # extraOutputs: |
+  #  log_format json/emf
+  #  worker 1
 
 firehose:
   enabled: true
@@ -141,6 +164,75 @@ elasticsearch:
   # extraOutputs: |
   #   Index = my-index
 
+s3:
+  enabled: true
+  match: "*"
+  bucket:
+  region: "us-east-1"
+  jsonDateKey: "date"
+  jsonDateFormat: "iso8601"
+  totalFileSize: "100M"
+  uploadChunkSize: 5M
+  uploadTimeout: "10m"
+  storeDir: "/tmp/fluent-bit/s3"
+  storeDirLimitSize: 0
+  s3KeyFormat: /pod-logs/$TAG/%Y/%m/%d/%H/%M/%S
+  s3KeyFormatTagDelimiters:
+  staticFilePath: false
+  usePutObject: false
+  roleArn:
+  endpoint:
+  stsEndpoint:
+  cannedAcl:
+  compression:
+  contentType:
+  sendContentMd5: false
+  autoRetryRequests: true
+  logKey:
+  preserveDataOrdering: true
+  storageClass:
+  retryLimit: 1
+  externalId:
+  # extraOutputs: |
+
+opensearch:
+  enabled: true
+  match: "*"
+  host:
+  port: "443"
+  tls: "on"
+  path: ""
+  bufferSize: "5m"
+  pipeline:
+  awsRegion: "us-east-1"
+  awsAuth: "On"
+  awsStsEndpoint:
+  awsRoleArn:
+  awsExternalId:
+  awsServiceName:
+  httpUser:
+  httpPasswd:
+  index: "aws-fluent-bit"
+  type: "_doc"
+  logstashFormat: "off"
+  logstashPrefix: "logstash"
+  logstashDateFormat: "%Y.%m.%d"
+  timeKey: "@timestamp"
+  timeKeyFormat: "%Y-%m-%dT%H:%M:%S"
+  timeKeyNanos: "Off"
+  includeTagKey: "Off"
+  tagKey: "_flb-key"
+  generateId: "Off"
+  idKey:
+  writeOperation: "create"
+  replaceDots: "Off"
+  traceOutput: "Off"
+  traceError: "Off"
+  currentTimeIndex: "Off"
+  logstashPrefixKey:
+  suppressTypeName: "On"
+  # extraOutputs: |
+
 # additionalOutputs: |
 #   [OUTPUT]
 #     Name file
@@ -171,7 +263,8 @@ tolerations: []
 
 affinity: {}
 
-annotations: {}
+annotations:
+  {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
 
 # Specifies if aws-for-fluent-bit should be started in hostNetwork mode.
@@ -203,7 +296,6 @@ env: []
 #       fieldRef:
 #         fieldPath: spec.nodeName
 
-
 volumes:
   - name: varlog
     hostPath:
@@ -218,7 +310,6 @@ volumeMounts:
   - name: varlibdockercontainers
     mountPath: /var/lib/docker/containers
     readOnly: true
-
 
 serviceMonitor:
   # service:


### PR DESCRIPTION
This PR is raised in extension of https://github.com/aws/eks-charts/pull/903 which got closed because of some conflicting changes.

### Issue
Resolves below issue/s:
#903 
#901 

Also can be added as resolver of:
#304 
#719 
#436  
#671 

Current fluent bit helm chart is outdated.

Aligning with recommendations from current repo to use [New Higher Performance Core Fluent Bit Plugin](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit#new-higher-performance-core-fluent-bit-plugin).(https://github.com/fluent/fluent-bit/tree/master/plugins/out_cloudwatch_logs) is directly integrated into fluent bit.

It can achieve higher throughput and will consume less CPU and memory. The [new cloudwatch plugin].
It also provides features to send metrics to cloudwatch with cloudwatch metric namespaces and dimesions.
Has better credential management with sts_endpoint.

#### Description of changes

- Added cloudwatch_logs plugin parameters
- Updated fluent-bit image to latest stable 2.28.4
- Added support for all new cloudwatch_logs features.
- Updated readme to reflect the change.

#### Checklist
[ x ] Added/modified documentation as required (such as the README.md for modified charts)
[ x ] Incremented the chart version in Chart.yaml for the modified chart(s)
[ x ] Manually tested. Describe what testing was done in the testing section below
[ x ] Make sure the title of the PR is a good description that can go into the release notes

#### Testing
added as part of argocd addon repository deployed with eks terraform blueprint. Here's the [addon repo](https://github.com/badal-deep-shared/eks-blueprints-add-ons-v2)

configfile is correctly reflecting as per provided config

![image](https://user-images.githubusercontent.com/55054090/224322535-48e20a9e-45df-4d88-9383-20bebc526625.png)

Helm chart deployed successfully
Chart version: `0.1.24`
![image](https://user-images.githubusercontent.com/55054090/224322591-e7bb47e9-63a6-41c5-aa90-c589b3330560.png)

All pods up:
![image](https://user-images.githubusercontent.com/55054090/224322618-422d7a94-ff70-4d9b-896f-e408eae57151.png)

Testing template feature:
Added below config to generate a new loggroup per namespace and new stream per app

```cloudWatch:
    enable: true
    logGroupName: /eks/newchart/workload-logs/fallback
    logStreamPrefix: fallback-
    logGroupTemplate: /eks/newchart/workload-logs/$kubernetes['namespace_name']
    logStreamTemplate: $kubernetes['pod_name'].$kubernetes['container_name']
```

Namespace isolated logs being generated:
![image](https://user-images.githubusercontent.com/55054090/224322658-60775142-cfe5-4356-a3cd-09eebbd1b5e5.png)

Application stream:
![image](https://user-images.githubusercontent.com/55054090/224322677-7444acf3-ce11-46ab-ac92-f6c8093454d2.png)

#### Additional features added

##### Support for S3
![image](https://user-images.githubusercontent.com/55054090/224322781-61b4e3d7-d9cc-44e0-8b1b-de247a794105.png)

![image](https://user-images.githubusercontent.com/55054090/224322802-7132d024-a4c0-4fec-8d9e-43f9d8518bb8.png)
![image](https://user-images.githubusercontent.com/55054090/224322816-743a19ea-3e2e-4c01-a613-705a90824180.png)

##### Support for opensearch
![image](https://user-images.githubusercontent.com/55054090/224322877-048f5740-c934-41c7-8fe3-82f3c3442d6b.png)

Sample data
![image](https://user-images.githubusercontent.com/55054090/224322895-378effc6-909b-42ab-91bd-522bf3ea41ed.png)

###### Known issue
> doesn't impact our implementation or this chart as its an issue with fluent bit itself

I noticed an issue that opensearch plugin doesnt work with record accessor, although it is mentioned in fluent-bit docs that it should.

I tried multiple combinations but it just doesnt seem to work. Raised an issue on fluentbit repo - https://github.com/fluent/fluent-bit/issues/6914 . Have you seen this behaviour before?

Here's a setting example
```
[OUTPUT]
        Name                opensearch
        Match               *
        AWS_Region          ap-southeast-1
        AWS_Auth            On
        Host                search-fluent-bit-logging-g6lh44s35e7ytj5vh2yrsds7qa.ap-southeast-1.es.amazonaws.com
        Port                443
        tls                true
        Buffer_Size         5m
        Index               $kubernetes['namespace_name']
        Type                _doc
        Logstash_Format     Off
        Logstash_Prefix     logstash
        Logstash_DateFormat %Y.%m.%d
        Time_Key            @timestamp
        Time_Key_Format     %Y-%m-%dT%H:%M:%S
        Time_Key_Nanos      Off
        Include_Tag_Key     Off
        Tag_Key             _flb-key
        Generate_ID         Off
        Write_Operation     create
        Replace_Dots        Off
        Trace_Output        On
        Trace_Error         Off
        Current_Time_Index  Off
        Suppress_Type_Name  On
```
Here's fluent bit log showing that index api call is not correct. Its literally sending in $kubernetes['namespace_name'] as string without resolving :
![image](https://user-images.githubusercontent.com/55054090/224323145-05ea3cb6-53a7-432f-bce9-8e6ac2c55c5c.png)

FYI I have raised below issues:
fluent bit : https://github.com/fluent/fluent-bit/issues/6914
aws-for-fluent-bit: https://github.com/aws/aws-for-fluent-bit/issues/557

Solution:
As per the notes on the issue, it is happening because latest public ecr image 2.31.3 is created with fluentbit [1.9.10](https://fluentbit.io/announcements/v1.9.10/) while the record accessor feature is introduced with fluent-bit 2.0.5. Current docker hub image for fluentbit is at 2.0.9 hence it works with that image.
Having said that we now know that the issue will resolve with later ecr image releases which will have base fluent bit image > 2.0.5


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.