### PR TITLE
Upgrade CloudWatch agent image version to support EKS version >= 1.24

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.9
-appVersion: "1.247350"
+version: 0.0.10
+appVersion: "1.247360"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: amazon/cloudwatch-agent
-  tag: 1.247350.0b251780
+  tag: 1.247360.0b252689
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name


### PR DESCRIPTION
The Dockershim to containerd change in k8s 1.24 creates an issue with the agent, which was updated in a version > 1.247350. On top of the containerd sock path change for Bottle Rocket, the agent version needs to be bumped up.

### Issue
This is related to https://github.com/aws/amazon-cloudwatch-agent/issues/750

### Description of changes

Updated the agent image tag to the current latest release, which includes the required containerd sock change for compatibility 

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
The CloudWatch agent team validates Container Insights changes with e2e testing, but specifically for this issue the linked issue from the agent's repo shows two customers who had their issues resolved by simply upgrading

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
