### PR TITLE
Bumping aws-for-fluent-bit helm chart version stable

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.25
-appVersion: 2.28.4
+version: 0.1.26
+appVersion: stable
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -30,7 +30,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | - | - | - | -
 | `global.namespaceOverride` | Override the deployment namespace | Not set (`Release.Namespace`) |
 | `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
-| `image.tag` | Image tag to deploy | `2.28.4`
+| `image.tag` | Image tag to deploy | `stable` |
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `podSecurityContext` | Security Context for pod | `{}` | 
 | `containerSecurityContext` | Security Context for container | `{}` | 

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
-  tag: 2.28.4
+  tag: stable
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
### Issue

eks-charts version for aws-for-fluent-bit was tied to an older stable. We can move to the `stable` tag to avoid extra updates here.

### Description of changes

- 2.28.4 --> stable (less manual updates)
- version 0.1.25 --> 0.1.26
- update readme

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- /scripts/package-charts.sh
- helm install ./aws-for-fluent-bit-0.1.26.tgz kubez --generate-name
- kubectl exec -it aws-for-fluent-bit-0-1686939361-4g885 -- cat AWS_FOR_FLUENT_BIT_VERSION

Verified `stable` version is 2.31.11 (later than 2.28.4)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
