### PR TITLE
Reuse existing (Cluster)Issuer for webhooks certificate 

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.5.5
+version: 1.5.6
 appVersion: v2.5.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -80,11 +80,13 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 #### Installing cert-manager
 
-If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
+If you are setting `certManager.enabled: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
 The controller helm chart requires the cert-manager with apiVersion `cert-manager.io/v1`.
 
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
+
+It is possible to set your own (Cluster)Issuer by supplying an `issuerRef`.
 
 #### Installing the Prometheus Operator
 
@@ -241,7 +243,8 @@ The default values set by the application itself can be confirmed [here](https:/
 | `replicaCount`                                 | Number of controller pods to run, only one will be active due to leader election                                                                                                                                       | `2`                                               |
 | `podDisruptionBudget`                          | Limit the disruption for controller pods. Require at least 2 controller replicas and 3 worker nodes                                                                                                                    | `{}`                                              |
 | `updateStrategy`                               | Defines the update strategy for the deployment                                                                                                                                                                         | `{}`                                              |
-| `enableCertManager`                            | If enabled, cert-manager issues the webhook certificates instead of the helm template, requires cert-manager and it's CRDs to be installed                                                                             | `false`                                           |
+| `certManager.enabled`                          | If enabled, cert-manager issues the webhook certificates instead of the helm template, requires cert-manager and it's CRDs to be installed                                                                             | `false`                                           |
+| `certManager.issuerRef`                        | Reuse an existing (Cluster)Issuer already available in the cluster by specifying the `issuerRef`                                                                             | None                                           |
 | `enableEndpointSlices`                         | If enabled, controller uses k8s EndpointSlices instead of Endpoints for IP targets                                                                                                                                     | `false`                                           |
 | `enableBackendSecurityGroup`                   | If enabled, controller uses shared security group for backend traffic                                                                                                                                                  | `true`                                            |
 | `backendSecurityGroup`                         | Backend security group to use instead of auto created one if the feature is enabled                                                                                                                                    | ``                                                |

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -3,7 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-{{- if $.Values.enableCertManager }}
+{{- if $.Values.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
 {{- end }}
@@ -12,7 +12,7 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 webhooks:
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{ if not $.Values.certManager.enabled -}}
     caBundle: {{ $tls.caCert }}
     {{ end }}
     service:
@@ -58,7 +58,7 @@ webhooks:
   sideEffects: None
 {{- if .Values.enableServiceMutatorWebhook }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{ if not $.Values.certManager.enabled -}}
     caBundle: {{ $tls.caCert }}
     {{ end }}
     service:
@@ -87,7 +87,7 @@ webhooks:
   sideEffects: None
 {{- end }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{ if not $.Values.certManager.enabled -}}
     caBundle: {{ $tls.caCert }}
     {{ end }}
     service:
@@ -113,7 +113,7 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-{{- if $.Values.enableCertManager }}
+{{- if $.Values.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
 {{- end }}
@@ -122,7 +122,7 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 webhooks:
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{ if not $.Values.certManager.enabled -}}
     caBundle: {{ $tls.caCert }}
     {{ end }}
     service:
@@ -151,7 +151,7 @@ webhooks:
     - ingressclassparams
   sideEffects: None
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{ if not $.Values.certManager.enabled -}}
     caBundle: {{ $tls.caCert }}
     {{ end }}
     service:
@@ -174,7 +174,7 @@ webhooks:
     - targetgroupbindings
   sideEffects: None
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{ if not $.Values.certManager.enabled -}}
     caBundle: {{ $tls.caCert }}
     {{ end }}
     service:
@@ -198,7 +198,7 @@ webhooks:
     - ingresses
   sideEffects: None
 ---
-{{- if not $.Values.enableCertManager }}
+{{- if not $.Values.certManager.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -224,10 +224,15 @@ spec:
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster.dnsDomain }}
   issuerRef:
+    {{- if .Values.certManager.issuerRef }}
+    {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
+    {{- else }}
     kind: Issuer
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+    {{- end }}
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---
+{{- if not $.Values.certManager.issuerRef -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -237,4 +242,5 @@ metadata:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 spec:
   selfSigned: {}
+{{- end }}
 {{- end }}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -99,7 +99,11 @@ podLabels: {}
 additionalLabels: {}
 
 # Enable cert-manager
-enableCertManager: false
+certManager:
+  enabled: false
+  # issuerRef:
+  #   name: "issuer"
+  #   kind: "ClusterIssuer"
 
 # The name of the Kubernetes cluster. A non-empty value is required
 clusterName:


### PR DESCRIPTION
### Issue

N/A

### Description of changes

Instead of always creating a self-signed Issuer when opting to use cert-manager for the web hooks certificate, I would like to add the possibility to reuse an existing (Cluster)Issuer. 

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Verified helm templating with different options
Deployed locally and tested the different options (with/without certmanager, with/without own Issuer)

**Remark:** the existing enableCertmanager value is changed to certManager.enabled (since other options are added as well). Don't know if you guys expect a patch or minor upgrade of the helm chart for this one. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
