### PR TITLE
aws-for-fluent-bit add ability to add securityContext

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.23
-appVersion: 2.21.5
+version: 0.1.24
+appVersion: 2.28.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -32,6 +32,8 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
 | `image.tag` | Image tag to deploy | `2.21.5`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
+| `podSecurityContext` | Security Context for pod | `{}` | 
+| `containerSecurityContext` | Security Context for container | `{}` | 
 | `rbac.pspEnabled` | Whether a pod security policy should be created | `false`
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -26,6 +26,10 @@ spec:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
@@ -39,6 +43,10 @@ spec:
         - name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}          
           {{- if .Values.env }}
           env:
             {{- toYaml .Values.env | nindent 12 }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -11,6 +11,18 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podSecurityContext: {}
+# runAsUser: 1000
+# runAsGroup: 1000
+# runAsNonRoot: true
+# seccompProfile:
+#   type: RuntimeDefault
+containerSecurityContext: {}
+# allowPrivilegeEscalation: false
+# capabilities: 
+#   Drop:
+#   - ALL
+
 rbac:
   # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
   pspEnabled: false


### PR DESCRIPTION
### Issue
Currently aws-for-fluent-bit does not have the ability to add a securityContext which could cause companies with strict Pod Security Standards to not be able to use aws-for-fluent-bit

### Description of changes
Added via Daemonset and created empty values for users to create their own policies

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Used helm template to ensure security policies showed up correctly - with and without a policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
