### PR TITLE
chore: merge index instead of regenerating

### DIFF
--- a/scripts/publish-charts.sh
+++ b/scripts/publish-charts.sh
@@ -17,7 +17,7 @@ if echo "${VERSION}" | grep -Eq "^v[0-9]+(\.[0-9]+){2}$"; then
     git config pull.rebase false
     git checkout gh-pages
     mv -n $PACKAGE_DIR/stable/*.tgz .
-    helmv3 repo index . --url https://aws.github.io/eks-charts
+    helmv3 repo index --merge index.yaml . --url https://aws.github.io/eks-charts
     git add .
     git commit -m "Publish stable charts ${VERSION}"
     git push origin gh-pages


### PR DESCRIPTION
Currently the index.yaml will be regenerated completely if a chart ist added. This change will merge only the changed parts.

```
--merge string   merge the generated index into the given index
```

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
