### PR TITLE
Remove patch permissions for policyendpoints on aws-vpc-cni helm chart

### DIFF
--- a/stable/aws-vpc-cni/templates/clusterrole.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrole.yaml
@@ -36,7 +36,7 @@ rules:
   - apiGroups: ["networking.k8s.aws"]
     resources:
       - policyendpoints
-    verbs: ["get", "patch", "list", "watch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.k8s.aws"]
     resources:
       - policyendpoints/status


### PR DESCRIPTION
### Issue
Removes patch permissions for policyendpoints resource on vpc-cni helm chart

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
Updating permissions on the cluster-role

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
N/A
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
