### PR TITLE
add liveness and readiness probe to aws-for-fluent-bit

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.25
+version: 0.1.26
 appVersion: 2.28.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.24
+version: 0.1.25
 appVersion: 2.28.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -188,12 +188,12 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `updateStrategy`| Optional update strategy |`type: RollingUpdate`|
 | `affinity`| Map of node/pod affinities |`{}`|
 | `env`| Optional List of pod environment variables for the pods |`[]`|
-| `livenessProbe`| Optional yaml to define liveness probe, [details](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit) |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
+| `livenessProbe`| Optional yaml to define liveness probe - In order for liveness probe to work correctly defaults have been set in `service.extraService`, [details](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit) |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
 | `readinessProbe`| Optional yaml to define readiness probe |`{}`|
-| `serviceMonitor.service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer |`ClusterIP`|
-| `serviceMonitor.service.port`| TCP port of the serviceMonitor service. | 2020 |
-| `serviceMonitor.service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
 | `serviceMonitor.enabled`| Whether serviceMonitor should be enabled or not, [details](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |`false`| ✔ |`[]`|
+| `serviceMonitor.service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer, ExternalName - [details](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |`ClusterIP`|
+| `serviceMonitor.service.port`| Incoming TCP port of the kubernetes service - Traffic is routed from this port to the targetPort to gain access to the application -  By default and for convenience, the targetPort is set to the same value as the port field. [details](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) | 2020 |
+| `serviceMonitor.service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
 | `serviceMonitor.interval`| Set how frequently Prometheus should scrape |`30s`|
 | `serviceMonitor.telemetryPath`| Set path to scrape metrics from |`/api/v1/metrics/prometheus`|
 | `serviceMonitor.labels`| Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator |`[]`|

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -38,9 +38,12 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
-| `service.extraService` | Append to existing service with this value | `""` |
-| `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
-| `service.extraParsers` | Adding more parsers with this value | `""` |
+| `service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer |`ClusterIP`|
+| `service.port`| TCP port of the serviceMonitor service. | 2020 |
+| `service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
+| `config.extraService` | Append to existing service with this value | HTTP_Server  On <br> HTTP_Listen  0.0.0.0 <br> HTTP_PORT    2020 <br> Health_Check On <br> HC_Errors_Count 5 <br> HC_Retry_Failure_Count 5 <br> HC_Period 5 |
+| `config.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
+| `config.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
 | `extraInputs` | Append to existing input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |
@@ -145,53 +148,63 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `s3.preserveDataOrdering` | Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads. | `true`
 | `s3.storageClass` | Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class. | |
 | `s3.retryLimit`| Integer value to set the maximum number of retries allowed. Note: this configuration is released since version 1.9.10 and 2.0.1. For previous version, the number of retries is 5 and is not configurable. |`1`|
-|`s3.externalId`| Specify an external ID for the STS API, can be used w ith the role_arn parameter if your role requires an external ID.
-|`s3.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `s3.extraOutputs.net.dns.mode=TCP`. | |
-|`opensearch.enabled`| Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch) |`false`| ✔
-|`opensearch.match`| The log filter |`"*"`| ✔
-|`opensearch.host`| The url of the Opensearch Search endpoint you want log records sent to. | | ✔
-|`opensearch.awsRegion`| The region in which your Opensearch search is/are in. |`"us-east-1"`|
-|`opensearch.awsAuth`| Enable AWS Sigv4 Authentication for Amazon Opensearch Service. |`"On"`|
-|`opensearch.tls`| Enable or disable TLS support | `"On"` |
-|`opensearch.port`| TCP Port of the target service. |`443`|
-|`opensearch.path`| OpenSearch accepts new data on HTTP query path "/_bulk". But it is also possible to serve OpenSearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI. | |
-|`opensearch.bufferSize`| Specify the buffer size used to read the response from the OpenSearch HTTP service. |`"5m"`|
-|`opensearch.pipeline`| OpenSearch allows to setup filters called pipelines. This option allows to define which pipeline the database should use. For performance reasons is strongly suggested to do parsing and filtering on Fluent Bit side, avoid pipelines. | |
-|`opensearch.awsStsEndpoint`| Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service. | |
-|`opensearch.awsRoleArn`| AWS IAM Role to assume to put records to your Amazon cluster. | |
-|`opensearch.awsExternalId`| External ID for the AWS IAM Role specified with aws_role_arn. | |
-|`opensearch.awsServiceName`| Service name to be used in AWS Sigv4 signature. For integration with Amazon OpenSearch Serverless, set to`aoss`. See the [FAQ](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch#faq) section on Amazon OpenSearch Serverless for more information. To use this option: make sure you set`image.tag`to`v2.30.0`or higher. | |
-|`opensearch.httpUser`| Optional username credential for access. | |
-|`opensearch.httpPasswd`| Password for user defined in HTTP_User. | |
-|`opensearch.index`| Index name, supports [Record Accessor syntax](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/record-accessor) |`"aws-fluent-bit"`|
-|`opensearch.type`| Type name |`"_doc"`|
-|`opensearch.logstashFormat`| Enable Logstash format compatibility. This option takes a boolean value: True/False, On/Off |`"on"`|
-|`opensearch.logstashPrefix`| When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date when the data is being generated. |`"logstash"`|
-|`opensearch.logstashDateFormat`| Time format (based on strftime) to generate the second part of the Index name. |`"%Y.%m.%d"`|
-|`opensearch.timeKey`| When Logstash_Format is enabled, each record will get a new timestamp field. The Time_Key property defines the name of that field. |`"@timestamp"`|
-|`opensearch.timeKeyFormat`| When Logstash_Format is enabled, this property defines the format of the timestamp. |`"%Y-%m-%dT%H:%M:%S"`|
-|`opensearch.timeKeyNanos`| When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps. |`"Off"`|
-|`opensearch.includeTagKey`| When enabled, it append the Tag name to the record. |`"Off"`|
-|`opensearch.tagKey`| When Include_Tag_Key is enabled, this property defines the key name for the tag. |`"_flb-key"`|
-|`opensearch.generateId`| When enabled, generate _id for outgoing records. This prevents duplicate records when retrying. |`"Off"`|
-|`opensearch.idKey`| If set, _id will be the value of the key from incoming record and Generate_ID option is ignored. | |
-|`opensearch.writeOperation`| Operation to use to write in bulk requests. |`"create"`|
-|`opensearch.replaceDots`| When enabled, replace field name dots with underscore. |`"Off"`|
-|`opensearch.traceOutput`| When enabled print the OpenSearch API calls to stdout (for diag only) |`"Off"`|
-|`opensearch.traceError`| When enabled print the OpenSearch API calls to stdout when OpenSearch returns an error (for diag only). |`"Off"`|
-|`opensearch.currentTimeIndex`| Use current time for index generation instead of message record |`"Off"`|
-|`opensearch.logstashPrefixKey`| When included: the value in the record that belongs to the key will be looked up and over-write the Logstash_Prefix for index generation. If the key/value is not found in the record then the Logstash_Prefix option will act as a fallback. Nested keys are not supported (if desired, you can use the nest filter plugin to remove nesting) | |
-|`opensearch.suppressTypeName`| When enabled, mapping types is removed and Type option is ignored. |`"Off"`|
-|`opensearch.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `opensearch.extraOutputs.net.dns.mode=TCP`. |`""`|
-|`additionalOutputs`| add outputs with value |`""`|
-|`priorityClassName`| Name of Priority Class to assign pods | |
-|`updateStrategy`| Optional update strategy |`type: RollingUpdate`|
-|`affinity`| Map of node/pod affinities |`{}`|
-|`env`| Optional List of pod environment variables for the pods |`[]`|
-|`tolerations`| Optional deployment tolerations |`[]`|
-|`nodeSelector`| Node labels for pod assignment |`{}`|
-|`annotations`| Optional pod annotations |`{}`|
-|`volumes`| Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
-|`volumeMounts`| Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
-|`dnsPolicy`| Optional dnsPolicy |`ClusterFirst`|
-|`hostNetwork`| If true, use hostNetwork |`false` |
+| `s3.externalId`| Specify an external ID for the STS API, can be used w ith the role_arn parameter if your role requires an external ID.
+| `s3.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `s3.extraOutputs.net.dns.mode=TCP`. | |
+| `opensearch.enabled`| Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch) |`false`| ✔
+| `opensearch.match`| The log filter |`"*"`| ✔
+| `opensearch.host`| The url of the Opensearch Search endpoint you want log records sent to. | | ✔
+| `opensearch.awsRegion`| The region in which your Opensearch search is/are in. |`"us-east-1"`|
+| `opensearch.awsAuth`| Enable AWS Sigv4 Authentication for Amazon Opensearch Service. |`"On"`|
+| `opensearch.tls`| Enable or disable TLS support | `"On"` |
+| `opensearch.port`| TCP Port of the target service. |`443`|
+| `opensearch.path`| OpenSearch accepts new data on HTTP query path "/_bulk". But it is also possible to serve OpenSearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI. | |
+| `opensearch.bufferSize`| Specify the buffer size used to read the response from the OpenSearch HTTP service. |`"5m"`|
+| `opensearch.pipeline`| OpenSearch allows to setup filters called pipelines. This option allows to define which pipeline the database should use. For performance reasons is strongly suggested to do parsing and filtering on Fluent Bit side, avoid pipelines. | |
+| `opensearch.awsStsEndpoint`| Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service. | |
+| `opensearch.awsRoleArn`| AWS IAM Role to assume to put records to your Amazon cluster. | |
+| `opensearch.awsExternalId`| External ID for the AWS IAM Role specified with aws_role_arn. | |
+| `opensearch.awsServiceName`| Service name to be used in AWS Sigv4 signature. For integration with Amazon OpenSearch Serverless, set to`aoss`. See the [FAQ](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch#faq) section on Amazon OpenSearch Serverless for more information. To use this option: make sure you set`image.tag`to`v2.30.0`or higher. | |
+| `opensearch.httpUser`| Optional username credential for access. | |
+| `opensearch.httpPasswd`| Password for user defined in HTTP_User. | |
+| `opensearch.index`| Index name, supports [Record Accessor syntax](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/record-accessor) |`"aws-fluent-bit"`|
+| `opensearch.type`| Type name |`"_doc"`|
+| `opensearch.logstashFormat`| Enable Logstash format compatibility. This option takes a boolean value: True/False, On/Off |`"on"`|
+| `opensearch.logstashPrefix`| When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date when the data is being generated. |`"logstash"`|
+| `opensearch.logstashDateFormat`| Time format (based on strftime) to generate the second part of the Index name. |`"%Y.%m.%d"`|
+| `opensearch.timeKey`| When Logstash_Format is enabled, each record will get a new timestamp field. The Time_Key property defines the name of that field. |`"@timestamp"`|
+| `opensearch.timeKeyFormat`| When Logstash_Format is enabled, this property defines the format of the timestamp. |`"%Y-%m-%dT%H:%M:%S"`|
+| `opensearch.timeKeyNanos`| When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps. |`"Off"`|
+| `opensearch.includeTagKey`| When enabled, it append the Tag name to the record. |`"Off"`|
+| `opensearch.tagKey`| When Include_Tag_Key is enabled, this property defines the key name for the tag. |`"_flb-key"`|
+| `opensearch.generateId`| When enabled, generate _id for outgoing records. This prevents duplicate records when retrying. |`"Off"`|
+| `opensearch.idKey`| If set, _id will be the value of the key from incoming record and Generate_ID option is ignored. | |
+| `opensearch.writeOperation`| Operation to use to write in bulk requests. |`"create"`|
+| `opensearch.replaceDots`| When enabled, replace field name dots with underscore. |`"Off"`|
+| `opensearch.traceOutput`| When enabled print the OpenSearch API calls to stdout (for diag only) |`"Off"`|
+| `opensearch.traceError`| When enabled print the OpenSearch API calls to stdout when OpenSearch returns an error (for diag only). |`"Off"`|
+| `opensearch.currentTimeIndex`| Use current time for index generation instead of message record |`"Off"`|
+| `opensearch.logstashPrefixKey`| When included: the value in the record that belongs to the key will be looked up and over-write the Logstash_Prefix for index generation. If the key/value is not found in the record then the Logstash_Prefix option will act as a fallback. Nested keys are not supported (if desired, you can use the nest filter plugin to remove nesting) | |
+| `opensearch.suppressTypeName`| When enabled, mapping types is removed and Type option is ignored. |`"Off"`|
+| `opensearch.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `opensearch.extraOutputs.net.dns.mode=TCP`. |`""`|
+| `additionalOutputs`| add outputs with value |`""`|
+| `priorityClassName`| Name of Priority Class to assign pods | |
+| `updateStrategy`| Optional update strategy |`type: RollingUpdate`|
+| `affinity`| Map of node/pod affinities |`{}`|
+| `env`| Optional List of pod environment variables for the pods |`[]`|
+| `livenessProbe`| Optional yaml to define liveness probe |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
+| `readinessProbe`| Optional yaml to define readiness probe |`{}`|
+| `serviceMonitor.enabled`| Whether serviceMonitor should be enabled or not, [details](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |`false`| ✔ |`[]`|
+| `serviceMonitor.interval`| Set how frequently Prometheus should scrape |`30s`|
+| `serviceMonitor.telemetryPath`| Set path to scrape metrics from |`/api/v1/metrics/prometheus`|
+| `serviceMonitor.labels`| Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator |`[]`|
+| `serviceMonitor.timeout`| Set timeout for scrape |`10s`|
+| `serviceMonitor.relabelings`| Set relabel_configs as per [details](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |`[]`|
+| `serviceMonitor.targetLabels`| Set of labels to transfer on the Kubernetes Service onto the target. |`[]`|
+| `serviceMonitor.metricRelabelings`| MetricRelabelConfigs to apply to samples before ingestion. |`[]`|
+| `tolerations`| Optional deployment tolerations |`[]`|
+| `nodeSelector`| Node labels for pod assignment |`{}`|
+| `annotations`| Optional pod annotations |`{}`|
+| `volumes`| Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
+| `volumeMounts`| Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
+| `dnsPolicy`| Optional dnsPolicy |`ClusterFirst`|
+| `hostNetwork`| If true, use hostNetwork |`false` |

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -38,9 +38,6 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
-| `k8sService.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer |`ClusterIP`|
-| `k8sService.port`| TCP port of the serviceMonitor service. | 2020 |
-| `k8sService.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
 | `service.extraService` | Append to existing service with this value | HTTP_Server  On <br> HTTP_Listen  0.0.0.0 <br> HTTP_PORT    2020 <br> Health_Check On <br> HC_Errors_Count 5 <br> HC_Retry_Failure_Count 5 <br> HC_Period 5 |
 | `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
 | `service.extraParsers` | Adding more parsers with this value | `""` |
@@ -193,6 +190,9 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `env`| Optional List of pod environment variables for the pods |`[]`|
 | `livenessProbe`| Optional yaml to define liveness probe, [details](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit) |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
 | `readinessProbe`| Optional yaml to define readiness probe |`{}`|
+| `serviceMonitor.service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer |`ClusterIP`|
+| `serviceMonitor.service.port`| TCP port of the serviceMonitor service. | 2020 |
+| `serviceMonitor.service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
 | `serviceMonitor.enabled`| Whether serviceMonitor should be enabled or not, [details](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |`false`| ✔ |`[]`|
 | `serviceMonitor.interval`| Set how frequently Prometheus should scrape |`30s`|
 | `serviceMonitor.telemetryPath`| Set path to scrape metrics from |`/api/v1/metrics/prometheus`|

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -148,7 +148,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `s3.preserveDataOrdering` | Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads. | `true`
 | `s3.storageClass` | Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class. | |
 | `s3.retryLimit`| Integer value to set the maximum number of retries allowed. Note: this configuration is released since version 1.9.10 and 2.0.1. For previous version, the number of retries is 5 and is not configurable. |`1`|
-| `s3.externalId`| Specify an external ID for the STS API, can be used w ith the role_arn parameter if your role requires an external ID.
+| `s3.externalId`| Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
 | `s3.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `s3.extraOutputs.net.dns.mode=TCP`. | |
 | `opensearch.enabled`| Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch) |`false`| ✔
 | `opensearch.match`| The log filter |`"*"`| ✔

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -38,12 +38,12 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
-| `service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer |`ClusterIP`|
-| `service.port`| TCP port of the serviceMonitor service. | 2020 |
-| `service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
-| `config.extraService` | Append to existing service with this value | HTTP_Server  On <br> HTTP_Listen  0.0.0.0 <br> HTTP_PORT    2020 <br> Health_Check On <br> HC_Errors_Count 5 <br> HC_Retry_Failure_Count 5 <br> HC_Period 5 |
-| `config.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
-| `config.extraParsers` | Adding more parsers with this value | `""` |
+| `k8sService.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer |`ClusterIP`|
+| `k8sService.port`| TCP port of the serviceMonitor service. | 2020 |
+| `k8sService.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
+| `service.extraService` | Append to existing service with this value | HTTP_Server  On <br> HTTP_Listen  0.0.0.0 <br> HTTP_PORT    2020 <br> Health_Check On <br> HC_Errors_Count 5 <br> HC_Retry_Failure_Count 5 <br> HC_Period 5 |
+| `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
+| `service.extraParsers` | Adding more parsers with this value | `""` |
 | `input.*` | Values for Kubernetes input | |
 | `extraInputs` | Append to existing input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |
@@ -191,7 +191,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `updateStrategy`| Optional update strategy |`type: RollingUpdate`|
 | `affinity`| Map of node/pod affinities |`{}`|
 | `env`| Optional List of pod environment variables for the pods |`[]`|
-| `livenessProbe`| Optional yaml to define liveness probe |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
+| `livenessProbe`| Optional yaml to define liveness probe, [details](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit) |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
 | `readinessProbe`| Optional yaml to define readiness probe |`{}`|
 | `serviceMonitor.enabled`| Whether serviceMonitor should be enabled or not, [details](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |`false`| ✔ |`[]`|
 | `serviceMonitor.interval`| Set how frequently Prometheus should scrape |`30s`|

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -8,13 +8,13 @@ metadata:
 data:
   fluent-bit.conf: |
     [SERVICE]
-{{- if .Values.service.extraService }}
-{{ .Values.service.extraService | indent 8 }}
+{{- if .Values.config.extraService }}
+{{ .Values.config.extraService | indent 8 }}
 {{- end }}
-{{- range .Values.service.parsersFiles }}
+{{- range .Values.config.parsersFiles }}
         Parsers_File {{ . }}
 {{- end }}
-{{- if .Values.service.extraParsers }}
+{{- if .Values.config.extraParsers }}
         Parsers_File /fluent-bit/etc/parser_extra.conf
 {{- end }}
 
@@ -456,7 +456,7 @@ data:
 {{ .Values.additionalOutputs | indent 4 }}
 {{- end }}
 
-{{- if .Values.service.extraParsers }}
+{{- if .Values.config.extraParsers }}
   parser_extra.conf: |-
-{{ .Values.service.extraParsers | indent 4 }}
+{{ .Values.config.extraParsers | indent 4 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -8,13 +8,13 @@ metadata:
 data:
   fluent-bit.conf: |
     [SERVICE]
-{{- if .Values.config.extraService }}
-{{ .Values.config.extraService | indent 8 }}
+{{- if .Values.service.extraService }}
+{{ .Values.service.extraService | indent 8 }}
 {{- end }}
-{{- range .Values.config.parsersFiles }}
+{{- range .Values.service.parsersFiles }}
         Parsers_File {{ . }}
 {{- end }}
-{{- if .Values.config.extraParsers }}
+{{- if .Values.service.extraParsers }}
         Parsers_File /fluent-bit/etc/parser_extra.conf
 {{- end }}
 
@@ -456,7 +456,7 @@ data:
 {{ .Values.additionalOutputs | indent 4 }}
 {{- end }}
 
-{{- if .Values.config.extraParsers }}
+{{- if .Values.service.extraParsers }}
   parser_extra.conf: |-
-{{ .Values.config.extraParsers | indent 4 }}
+{{ .Values.service.extraParsers | indent 4 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -59,6 +59,14 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
       volumes:
         - name: fluentbit-config
           configMap:

--- a/stable/aws-for-fluent-bit/templates/service.yaml
+++ b/stable/aws-for-fluent-bit/templates/service.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   ports:
   - name: monitor-agent
-    port: {{ .Values.k8sService.port }}
+    port: {{ .Values.serviceMonitor.service.port }}
     protocol: TCP
-    targetPort: {{ .Values.k8sService.targetPort }}
+    targetPort: {{ .Values.serviceMonitor.service.targetPort }}
   selector:
     {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 4 }}
   sessionAffinity: None
-  type: {{ .Values.k8sService.type }}
+  type: {{ .Values.serviceMonitor.service.type }}

--- a/stable/aws-for-fluent-bit/templates/service.yaml
+++ b/stable/aws-for-fluent-bit/templates/service.yaml
@@ -1,5 +1,3 @@
-{{- if $.Values.serviceMonitor }}
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,12 +8,10 @@ metadata:
 spec:
   ports:
   - name: monitor-agent
-    port: {{ .Values.serviceMonitor.service.port }}
+    port: {{ .Values.service.port }}
     protocol: TCP
-    targetPort: {{ .Values.serviceMonitor.service.targetPort }}
+    targetPort: {{ .Values.service.targetPort }}
   selector:
     {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 4 }}
   sessionAffinity: None
-  type: {{ .Values.serviceMonitor.service.type }}
-{{- end }}
-{{- end }}
+  type: {{ .Values.service.type }}

--- a/stable/aws-for-fluent-bit/templates/service.yaml
+++ b/stable/aws-for-fluent-bit/templates/service.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   ports:
   - name: monitor-agent
-    port: {{ .Values.service.port }}
+    port: {{ .Values.k8sService.port }}
     protocol: TCP
-    targetPort: {{ .Values.service.targetPort }}
+    targetPort: {{ .Values.k8sService.targetPort }}
   selector:
     {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 4 }}
   sessionAffinity: None
-  type: {{ .Values.service.type }}
+  type: {{ .Values.k8sService.type }}

--- a/stable/aws-for-fluent-bit/templates/servicemonitor.yaml
+++ b/stable/aws-for-fluent-bit/templates/servicemonitor.yaml
@@ -8,9 +8,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.labels | indent 4}}
 {{- end }}
   name: {{ include "aws-for-fluent-bit.fullname" . }}
-{{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
-{{- end }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
 spec:
   endpoints:
   - port: monitor-agent

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -27,11 +27,6 @@ rbac:
   # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
   pspEnabled: false
 
-k8sService:
-  type: ClusterIP
-  port: 2020
-  targetPort: 2020
-
 service:
   ## Allow the service to be exposed for monitoring
   ## For liveness check to work, Health_Check must be set to On
@@ -355,6 +350,10 @@ readinessProbe: {}
   # timeoutSeconds: 10
 
 serviceMonitor:
+  service: 
+    type: ClusterIP
+    port: 2020
+    targetPort: 2020
   ## When set true then use a ServiceMonitor to configure scraping
   enabled: false
   interval: 30s

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -34,6 +34,7 @@ k8sService:
 
 service:
   ## Allow the service to be exposed for monitoring
+  ## For liveness check to work, Health_Check must be set to On
   ## https://docs.fluentbit.io/manual/administration/monitoring
   extraService: |
     HTTP_Server  On
@@ -334,6 +335,7 @@ volumeMounts:
     mountPath: /var/lib/docker/containers
     readOnly: true
 
+# For livenessProbe to work - service.extraService must also enable Health_Check On
 livenessProbe:
   httpGet:
     path: /api/v1/health

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -27,14 +27,12 @@ rbac:
   # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
   pspEnabled: false
 
-# To enable .Values.livenessProbe or .Values.readinessProbe you will need to enable this section
-# Specifically the Health_Check enables the health check endpoint for fluent-bit
-service:
+k8sService:
   type: ClusterIP
   port: 2020
   targetPort: 2020
 
-config:
+service:
   ## Allow the service to be exposed for monitoring
   ## https://docs.fluentbit.io/manual/administration/monitoring
   extraService: |

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -26,13 +26,26 @@ containerSecurityContext: {}
 rbac:
   # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
   pspEnabled: false
+
+# To enable .Values.livenessProbe or .Values.readinessProbe you will need to enable this section
+# Specifically the Health_Check enables the health check endpoint for fluent-bit
 service:
+  type: ClusterIP
+  port: 2020
+  targetPort: 2020
+
+config:
   ## Allow the service to be exposed for monitoring
   ## https://docs.fluentbit.io/manual/administration/monitoring
-  # extraService: |
-  #   HTTP_Server  On
-  #   HTTP_Listen  0.0.0.0
-  #   HTTP_PORT    2020
+  extraService: |
+    HTTP_Server  On
+    HTTP_Listen  0.0.0.0
+    HTTP_PORT    2020
+    Health_Check On 
+    HC_Errors_Count 5 
+    HC_Retry_Failure_Count 5 
+    HC_Period 5 
+
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
   # extraParsers: |
@@ -323,25 +336,33 @@ volumeMounts:
     mountPath: /var/lib/docker/containers
     readOnly: true
 
-serviceMonitor:
-  # service:
-  #   type: ClusterIP
+livenessProbe:
+  httpGet:
+    path: /api/v1/health
+    port: 2020
+    scheme: HTTP
+  failureThreshold: 2
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+
+readinessProbe: {}
+  # httpGet:
+  #   path: /api/v1/health
   #   port: 2020
-  #   targetPort: 2020
-  # When set true then use a ServiceMonitor to configure scraping
+  #   scheme: HTTP
+  # failureThreshold: 2
+  # initialDelaySeconds: 30
+  # timeoutSeconds: 10
+
+serviceMonitor:
+  ## When set true then use a ServiceMonitor to configure scraping
   enabled: false
-  # Set the namespace the ServiceMonitor should be deployed
-  # namespace: monitoring
-  # Set how frequently Prometheus should scrape
-  # interval: 30s
-  # Set path of metrics, e.g /api/v1/metrics/prometheus
-  # telemetryPath: /api/v1/metrics/prometheus
-  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
-  # labels:
-  # Set timeout for scrape
-  # timeout: 10s
-  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-  # relabelings: []
-  # Set of labels to transfer on the Kubernetes Service onto the target.
-  # targetLabels: []
-  # metricRelabelings: []
+  interval: 30s
+  telemetryPath: /api/v1/metrics/prometheus
+  labels:
+    # app: example-application
+    # teamname: example
+  timeout: 10s
+  relabelings: []
+  targetLabels: []
+  metricRelabelings: []


### PR DESCRIPTION
### Issue
https://github.com/aws/eks-charts/issues/946

### Description of changes
Added ability to configure livenessProbe and readinessProbe for aws-for-fluent-bit - also adjusted the defaults for .Values.service.extraService to turn on the healthcheck endpoint

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing
using helm template i made sure the new livenessProbe showed correctly and that the readinessProbe did not show up - i allowed for a readinessProbe but i dont think we need here 
```
helm template ./stable/aws-for-fluent-bit/ --kube-version 1.19.0 --api-versions monitoring.coreos.com/v1 --set serviceMonitor.enabled=true --set serviceMonitor.service.port=2020 --set serviceMonitor.service.type=ClusterIP --set serviceMonitor.service.targetPort=2020
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
