### PR TITLE
[aws-load-balancer-controller]: Allow specifying apiVersion for CertManager

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.5.2
+version: 1.5.3
 appVersion: v2.5.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -82,7 +82,7 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
-By default, the apiVersion of cert-manager is set to `cert-manager.io/v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `v1alpha2`.
+By default, the apiVersion of cert-manager is set to `v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `v1alpha2`.
 
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -82,7 +82,7 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
-By default, the apiVersion of cert-manager is set to `cert-manager.io/v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `certmanager.k8s.io/v1alpha1`.
+By default, the apiVersion of cert-manager is set to `cert-manager.io/v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `v1alpha1`.
 
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -82,7 +82,7 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
-By default, the apiVersion of cert-manager is set to `cert-manager.io/v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `v1alpha1`.
+By default, the apiVersion of cert-manager is set to `cert-manager.io/v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `v1alpha2`.
 
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -82,6 +82,8 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
+By default, the apiVersion of cert-manager is set to `cert-manager.io/v1`. If you are using an older version of cert-manager, you may need to set `certManagerApiVersion` to `certmanager.k8s.io/v1alpha1`.
+
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 
 #### Installing the Prometheus Operator
@@ -240,6 +242,7 @@ The default values set by the application itself can be confirmed [here](https:/
 | `podDisruptionBudget`                          | Limit the disruption for controller pods. Require at least 2 controller replicas and 3 worker nodes                                                                                                                    | `{}`                                              |
 | `updateStrategy`                               | Defines the update strategy for the deployment                                                                                                                                                                         | `{}`                                              |
 | `enableCertManager`                            | If enabled, cert-manager issues the webhook certificates instead of the helm template, requires cert-manager and it's CRDs to be installed                                                                             | `false`                                           |
+| `certManagerApiVersion`                        | The cert-manager API version to use                                                                                                                                                                                    | `v1`                                        |
 | `enableEndpointSlices`                         | If enabled, controller uses k8s EndpointSlices instead of Endpoints for IP targets                                                                                                                                     | `false`                                           |
 | `enableBackendSecurityGroup`                   | If enabled, controller uses shared security group for backend traffic                                                                                                                                                  | `true`                                            |
 | `backendSecurityGroup`                         | Backend security group to use instead of auto created one if the feature is enabled                                                                                                                                    | ``                                                |

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -212,7 +212,7 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
-apiVersion: {{ .Values.certManagerApiVersion }}
+apiVersion: cert-manager.io/{{ .Values.certManagerApiVersion }}
 kind: Certificate
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
@@ -228,7 +228,7 @@ spec:
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---
-apiVersion: {{ .Values.certManagerApiVersion }}
+apiVersion: cert-manager.io/{{ .Values.certManagerApiVersion }}
 kind: Issuer
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -212,11 +212,7 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
-apiVersion: cert-manager.io/v1
-{{- else }}
-apiVersion: cert-manager.io/v1alpha2
-{{- end }}
+apiVersion: {{ .Values.certManagerApiVersion }}
 kind: Certificate
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
@@ -232,11 +228,7 @@ spec:
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
-apiVersion: cert-manager.io/v1
-{{- else }}
-apiVersion: cert-manager.io/v1alpha2
-{{- end }}
+apiVersion: {{ .Values.certManagerApiVersion }}
 kind: Issuer
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -100,6 +100,7 @@ additionalLabels: {}
 
 # Enable cert-manager
 enableCertManager: false
+certManagerApiVersion: "cert-manager.io/v1"
 
 # The name of the Kubernetes cluster. A non-empty value is required
 clusterName:

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -99,7 +99,7 @@ podLabels: {}
 additionalLabels: {}
 
 # Enable cert-manager
-enableCertManager: true
+enableCertManager: false
 # Select the apiVersion cert-manager uses
 certManagerApiVersion: "v1"
 

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -99,8 +99,9 @@ podLabels: {}
 additionalLabels: {}
 
 # Enable cert-manager
-enableCertManager: false
-certManagerApiVersion: "cert-manager.io/v1"
+enableCertManager: true
+# Select the apiVersion cert-manager uses
+certManagerApiVersion: "v1"
 
 # The name of the Kubernetes cluster. A non-empty value is required
 clusterName:


### PR DESCRIPTION
### Issue
https://github.com/aws/eks-charts/issues/942
and
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3188

### Description of changes
This PR allows the user to specify the apiVersion for CertManager with a default of `v1`.

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

Ran `helm template --set clusterName=test .`
```
---
# Source: aws-load-balancer-controller/templates/webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  name: aws-load-balancer-webhook
  labels:
    helm.sh/chart: aws-load-balancer-controller-1.5.3
    app.kubernetes.io/name: aws-load-balancer-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.5.1"
    app.kubernetes.io/managed-by: Helm
webhooks:
- clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURRRENDQWlpZ0F3SUJBZ0lSQU9qaDIxMFlBakRsUjdsK2hqNUluN2d3RFFZSktvWklodmNOQVFFTEJRQXcKS..........
```
This continues to function as normal.


Ran `helm template --set clusterName=test --set enableCertManager=true .`
```
---
# Source: aws-load-balancer-controller/templates/webhook.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: aws-load-balancer-serving-cert
  namespace: kube-system
  labels:
    helm.sh/chart: aws-load-balancer-controller-1.5.3
    app.kubernetes.io/name: aws-load-balancer-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.5.1"
    app.kubernetes.io/managed-by: Helm
spec:
  dnsNames:
  - aws-load-balancer-webhook-service.kube-system.svc
  - aws-load-balancer-webhook-service.kube-system.svc.cluster.local
  issuerRef:
    kind: Issuer
    name: aws-load-balancer-selfsigned-issuer
  secretName: aws-load-balancer-tls
---
# Source: aws-load-balancer-controller/templates/webhook.yaml
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: aws-load-balancer-selfsigned-issuer
  namespace: kube-system
  labels:
    helm.sh/chart: aws-load-balancer-controller-1.5.3
    app.kubernetes.io/name: aws-load-balancer-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.5.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selfSigned: {}
```
apiVersion of cert-manager is set to v1.

Attempting a change to the cert-manager version to `v1alpha2`:
`helm template --set clusterName=test --set enableCertManager=true . --set certManagerApiVersion=v1alpha2`
```
---
# Source: aws-load-balancer-controller/templates/webhook.yaml
apiVersion: cert-manager.io/v1alpha2
kind: Certificate
metadata:
  name: aws-load-balancer-serving-cert
  namespace: kube-system
  labels:
    helm.sh/chart: aws-load-balancer-controller-1.5.3
    app.kubernetes.io/name: aws-load-balancer-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.5.1"
    app.kubernetes.io/managed-by: Helm
spec:
  dnsNames:
  - aws-load-balancer-webhook-service.kube-system.svc
  - aws-load-balancer-webhook-service.kube-system.svc.cluster.local
  issuerRef:
    kind: Issuer
    name: aws-load-balancer-selfsigned-issuer
  secretName: aws-load-balancer-tls
---
# Source: aws-load-balancer-controller/templates/webhook.yaml
apiVersion: cert-manager.io/v1alpha2
kind: Issuer
metadata:
  name: aws-load-balancer-selfsigned-issuer
  namespace: kube-system
  labels:
    helm.sh/chart: aws-load-balancer-controller-1.5.3
    app.kubernetes.io/name: aws-load-balancer-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.5.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selfSigned: {}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
