### PR TITLE
🥳 aws-load-balancer-controller v2.5.3 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.5.3
-appVersion: v2.5.2
+version: 1.5.4
+appVersion: v2.5.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -82,6 +82,8 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
+The controller helm chart requires the cert-manager with apiVersion `cert-manager.io/v1`.
+
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 
 #### Installing the Prometheus Operator

--- a/stable/aws-load-balancer-controller/templates/pdb.yaml
+++ b/stable/aws-load-balancer-controller/templates/pdb.yaml
@@ -1,9 +1,5 @@
 {{- if and .Values.podDisruptionBudget (gt (int .Values.replicaCount) 1) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "aws-load-balancer-controller.fullname" . }}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -212,11 +212,7 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
-{{- else }}
-apiVersion: cert-manager.io/v1alpha2
-{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
@@ -232,11 +228,7 @@ spec:
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
-{{- else }}
-apiVersion: cert-manager.io/v1alpha2
-{{- end }}
 kind: Issuer
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.2
+  tag: v2.5.3
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.2
+  tag: v2.5.3
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.5.3 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.5.3 (requires Kubernetes 1.22+)

## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/)

Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.5.3
Thanks to all our contributors! 😊

## Enhancement

* Update go dependencies and base image to address CVEs
* Drop the support for ```policy/v1beta1``` of PodDisruptionBudget, since the k8s 1.22+ supports ```policy/v1```
* Drop the support for ```cert-manager.io/v1alpha2```, and explicitly set to ```cert-manager.io/v1``` 

## Fixes

* Update ```k8s.io/client-go``` to v0.26.5 to fix the promethus-adapter issue that causes the client-go to crash in k8s 1.27

## Changelog since v2.5.2

* update to go 1.20.5 ([#3253](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3253), @oliviassss)
* Update dependency and base image ([#3239](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3239), @oliviassss)
* update aws partition in test script and add iam policy for iso regions ([#3246](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3246), @oliviassss)
* Remove policy/v1beta1 since the min supported k8s version supports policy/v1 ([#3230](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3230), @rdrgmnzs)
* chore: Added dependabot ([#3228](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3228), @ellistarn)
* fix typo in test script ([#3226](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3226), @oliviassss)
* Fix formatting ([#3219](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3219), @hsusanoo)
* Explicitly setting CertManager APIVersion to V1 ([#3189](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3189), @hawkesn)