### PR TITLE
Enabled service to have multiple ports, and the serviceMonitor to mon…

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.29
+version: 0.1.30
 appVersion: 2.31.11
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.28
+version: 0.1.29
 appVersion: 2.31.11
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -205,6 +205,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `serviceMonitor.service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer, ExternalName - [details](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |`ClusterIP`|
 | `serviceMonitor.service.port`| Incoming TCP port of the kubernetes service - Traffic is routed from this port to the targetPort to gain access to the application -  By default and for convenience, the targetPort is set to the same value as the port field. [details](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) | 2020 |
 | `serviceMonitor.service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
+| `serviceMonitor.service.extraPorts`| Extra ports to expose on fluent-bit service | `[]` |
 | `serviceMonitor.interval`| Set how frequently Prometheus should scrape |`30s`|
 | `serviceMonitor.telemetryPath`| Set path to scrape metrics from |`/api/v1/metrics/prometheus`|
 | `serviceMonitor.labels`| Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator |`[]`|
@@ -212,6 +213,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `serviceMonitor.relabelings`| Set relabel_configs as per [details](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |`[]`|
 | `serviceMonitor.targetLabels`| Set of labels to transfer on the Kubernetes Service onto the target. |`[]`|
 | `serviceMonitor.metricRelabelings`| MetricRelabelConfigs to apply to samples before ingestion. |`[]`|
+| `serviceMonitor.extraEndpoints`| Extra endpoints on the fluen-bit service for the serviceMonitor to monitor |`[]`|
 | `tolerations`| Optional deployment tolerations |`[]`|
 | `nodeSelector`| Node labels for pod assignment |`{}`|
 | `annotations`| Optional pod annotations |`{}`|

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -213,7 +213,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `serviceMonitor.relabelings`| Set relabel_configs as per [details](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |`[]`|
 | `serviceMonitor.targetLabels`| Set of labels to transfer on the Kubernetes Service onto the target. |`[]`|
 | `serviceMonitor.metricRelabelings`| MetricRelabelConfigs to apply to samples before ingestion. |`[]`|
-| `serviceMonitor.extraEndpoints`| Extra endpoints on the fluen-bit service for the serviceMonitor to monitor |`[]`|
+| `serviceMonitor.extraEndpoints`| Extra endpoints on the fluent-bit service for the serviceMonitor to monitor |`[]`|
 | `tolerations`| Optional deployment tolerations |`[]`|
 | `nodeSelector`| Node labels for pod assignment |`{}`|
 | `annotations`| Optional pod annotations |`{}`|

--- a/stable/aws-for-fluent-bit/templates/service.yaml
+++ b/stable/aws-for-fluent-bit/templates/service.yaml
@@ -11,6 +11,14 @@ spec:
     port: {{ .Values.serviceMonitor.service.port }}
     protocol: TCP
     targetPort: {{ .Values.serviceMonitor.service.targetPort }}
+{{- if .Values.serviceMonitor.service.extraPorts }}
+  {{- range .Values.serviceMonitor.service.extraPorts }}
+  - name: {{ .name }}
+    targetPort: {{ .targetPort }}
+    protocol: {{ .protocol }}
+    port: {{ .port }}
+  {{- end }}
+{{- end }}
   selector:
     {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 4 }}
   sessionAffinity: None

--- a/stable/aws-for-fluent-bit/templates/servicemonitor.yaml
+++ b/stable/aws-for-fluent-bit/templates/servicemonitor.yaml
@@ -30,6 +30,9 @@ spec:
     relabelings:
 {{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
 {{- end }}
+{{- with .Values.serviceMonitor.extraEndpoints }}
+    {{- toYaml . | nindent 2 }}
+{{- end }}
   jobLabel: {{ default "app.kubernetes.io/instance" .Values.serviceMonitor.jobLabel }}
   namespaceSelector:
     matchNames:

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -368,6 +368,11 @@ serviceMonitor:
     type: ClusterIP
     port: 2020
     targetPort: 2020
+    extraPorts: {}
+      # - port: 2021
+      #   targetPort: 2021
+      #   protocol: TCP
+      #   name: metrics
   ## When set true then use a ServiceMonitor to configure scraping
   enabled: false
   interval: 30s
@@ -379,3 +384,9 @@ serviceMonitor:
   relabelings: []
   targetLabels: []
   metricRelabelings: []
+  extraEndpoints: {}
+    # - port: metrics
+    #   path: /metrics
+    #   interval: 30s
+    #   scrapeTimeout: 10s
+    #   scheme: http

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -368,7 +368,7 @@ serviceMonitor:
     type: ClusterIP
     port: 2020
     targetPort: 2020
-    extraPorts: {}
+    extraPorts: []
       # - port: 2021
       #   targetPort: 2021
       #   protocol: TCP
@@ -384,7 +384,7 @@ serviceMonitor:
   relabelings: []
   targetLabels: []
   metricRelabelings: []
-  extraEndpoints: {}
+  extraEndpoints: []
     # - port: metrics
     #   path: /metrics
     #   interval: 30s


### PR DESCRIPTION
Enabled service to have multiple ports, and the serviceMonitor to monitor multiple endpoints on the service, added relevant configuration examples as comments to values.yaml and updated the README file for the new chart fields.

### Issue

https://github.com/aws/eks-charts/issues/987

### Description of changes
- Updated the `serviceMonitor.yaml` template to allow for more service endpoints to be monitored
- Updated the `service.yaml` template to allow for more port to be exposed on the fluent-bit service
- Updated the `values.yaml` file to add the new config keys, and comments on how to configure them
- Updated the `README` file of the chart to add configuration notes for the new config fields

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

After making the changes to the chart, I ran `helm template .` in the chart directory and inspected the output to ensure it is producing the desired effect. An excerpt of the output is as shown below:

```
---
# Source: aws-for-fluent-bit/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    helm.sh/chart: aws-for-fluent-bit-0.1.28
    app.kubernetes.io/name: aws-for-fluent-bit
    app.kubernetes.io/instance: release-name-aws-for-fluent-bit
    app.kubernetes.io/version: "2.31.11"
    app.kubernetes.io/managed-by: Helm
  name: release-name-aws-for-fluent-bit
  namespace: default
spec:
  ports:
  - name: monitor-agent
    port: 2020
    protocol: TCP
    targetPort: 2020
  - name: metrics
    targetPort: 2021
    protocol: TCP
    port: 2021
  selector:
    app.kubernetes.io/name: aws-for-fluent-bit
    app.kubernetes.io/instance: release-name-aws-for-fluent-bit
  sessionAffinity: None
  type: ClusterIP
---
# Source: aws-for-fluent-bit/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-aws-for-fluent-bit
  namespace: default
spec:
  endpoints:
  - port: monitor-agent
    scheme: http
    interval: 30s
    path: /api/v1/metrics/prometheus
    scrapeTimeout: 10s
  - interval: 10s
    path: /metrics
    port: metrics
    scheme: http
    scrapeTimeout: 10s
  jobLabel: app.kubernetes.io/instance
  namespaceSelector:
    matchNames:
    - default
  selector:
    matchLabels:
      app.kubernetes.io/name: aws-for-fluent-bit
      app.kubernetes.io/instance: release-name-aws-for-fluent-bit
```
### Pre-Requisites to Testing Procedure
#### Changes in Values
* Before testing the chart, the `values.yaml` file needs to be updated as below: 
> NB: (Note that we remove the `[]` on lines 387 and 371 and set the service monitor to enabled
```
serviceMonitor:
  service: 
    type: ClusterIP
    port: 2020
    targetPort: 2020
    extraPorts: # Removing the empty array placeholder []  because we are now pupulating the array
      - port: 2021
        targetPort: 2021
        protocol: TCP
        name: metrics
  ## When set true then use a ServiceMonitor to configure scraping
  enabled: true # Enabling the servicMonitor
  interval: 30s
  telemetryPath: /api/v1/metrics/prometheus
  labels:
    # app: example-application
    # teamname: example
  timeout: 10s
  relabelings: []
  targetLabels: []
  metricRelabelings: []
  extraEndpoints:  # removing the empty array placeholder [] because now we are populating the array
    - port: metrics
      path: /metrics
      interval: 30s
      scrapeTimeout: 10s
      scheme: http
```
* In addition, the `serviceMonitor` object is a CRD created by the promehteus community. If your are doing helm template locally using `helm 3.x` please see below:

#### Templating locally
Helm does not automatically recognise CRDs, to be able to output the template including CRDs we need to:
* Download the `serviceMonitor` CRD from the prometheus operator Repo: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
* We add this YAML file to our chart directory either in the root together with Chart.yamland values.yaml or under the templates directory. This will help helm to understand the CRD resource.
* Next in the `serviceMonitor.yaml` template on line two, there is a condition: `{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}` -  which checks if the cluster API version has the "monitoring.coreos.com/v1" capabillity. For a dry run, since we are not installing this on an actual cluster with the relevant API version installed, we may temporarily disable that check by changing the `and` to an `or`. (If you are test installing on actual cluster -  please see the next heading.)
* Once all this is setup -  you can then run `helm template .` and inspect the output for `kind: Service` and the `kind: ServiceMonitor`
* Revert the condition in `serviceMonitor.yaml` template back to `and` AND  delete the serviceMonitor CRD file from the chart directory
* In values.yaml -  comment out lines [372-375] amnd [388 - 392], place back the the empty array place holders `[]` on lines 371 and 387, and set the `enabled: false` for the serviceMonitor such that theconfig looks like below:

```
serviceMonitor:
  service: 
    type: ClusterIP
    port: 2020
    targetPort: 2020
    extraPorts: []
      # - port: 2021
      #   targetPort: 2021
      #   protocol: TCP
      #   name: metrics
  ## When set true then use a ServiceMonitor to configure scraping
  enabled: false
  interval: 30s
  telemetryPath: /api/v1/metrics/prometheus
  labels:
    # app: example-application
    # teamname: example
  timeout: 10s
  relabelings: []
  targetLabels: []
  metricRelabelings: []
  extraEndpoints: []
    # - port: metrics
    #   path: /metrics
    #   interval: 30s
    #   scrapeTimeout: 10s
    #   scheme: http
``` 

#### Installing on test cluster
If you are testing by installing the helm chart on a cluster -  you need to ensure that you first install the `prometheus-operator` CRDs on the cluster -  especially the `serviceMonitor` in our case.

##### Example using minikube cluster
* Download the serviceMonitor CRD from the prometheus operator repo: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
* Run `kubectl apply -f </path/to/serviceMonitor.yaml>` to install the CRD on the cluster (this is so that the condition in serviceMonitor.yaml template passes)
* In the values.yaml of our chart:
    * Enable the serviceMonitor
    * Uncomment the lines [372-375] and lines [388-392]
    * remove the empty array placeholders `[]` on lines 387 and 371
* The config for service Monitor should now look like:

```
serviceMonitor:
  service: 
    type: ClusterIP
    port: 2020
    targetPort: 2020
    extraPorts:
      - port: 2021
        targetPort: 2021
        protocol: TCP
        name: metrics
  ## When set true then use a ServiceMonitor to configure scraping
  enabled: true
  interval: 30s
  telemetryPath: /api/v1/metrics/prometheus
  labels:
    # app: example-application
    # teamname: example
  timeout: 10s
  relabelings: []
  targetLabels: []
  metricRelabelings: []
  extraEndpoints: 
    - port: metrics
      path: /metrics
      interval: 30s
      scrapeTimeout: 10s
      scheme: http
```

* Run `helm install aws-for-fluentbit .` from the chart directory. Helm will install the chart.
* To get the service monitor run `kubectl get serviceMonitor -n <namespace where chart is deployed>` and you will see the service monitor.
* Run `kubectl describe serviceMonitor <serviceMonitor name from previous output> -n <the namespace where it is installed>` and inspect the out put.
* To see the yaml output run: `kubectl get serviceMonitor <serviceMonitor name> -n <namespace of serviceMonitor> -o yaml` and inspect the output
* Do the same for the `Service` resource 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
