### PR TITLE
Create flag to enable / disable creation of the amazon-vpc-cni configmap

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.15.1
+version: 1.15.2
 appVersion: "v1.15.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -32,6 +32,7 @@ The following table lists the configurable parameters for this chart and their d
 | Parameter               | Description                                             | Default                             |
 | ------------------------|---------------------------------------------------------|-------------------------------------|
 | `affinity`              | Map of node/pod affinities                              | `{}`                                |
+| `amazonVpcCniConfig.enabled` | Enable disabling the creation of amazon-vpc-cni config  | `true`                         |
 | `cniConfig.enabled`     | Enable overriding the default 10-aws.conflist file      | `false`                             |
 | `cniConfig.fileContents`| The contents of the custom cni config file              | `nil`                               |
 | `eniConfig.create`      | Specifies whether to create ENIConfig resource(s)       | `false`                             |

--- a/stable/aws-vpc-cni/templates/configmap.yaml
+++ b/stable/aws-vpc-cni/templates/configmap.yaml
@@ -9,6 +9,7 @@ binaryData:
   10-aws.conflist: {{ .Values.cniConfig.fileContents | b64enc }}
 {{- end -}}
 ---
+{{- if .Values.amazonVpcCniConfig.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,3 +20,4 @@ metadata:
 data:
   enable-windows-ipam: {{ .Values.enableWindowsIpam | quote }}
   enable-network-policy-controller: {{ .Values.enableNetworkPolicy | quote }}
+{{- end -}}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -85,6 +85,11 @@ env:
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release
 originalMatchLabels: false
 
+# this flag enables you to not instanciate the amazon-vpc-cni configmap which is handy if you have several
+# instances of the chart in your cluster
+amazonVpcCniConfig:
+  enabled: true
+
 enableWindowsIpam: "false"
 enableNetworkPolicy: "false"
 


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/issues/1003

### Description of changes

I have just added a flag allowing to not deploy the configmap amazon-vpc-cni, and thus allowing again multiple deployments of the chart in the same cluster.

### Checklist
- [x ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below.
- [x ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Successfully upgraded the 2 charts instances to v1.15.1 in one cluster with the flag enabled for the first and disabled for the second.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
