### PR TITLE
fix: configure serviceMonitor condition for monitoring API #4667

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.6.1
+version: 1.6.2
 appVersion: v2.6.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
+++ b/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 {{- if.Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -32,4 +33,5 @@ spec:
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Issue

### Description of changes

Fixes
Description
Some installations we configure Karpenter before prometheus-operator and our argo-cd Waves broke and cannot continue the installation we implement the same structure as argocd [helm-chart](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml#L1C1-L1C70) to check if the monitoring API is available.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
