### PR TITLE
Missing "imagePullSecrets" field in Cloudwatch metrics helm templates definition (daemonset.yaml)

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.9
+version: 0.0.10
 appVersion: "1.247350"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -28,6 +28,7 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Service account to be used | |
+| `imagePullSecrets` | Image Pull Secret to be used ||
 | `hostNetwork` | Allow to use the network namespace and network resources of the node | `false` |
 | `nodeSelector` | Node labels for pod assignment	 | {} |
 | `tolerations` | Optional deployment tolerations	 | {} |

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     spec:
       serviceAccountName: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -4,6 +4,7 @@ image:
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name
+imagePullSecrets: []
 
 resources:
   limits:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available --> Not Available

### Description of changes

<!-- Please explain the changes you made here. --> imagePullSecrets field is missing in daemonset.yaml in https://github.com/aws/eks-charts/blob/master/stable/aws-cloudwatch-metrics/templates/daemonset.yaml. I have added this definition and also updated values.yaml accordingly here - https://github.com/aws/eks-charts/blob/master/stable/aws-cloudwatch-metrics/values.yaml

### Checklist
- [Y] Added/modified documentation as required (such as the `README.md` for modified charts)
- [Y] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [Y] Manually tested. Describe what testing was done in the testing section below
- [Y] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. --> Downloaded the chart and updated the field of imagePullSecret and pushed the helm chart to private helm repo and using this installed the helm chart for aws-cloudwatch-metrics with imagepullsecret value and its working fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
