### PR TITLE
🥳 aws-load-balancer-controller v2.6.0 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.5.5
-appVersion: v2.5.4
+version: 1.6.0
+appVersion: v2.6.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.4
+  tag: v2.6.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.4
+  tag: v2.6.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.6.0 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.6.0 (requires Kubernetes 1.22+)
## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/)

Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.6.0
Thanks to all our contributors! 😊

## Enhancement
* Added support of Security Groups for NLB. With the security group support, it is feasible to forward the NLB traffic to the EC2 instances without having to open up the instances for global access. For backwards compatibility, NLBs created without the security groups or the existing NLBs will continue to provide the legacy behavior. Similar to ALB, there are two sets of SGs for NLB - frontend and backend SGs:
    * The controller will automatically create and attach the frontend SG to the NLB provisioned, and add rules for `inbound-cidrs` and `listen-ports`. If the users want to attach existing frontend SG to the NLB, they can explicitly specify via annotation `service.beta.kubernetes.io/aws-load-balancer-security-groups`
    * The Backend SG controls the traffic between the NLB and the EC2 instances/ENIs, and it gets attached to the NLB similar to the frontend SG. In case of auto-generated frontend SG, the controller automatically adds Node/ENI SG rules to allow egress traffic from the NLB. The rule management is disabled by default if the frontend SG is specified via annotation. We provide an annotation to configure controller’s management on backend SG rules regardless of the frontend SG type `service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: true/false`
* Improved the ingress cert auto-discovery to discover more cert types from ACM:
```
     KeyAlgorithmRsa1024,
     KeyAlgorithmRsa2048,
     KeyAlgorithmRsa3072,
     KeyAlgorithmRsa4096,
     KeyAlgorithmEcPrime256v1,
     KeyAlgorithmEcSecp384r1,
     KeyAlgorithmEcSecp521r1,
```

## Fixes
* Fixed the race condition in pod cache and endpoint resolver
* Made the ingress validating webhook ignore ingresses that are not managed by AWS LBC
* Fixed typo in doc

## Changelog since v2.5.4

- Add support for NLB security groups (#3329)
- Allow TLS 1.2 with restricted ciphers for webhooks (#3318)
- Update the RSA filter for Cert discovery (#3314)
- Doc: Add note for rename behavior of IngressGroup (#3283)
- Make Ingress validating webhook ignore ingresses not managed by AWS LBC (#3272)
- add oliviassss as reviewer (#3306)
- fix the race condition in pod cache and endpoint resolver (#3305)
- Bump github.com/onsi/ginkgo/v2 from 2.6.0 to 2.11.0 (#3300)
- Bump github.com/aws/aws-sdk-go from 1.44.184 to 1.44.294 (#3271)
- Provide better explanation of failure to find a subnet (#3292)
- test/framework: replace deprecated ioutil.ReadAll (#3256)
- Add warning in doc for ServiceMutatorWebhook (#3180)
- Add note about keeping OWNERS in sync (#3289)
- Docs: Fix typo in `nlb.md`. (#3257)
- fix: typo in PR template (#3267)