### PR TITLE
Update aws-vpc-cni and cni-metrics-helper charts for v1.15.0 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.14.1
-appVersion: "v1.14.1"
+version: 1.15.0
+appVersion: "v1.15.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -40,10 +40,10 @@ The following table lists the configurable parameters for this chart and their d
 | `eniConfig.subnets.id`  | The ID of the subnet within the AZ which will be used in the ENIConfig | `nil`                |
 | `eniConfig.subnets.securityGroups`  | The IDs of the security groups which will be used in the ENIConfig | `nil`        |
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
-| `enableWindowsIpam`     | Enable windows support for your cluster                  | `false`                            |
-| `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                          |
+| `enableWindowsIpam`     | Enable windows support for your cluster                 | `false`                             |
+| `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.14.1`                           |
+| `image.tag`             | Image tag                                               | `v1.15.0`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.14.1`                           |
+| `init.image.tag`        | Image tag                                               | `v1.15.0`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -65,12 +65,14 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.2`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
-| `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
-| `nodeAgent.image.account`    | ECR repository account number                           | `602401143452`                      |
+| `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |
+| `nodeAgent.image.account`    | ECR repository account number                      | `602401143452`                      |
 | `nodeAgent.image.pullPolicy` | Container pull policy                              | `IfNotPresent`                      |
 | `nodeAgent.securityContext`  | Node Agent container Security context              | `capabilities: add: - "NET_ADMIN" privileged: true`  |
 | `nodeAgent.enableCloudWatchLogs`  | Enable CW logging for Node Agent              | `false`                             |
-| `nodeAgent.enableIpv6`
+| `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
+| `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |
+| `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
 | `extraVolumes`          | Array to add extra volumes                              | `[]`                                |
 | `extraVolumeMounts`     | Array to add extra mount                                | `[]`                                |
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |

--- a/stable/aws-vpc-cni/templates/clusterrole.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-    verbs: ["list", "watch", "get", "update"]
+    verbs: ["list", "watch", "get"]
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
@@ -41,3 +41,8 @@ rules:
     resources:
       - policyendpoints/status
     verbs: ["get"]
+  - apiGroups:
+      - vpcresources.k8s.aws
+    resources:
+      - cninodes
+    verbs: ["get", "list", "patch"]

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.14.1
+    tag: v1.15.0
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -45,7 +45,7 @@ nodeAgent:
   healthProbeBindAddr: "8163"
 
 image:
-  tag: v1.14.1
+  tag: v1.15.0
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.14.1
-appVersion: v1.14.1
+version: 1.15.0
+appVersion: v1.15.0
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.14.1            |
+| image.tag                    | Image tag                                                     | v1.15.0            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.14.1
+  tag: v1.15.0
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image


### PR DESCRIPTION
### Issue
N/A

### Description of changes
This PR updates the `aws-vpc-cni` and `cni-metrics-helper` charts for the upcoming `v1.15.0` release. Changes to call out in charts:
`aws-vpc-cni`:
- Removal of the `update` permission for `nodes` resources in `ClusterRole`
- Addition of `get, watch, patch` permissions for CNINodes resources in `ClusterRole`
- image tag updates

`cni-metrics-helper`:
- image tag updates

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Manually verified that chart can be applied

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
