### PR TITLE
[appmesh-prometheus] Add support for remote-write

### DIFF
--- a/stable/appmesh-prometheus/Chart.yaml
+++ b/stable/appmesh-prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-prometheus
 description: App Mesh Prometheus Helm chart for Kubernetes
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.13.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/appmesh-prometheus/README.md
+++ b/stable/appmesh-prometheus/README.md
@@ -107,12 +107,16 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
-`rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
-`serviceAccount.create` | If `true`, create a new service account | `true`
-`serviceAccount.name` | Service account to be used | None
-`retention` |  When to remove old data | `6h`
-`scrapeInterval` |  Interval between consecutive scrapes | `5s`
-`persistentVolumeClaim.claimName` |  Specify an existing volume claim to be used for Prometheus data | None
+`rbac.pspEnabled` | if `true`, create and use a restricted pod security policy | `false`
+`serviceAccount.create` | if `true`, create a new service account | `true`
+`serviceAccount.name` | service account to be used | None
+`retention` |  when to remove old data | `6h`
+`scrapeInterval` |  interval between consecutive scrapes | `5s`
+`persistentVolumeClaim.claimName` |  specify an existing volume claim to be used for Prometheus data | None
+`remoteWrite.enabled` | if `true`, write prometheus metrics to an external location | `false`
+`remoteWrite.url` | the url of the endpoint to send samples to | None
+`remoteWrite.bearer_token` | bearer token | None
+
 
 ## Troubleshooting
 

--- a/stable/appmesh-prometheus/templates/config.yaml
+++ b/stable/appmesh-prometheus/templates/config.yaml
@@ -143,3 +143,9 @@ data:
         source_labels:
         - __meta_kubernetes_pod_name
         target_label: kubernetes_pod_name
+
+    {{- if .Values.remote_write.enabled }}
+    remote_write:
+      - url: "{{ .Values.remote_write.endpoint }}"
+        bearer_token: "{{ .Values.remote_write.bearer_token }}"
+    {{- end }}

--- a/stable/appmesh-prometheus/values.yaml
+++ b/stable/appmesh-prometheus/values.yaml
@@ -48,3 +48,8 @@ rbac:
 persistentVolumeClaim:
   # persistentVolumeClaim.claimName: Specify an existing volume claim to be used for Prometheus data
   claimName: ""
+
+remote_write:
+  enabled: false
+  endpoint: ""
+  bearer_token: ""


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/issues/977

### Description of changes

Add optional configuration for prometheus remote-write according to documentation for Prometheus v2.13. This will need to be changed when the chart installs Prometheus >= 2.26

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually added the remote_write configuration with URL and bearer token directly to a running configuration of appmesh-prometheus and verified successful remote writing to (in my case) NewRelic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
