### PR TITLE
Updates aws-vpc-cni helm chart for v1.14.1 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.14.0
-appVersion: "v1.14.0"
+version: 1.14.1
+appVersion: "v1.14.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `enableWindowsIpam`     | Enable windows support for your cluster                  | `false`                            |
 | `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                          |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.14.0`                           |
+| `image.tag`             | Image tag                                               | `v1.14.1`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.14.0`                           |
+| `init.image.tag`        | Image tag                                               | `v1.14.1`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -62,7 +62,7 @@ The following table lists the configurable parameters for this chart and their d
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.1`                            |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.2`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |

--- a/stable/aws-vpc-cni/templates/_helpers.tpl
+++ b/stable/aws-vpc-cni/templates/_helpers.tpl
@@ -88,3 +88,17 @@ The aws-network-policy-agent image to use
 {{- printf "%s.dkr.%s.%s.%s/amazon/aws-network-policy-agent:%s" .Values.nodeAgent.image.account .Values.nodeAgent.image.endpoint .Values.nodeAgent.image.region .Values.nodeAgent.image.domain .Values.nodeAgent.image.tag }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The aws-network-policy-agent port to bind to for metrics
+*/}}
+{{- define "aws-vpc-cni.nodeAgentMetricsBindAddr" -}}
+{{- printf ":%s" .Values.nodeAgent.metricsBindAddr }}
+{{- end -}}
+
+{{/*
+The aws-network-policy-agent port to bind to for health probes
+*/}}
+{{- define "aws-vpc-cni.nodeAgentHealthProbeBindAddr" -}}
+{{- printf ":%s" .Values.nodeAgent.healthProbeBindAddr }}
+{{- end -}}

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -128,6 +128,8 @@ spec:
             - --enable-ipv6={{ .Values.nodeAgent.enableIpv6 }}
             - --enable-network-policy={{ .Values.enableNetworkPolicy }}
             - --enable-cloudwatch-logs={{ .Values.nodeAgent.enableCloudWatchLogs }}
+            - --metrics-bind-addr={{ include "aws-vpc-cni.nodeAgentMetricsBindAddr" . }}
+            - --health-probe-bind-addr={{ include "aws-vpc-cni.nodeAgentHealthProbeBindAddr" . }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.14.0
+    tag: v1.14.1
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -25,7 +25,7 @@ init:
 
 nodeAgent:
   image:
-    tag: v1.0.1
+    tag: v1.0.2
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -41,9 +41,11 @@ nodeAgent:
     privileged: true
   enableCloudWatchLogs: "false"
   enableIpv6: "false"
+  metricsBindAddr: "8162"
+  healthProbeBindAddr: "8163"
 
 image:
-  tag: v1.14.0
+  tag: v1.14.1
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
N/A

### Description of changes

<!-- Please explain the changes you made here. -->
This updates the helm chart for aws-vpc-cni v1.14.1 release. It also adds two new flags `healthProbeBindAddr` & `metricsBindAddr` to make the metrics port configurable for `aws-eks-nodeagent`

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Tested by generating the manifest with the above changes
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
