### PR TITLE
Adding eks-connector charts 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ helm repo add eks https://aws.github.io/eks-charts
 
 * [cni-metrics-helper](stable/cni-metrics-helper): A helm chart for [CNI Metrics Helper](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/cmd/cni-metrics-helper/README.md)
 
+
+### AWS EKS Connector
+
+* [aws-eks-connector](https://github.com/aws/amazon-eks-connector): A helm chart for connecting/registering customer's own cluster to AWS EKS console.
+
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/stable/eks-connector/.helmignore
+++ b/stable/eks-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/eks-connector/Chart.yaml
+++ b/stable/eks-connector/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "0.0.4"
+description: EKS Connector is a client-side agent which connects any Kubernetes cluster to AWS.
+name: eks-connector
+version: 0.1.0

--- a/stable/eks-connector/templates/configmap.yaml
+++ b/stable/eks-connector/templates/configmap.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: eks-connector-agent
+data:
+  amazon-ssm-agent.json: |
+    {
+      "Profile": {
+        "KeyAutoRotateDays": 7
+      },
+      "Agent": {
+        "ContainerMode": true
+      },
+      "Identity": {
+        "ConsumptionOrder": [
+          "OnPrem"
+        ]
+      }
+    }
+  seelog.xml: |
+    <seelog type="adaptive" mininterval="2000000" maxinterval="100000000" critmsgcount="500" minlevel="info">
+        <exceptions>
+            <exception filepattern="test*" minlevel="error"/>
+        </exceptions>
+        <outputs formatid="fmtinfo">
+            <console formatid="fmtinfo"/>
+            <rollingfile type="size" filename="/var/log/amazon/ssm/amazon-ssm-agent.log" maxsize="30000000" maxrolls="5"/>
+            <filter levels="error,critical" formatid="fmterror">
+                <console formatid="fmterror"/>
+                <rollingfile type="size" filename="/var/log/amazon/ssm/errors.log" maxsize="10000000" maxrolls="5"/>
+            </filter>
+        </outputs>
+        <formats>
+            <format id="fmterror" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+            <format id="fmtdebug" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+            <format id="fmtinfo" format="%Date %Time %LEVEL %Msg%n"/>
+        </formats>
+    </seelog>

--- a/stable/eks-connector/templates/role.yaml
+++ b/stable/eks-connector/templates/role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Values.secretOverrides.namespace | default .Release.Namespace }}
+  name: eks-connector-secret-access
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      - secrets
+    verbs: [ "get", "update" ]
+    resourceNames:
+      {{- range $i, $e := until (int .Values.replicaCount) }}
+      - {{ $.Values.secretOverrides.prefix | default "eks-connector-state" }}-{{ $i }}
+      {{- end}}
+  - apiGroups: [ "" ]
+    resources:
+      - secrets
+    verbs: [ "create" ]

--- a/stable/eks-connector/templates/rolebinding.yaml
+++ b/stable/eks-connector/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Values.secretOverrides.namespace | default .Release.Namespace }}
+  name: eks-connector-secret-access
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Values.secretOverrides.namespace | default .Release.Namespace }}
+    name: eks-connector
+roleRef:
+  kind: Role
+  name: eks-connector-secret-access
+  apiGroup: rbac.authorization.k8s.io

--- a/stable/eks-connector/templates/secret.yaml
+++ b/stable/eks-connector/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: eks-connector-activation-config
+type: Opaque
+data:
+  code: {{  .Values.eks.activationCode | print | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name:  eks-connector-token
+  annotations:
+    kubernetes.io/service-account.name:  eks-connector

--- a/stable/eks-connector/templates/serviceaccount.yaml
+++ b/stable/eks-connector/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: eks-connector
+automountServiceAccountToken: false

--- a/stable/eks-connector/templates/statefulset.yaml
+++ b/stable/eks-connector/templates/statefulset.yaml
@@ -1,0 +1,155 @@
+{{- if not .Values.eks.activationId }}
+{{- fail "eks.activationId must be set." }}
+{{- end }}
+{{- if not .Values.eks.activationId }}
+{{- fail "eks.activationCode must be set." }}
+{{- end }}
+{{- if not .Values.eks.agentRegion }}
+{{- fail "eks.agentRegion must be set." }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: eks-connector
+  labels:
+    app: eks-connector
+spec:
+  replicas: {{ .replicaCount }}
+  selector:
+    matchLabels:
+      app: eks-connector
+  serviceName: eks-connector
+  template:
+    metadata:
+      labels:
+        app: eks-connector
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - eks-connector
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - env:
+            - name: AWS_EC2_METADATA_DISABLED
+              value: "true"
+          {{- with .Values.images.ssmAgent }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          name: connector-agent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - DAC_OVERRIDE
+              drop:
+                - ALL
+          volumeMounts:
+            - name: eks-agent-config
+              mountPath: /etc/amazon/ssm/amazon-ssm-agent.json
+              subPath: amazon-ssm-agent.json
+            - name: eks-agent-config
+              mountPath: /etc/amazon/ssm/seelog.xml
+              subPath: seelog.xml
+            - name: eks-agent-vault
+              mountPath: /var/lib/amazon/ssm/Vault
+            - name: eks-connector-shared
+              mountPath: /var/eks/shared
+        - args:
+            - server
+            - --state.secretNamespace={{ .Values.secretOverrides.namespace | default .Release.Namespace }}
+            {{- if .Values.secretOverrides.prefix }}
+            - --state.secretNamePrefix={{ .Values.secretOverrides.prefix }}
+            {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- with .Values.images.eksConnector }}
+          image: {{ .repository }}:{{ .tag | default $.Chart.AppVersion }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          name: connector-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - DAC_OVERRIDE
+              drop:
+                - ALL
+          volumeMounts:
+            - name: eks-agent-vault
+              mountPath: /var/lib/amazon/ssm/Vault
+            - name: eks-connector-shared
+              mountPath: /var/eks/shared
+            - name: service-account-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      initContainers:
+        - args:
+            - init
+            - --activation.code={{ .Values.eks.activationCode }}
+            - --activation.id={{ .Values.eks.activationId }}
+            - --agent.region={{ .Values.eks.agentRegion }}
+            - --state.secretNamespace={{ .Values.secretOverrides.namespace | default .Release.Namespace }}
+            {{- if .Values.secretOverrides.prefix }}
+            - --state.secretNamePrefix={{ .Values.secretOverrides.prefix }}
+            {{- end }}
+          env:
+            - name: EKS_ACTIVATION_CODE
+              valueFrom:
+                secretKeyRef:
+                  name: eks-connector-activation-config
+                  key: code
+            - name: EKS_ACTIVATION_ID
+              value: {{ .Values.eks.activationId | quote }}
+            - name: EKS_AGENT_REGION
+              value: {{ .Values.eks.agentRegion }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- with .Values.images.eksConnector }}
+          image: {{ .repository }}:{{ .tag | default $.Chart.AppVersion }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          name: connector-init
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - DAC_OVERRIDE
+              drop:
+                - ALL
+          volumeMounts:
+            - name: eks-agent-vault
+              mountPath: /var/lib/amazon/ssm/Vault
+            - name: service-account-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      serviceAccountName: eks-connector
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      volumes:
+        - name: eks-agent-config
+          configMap:
+            name: eks-connector-agent
+        - name: eks-agent-vault
+          emptyDir: { }
+        - name: eks-connector-shared
+          emptyDir: { }
+        - name: service-account-token
+          secret:
+            secretName: eks-connector-token

--- a/stable/eks-connector/values.yaml
+++ b/stable/eks-connector/values.yaml
@@ -1,0 +1,29 @@
+eks:
+  # !!!! NOTICE !!!!
+  # Follow the instructions below to retrieve your "activationCode" and "activationId"
+  # https://docs.aws.amazon.com/eks/latest/userguide/connecting-cluster.html#connector-connecting
+  activationCode:
+  activationId:
+  # Should be a legit AWS region, such as "us-west-2"
+  agentRegion:
+
+replicaCount: 2
+
+images:
+  eksConnector:
+    pullPolicy: IfNotPresent
+    repository: public.ecr.aws/eks-connector/eks-connector
+    # Overrides the image tag whose default is the chart appVersion:
+    tag: ""
+
+  ssmAgent:
+    pullPolicy: IfNotPresent
+    repository: public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent
+    tag: "3.1.1927.0"
+
+# Fill in the following properties to override the secrets related setting.
+secretOverrides:
+  # The prefix of secret name to persist eks-connector state
+  prefix:
+  # The namespace of secret to persist eks-connector state
+  namespace:


### PR DESCRIPTION
This pull adds helm chart of https://github.com/aws/amazon-eks-connector to eks chart registry.

follow-up: documenting helm chart installation on the product document: https://docs.aws.amazon.com/eks/latest/userguide/connecting-cluster.html