### PR TITLE
Chart updates for VPC CNI v1.13.0 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.2.8
-appVersion: "v1.12.6"
+version: 1.13.0
+appVersion: "v1.13.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -18,7 +18,7 @@ helm repo add eks https://aws.github.io/eks-charts
 To install the chart with the release name `aws-vpc-cni` and default configuration:
 
 ```shell
-$ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni
+$ helm install aws-vpc-cni --namespace kube-system eks/aws-vpc-cni
 ```
 
 To install into an EKS cluster where the CNI is already installed, see [this section below](#adopting-the-existing-aws-node-resources-in-an-eks-cluster)
@@ -41,17 +41,19 @@ The following table lists the configurable parameters for this chart and their d
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `image.tag`             | Image tag                                               | `v1.12.6`                           |
-| `image.account`         | ECR repository account number                           | `602401143452`                      |
+| `image.tag`             | Image tag                                               | `v1.13.0`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
+| `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
+| `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
+| `image.account`         | ECR repository account number                           | `602401143452`                      |
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `init.image.tag`        | Image tag                                               | `v1.12.6`                           |
-| `init.image.account`    | ECR repository account number                           | `602401143452`                      |
+| `init.image.tag`        | Image tag                                               | `v1.13.0`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
+| `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
+| `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
+| `init.image.account`    | ECR repository account number                           | `602401143452`                      |
 | `init.image.pullPolicy` | Container pull policy                                   | `IfNotPresent`                      |
 | `init.image.override`   | A custom docker image to use                            | `nil`                               |
 | `init.env`              | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
@@ -65,20 +67,20 @@ The following table lists the configurable parameters for this chart and their d
 | `podAnnotations`        | annotations to add to each pod                          | `{}`                                |
 | `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
-| `resources`             | Resources for the pods                                  | `requests.cpu: 10m`                 |
+| `resources`             | Resources for containers in pod                         | `requests.cpu: 25m`                 |
 | `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" - "NET_RAW"`  |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |
 | `livenessProbe`         | Livenness probe settings for daemonset                  | (see `values.yaml`)                 |
 | `readinessProbe`        | Readiness probe settings for daemonset                  | (see `values.yaml`)                 |
-| `tolerations`           | Optional deployment tolerations                         | `[]`                                |
+| `tolerations`           | Optional deployment tolerations                         | `[{"operator": "Exists"}]`          |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 
 ```shell
-$ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni --values values.yaml
+$ helm install aws-vpc-cni --namespace kube-system eks/aws-vpc-cni --values values.yaml
 ```
 
 ## Adopting the existing aws-node resources in an EKS cluster

--- a/stable/aws-vpc-cni/templates/_helpers.tpl
+++ b/stable/aws-vpc-cni/templates/_helpers.tpl
@@ -55,3 +55,25 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The aws-vpc-cni-init image to use
+*/}}
+{{- define "aws-vpc-cni.initImage" -}}
+{{- if .Values.init.image.override }}
+{{- .Values.init.image.override }}
+{{- else }}
+{{- printf "%s.dkr.%s.%s.%s/amazon-k8s-cni-init:%s" .Values.init.image.account .Values.init.image.endpoint .Values.init.image.region .Values.init.image.domain .Values.init.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+The aws-vpc-cni image to use
+*/}}
+{{- define "aws-vpc-cni.image" -}}
+{{- if .Values.image.override }}
+{{- .Values.image.override }}
+{{- else }}
+{{- printf "%s.dkr.%s.%s.%s/amazon-k8s-cni:%s" .Values.image.account .Values.image.endpoint .Values.image.region .Values.image.domain .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/stable/aws-vpc-cni/templates/clusterrole.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrole.yaml
@@ -29,10 +29,6 @@ rules:
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions"]
-    resources:
-      - '*'
-    verbs: ["list", "watch"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}{{- .Values.init.image.account }}.dkr.ecr.{{- .Values.init.image.region }}.{{- .Values.init.image.domain }}/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
+        image: {{ include "aws-vpc-cni.initImage" . }}
         env:
 {{- range $key, $value := .Values.init.env }}
           - name: {{ $key }}
@@ -48,12 +48,16 @@ spec:
 {{- end }}
         securityContext:
           {{- toYaml .Values.init.securityContext | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
       terminationGracePeriodSeconds: 10
+      {{- with .Values.tolerations }}
       tolerations:
-        - operator: Exists
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -62,7 +66,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: aws-node
-          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
+          image: {{ include "aws-vpc-cni.image" . }}
           ports:
             - containerPort: 61678
               name: metrics
@@ -80,10 +84,12 @@ spec:
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:
+                  apiVersion: v1
                   fieldPath: spec.nodeName
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:
+                  apiVersion: v1
                   fieldPath: metadata.name
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -142,9 +148,5 @@ spec:
       {{- end }}
     {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,12 +8,14 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.12.6
+    tag: v1.13.0
+    domain: amazonaws.com
     region: us-west-2
+    endpoint: ecr
     account: "602401143452"
     pullPolicy: Always
-    domain: "amazonaws.com"
     # Set to use custom image
+    override:
     # override: "repo/org/image:tag"
   env:
     DISABLE_TCP_EARLY_DEMUX: "false"
@@ -22,12 +24,14 @@ init:
     privileged: true
 
 image:
+  tag: v1.13.0
+  domain: amazonaws.com
   region: us-west-2
-  tag: v1.12.6
+  endpoint: ecr
   account: "602401143452"
-  domain: "amazonaws.com"
   pullPolicy: Always
   # Set to use custom image
+  override:
   # override: "repo/org/image:tag"
 
 # The CNI supports a number of environment variable settings
@@ -122,7 +126,8 @@ updateStrategy:
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - operator: Exists
 
 affinity:
   nodeAffinity:

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 0.1.18
-appVersion: v1.12.6
+version: 1.13.0
+appVersion: v1.13.0
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -47,12 +47,14 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.12.6            |
+| image.tag                    | Image tag                                                     | v1.13.0            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |
 | env.AWS_CLUSTER_ID           | ID of the cluster to use when exporting metrics to CloudWatch | default            |
 | env.AWS_VPC_K8S_CNI_LOGLEVEL | Log verbosity level (ie. FATAL, ERROR, WARN, INFO, DEBUG)     | INFO               |
+| env.METRIC_UPDATE_INTERVAL   | Interval at which to update CloudWatch metrics, in seconds.   |                    |
+|                              | Metrics are published to CloudWatch at 2x the interval        | 30                 |
 | serviceAccount.name          | The name of the ServiceAccount to use                         | nil                |
 | serviceAccount.create        | Specifies whether a ServiceAccount should be created          | true               |
 | serviceAccount.annotations   | Specifies the annotations for ServiceAccount                  | {}                 |

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.12.6
+  tag: v1.13.0
   account: "602401143452"
   domain: "amazonaws.com"   
   # Set to use custom image


### PR DESCRIPTION
### Issue
N/A

### Description of changes
This CR updates the `aws-vpc-cni` and `cni-metrics-helper` charts for the VPC CNI `v1.13.0` release. There are no major changes to call out, but two are highlighted:
1. https://github.com/aws/amazon-vpc-cni-k8s/pull/2345
2. https://github.com/aws/amazon-vpc-cni-k8s/issues/2191

I am marking this PR as a draft so that it does not merge until VPC CNI v1.13.0 is publicly released.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
