### PR TITLE
aws-vpc-cni and cni-metrics-helper chart updates for 1.15.1 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.15.0
-appVersion: "v1.15.0"
+version: 1.15.1
+appVersion: "v1.15.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `enableWindowsIpam`     | Enable windows support for your cluster                 | `false`                             |
 | `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.15.0`                           |
+| `image.tag`             | Image tag                                               | `v1.15.1`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.15.0`                           |
+| `init.image.tag`        | Image tag                                               | `v1.15.1`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -62,14 +62,15 @@ The following table lists the configurable parameters for this chart and their d
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.2`                            |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.4`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |
 | `nodeAgent.image.account`    | ECR repository account number                      | `602401143452`                      |
 | `nodeAgent.image.pullPolicy` | Container pull policy                              | `IfNotPresent`                      |
-| `nodeAgent.securityContext`  | Node Agent container Security context              | `capabilities: add: - "NET_ADMIN" privileged: true`  |
+| `nodeAgent.securityContext`  | Node Agent container Security context              | `capabilities: add: - "NET_ADMIN" privileged: true` |
 | `nodeAgent.enableCloudWatchLogs`  | Enable CW logging for Node Agent              | `false`                             |
+| `nodeAgent.enablePolicyEventLogs` | Enable policy decision logs for Node Agent    | `false`                             |
 | `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
 | `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |
 | `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
@@ -81,7 +82,7 @@ The following table lists the configurable parameters for this chart and their d
 | `podLabels`             | Labels to add to each pod                               | `{}`                                |
 | `priorityClassName`     | Name of the priorityClass                               | `system-node-critical`              |
 | `resources`             | Resources for containers in pod                         | `requests.cpu: 25m`                 |
-| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" - "NET_RAW"`  |
+| `securityContext`       | Container Security context                              | `capabilities: add: - "NET_ADMIN" - "NET_RAW"` |
 | `serviceAccount.name`   | The name of the ServiceAccount to use                   | `nil`                               |
 | `serviceAccount.create` | Specifies whether a ServiceAccount should be created    | `true`                              |
 | `serviceAccount.annotations` | Specifies the annotations for ServiceAccount       | `{}`                                |

--- a/stable/aws-vpc-cni/templates/configmap.yaml
+++ b/stable/aws-vpc-cni/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "aws-vpc-cni.fullname" . }}
   labels:
 {{ include "aws-vpc-cni.labels" . | indent 4 }}
-data:
+binaryData:
   10-aws.conflist: {{ .Values.cniConfig.fileContents | b64enc }}
 {{- end -}}
 ---

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -128,6 +128,7 @@ spec:
             - --enable-ipv6={{ .Values.nodeAgent.enableIpv6 }}
             - --enable-network-policy={{ .Values.enableNetworkPolicy }}
             - --enable-cloudwatch-logs={{ .Values.nodeAgent.enableCloudWatchLogs }}
+            - --enable-policy-event-logs={{ .Values.nodeAgent.enablePolicyEventLogs }}
             - --metrics-bind-addr={{ include "aws-vpc-cni.nodeAgentMetricsBindAddr" . }}
             - --health-probe-bind-addr={{ include "aws-vpc-cni.nodeAgentHealthProbeBindAddr" . }}
           resources:
@@ -144,7 +145,7 @@ spec:
           - mountPath: /var/run/aws-node
             name: run-dir
       volumes:
-      - name: bpf-pin-path 
+      - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
       - name: cni-bin-dir

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.15.0
+    tag: v1.15.1
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -25,7 +25,7 @@ init:
 
 nodeAgent:
   image:
-    tag: v1.0.2
+    tag: v1.0.4
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -40,12 +40,13 @@ nodeAgent:
       - "NET_ADMIN"
     privileged: true
   enableCloudWatchLogs: "false"
+  enablePolicyEventLogs: "false"
   enableIpv6: "false"
   metricsBindAddr: "8162"
   healthProbeBindAddr: "8163"
 
 image:
-  tag: v1.15.0
+  tag: v1.15.1
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr
@@ -78,6 +79,7 @@ env:
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
+  VPC_CNI_VERSION: "v1.15.1"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.15.0
-appVersion: v1.15.0
+version: 1.15.1
+appVersion: v1.15.1
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.15.0            |
+| image.tag                    | Image tag                                                     | v1.15.1            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.15.0
+  tag: v1.15.1
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image


### PR DESCRIPTION
### Issue
N/A

### Description of changes
This PR contains chart updates for `aws-vpc-cni` and `cni-metrics-helper` for `v1.15.1` release. The changes are:
**aws-vpc-cni:**
* image tag update for VPC CNI and network policy agent containers
* `--enable-policy-event-logs` arg for network policy agent container, paired with configurable `nodeAgent.enablePolicyEventLogs` in `values.yaml` (default `false`)
* `data` -> `binaryData` fix in ConfigMap
* `VPC_CNI_VERSION` environment variable
* `ENABLE_V4_EGRESS` environment variable

**cni-metrics-helper:**
* image tag update

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Manually verified that chart can be applied to cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
