### PR TITLE
Pod labels updated to include app.kubernetes.io/version

### DIFF
--- a/stable/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/stable/aws-load-balancer-controller/templates/_helpers.tpl
@@ -65,6 +65,21 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+Pod labels
+*/}}
+{{- define "aws-load-balancer-controller.podLabels" -}}
+helm.sh/chart: {{ include "aws-load-balancer-controller.chart" . }}
+{{ include "aws-load-balancer-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "aws-load-balancer-controller.serviceAccountName" -}}

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -21,10 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
-        {{- end }}
+        {{- include "aws-load-balancer-controller.podLabels" . | nindent 8 }}
       annotations:
         {{- if not .Values.serviceMonitor.enabled }}
         prometheus.io/scrape: "true"


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

I would like to see the app version added to pods as a label. In addition I moved the merging of selectorLabels into the podLabels out of the deployment and into a new helper.

I'd be curious if merging additionalLabels into the podLabels would also be a good idea since the description of additionalLabels says they are added to all components but that doesn't include the pods created by the deployment. Perhaps that is intentional.

Also, I copied the code for `app.kubernetes.io/managed-by` which will default to `Helm` but perhaps that should be removed since technically the pod is managed by the deployment which is managed by Helm...

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
