### PR TITLE
🥳 aws-load-balancer-controller v2.5.1 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.5.0
-appVersion: v2.5.0
+version: 1.5.1
+appVersion: v2.5.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.0
+  tag: v2.5.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.0
+  tag: v2.5.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -303,8 +303,14 @@ disableRestrictedSecurityGroupRules:
 controllerConfig:
   # featureGates set of key: value pairs that describe AWS load balance controller features
   featureGates: {}
-  #  ServiceTypeLoadBalancerOnly: true
-  #  EndpointsFailOpen: true
+  # ListenerRulesTagging: false
+  # WeightedTargetGroups: false
+  # ServiceTypeLoadBalancerOnly: false
+  # EndpointsFailOpen: true
+  # EnableServiceController: false
+  # EnableIPTargetType: false
+  # SubnetsClusterTagCheck: false
+  # NLBHealthCheckAdvancedConfig: false
 
 # objectSelector for webhook
 objectSelector:


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.5.1 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.5.1 (requires Kubernetes 1.22+)

## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/)
Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.5.1

Thanks to all our contributors! 😊

## Action Requrired
* 🚨 🚨 🚨We've updated the controller manifests, so either use helm upgrade or apply the new manifest. The new controller image from the patch release is not compatible with manifests from v2.4.x or earlier releases
* 🚨 🚨 🚨We have made the LBC the default controller for service type LoadBalancer by adding a mutating webhook. You can disable the feature by setting the helm chart value `enableServiceMutatorWebhook`  to `false`. **You will no longer be able to provision new Classic Load Balancer (CLB) from your kubernetes service unless you disable this feature.**

Please refer to the v2.5.0 release notes for further details.

## Bug fixes
* Fix ingress validator to handle ingress rules without http paths, issue #3158

## Changelog since v2.5.0
* cut v2.5.1 release ([#3160](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3160), @kishorj)
* chore(aws-load-balancer-controller): add all controllerConfig.featureGates samples ([#3156](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3156), @kahirokunn)
* Fix validator for ingress rules without http paths ([#3159](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3159), @kishorj)
* update doc for 2.5 ([#3154](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3154), @oliviassss)