### PR TITLE
Chart updates for VPC CNI v1.15.3 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.15.1
-appVersion: "v1.15.1"
+version: 1.15.3
+appVersion: "v1.15.3"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `enableWindowsIpam`     | Enable windows support for your cluster                 | `false`                             |
 | `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.15.1`                           |
+| `image.tag`             | Image tag                                               | `v1.15.3`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.15.1`                           |
+| `init.image.tag`        | Image tag                                               | `v1.15.3`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -60,9 +60,11 @@ The following table lists the configurable parameters for this chart and their d
 | `init.image.override`   | A custom docker image to use                            | `nil`                               |
 | `init.env`              | List of init container environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `init.securityContext`  | Init container Security context                         | `privileged: true`                  |
+| `init.resources`        | Init container resources, will defualt to .Values.resources if not set | `{}`                 |
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.4`                            |
+| `nodeAgent.enabled`     | If the Node Agent container should be created           | `true`                              |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.5`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |
@@ -74,6 +76,7 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
 | `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |
 | `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
+| `nodeAgent.resources`   | Node Agent resources, will defualt to .Values.resources if not set | `{}`                     |
 | `extraVolumes`          | Array to add extra volumes                              | `[]`                                |
 | `extraVolumeMounts`     | Array to add extra mount                                | `[]`                                |
 | `nodeSelector`          | Node labels for pod assignment                          | `{}`                                |

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -48,8 +48,10 @@ spec:
 {{- end }}
         securityContext:
           {{- toYaml .Values.init.securityContext | nindent 12 }}
+        {{- with default .Values.resources .Values.init.resources }}
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -91,8 +93,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
@@ -100,13 +104,13 @@ spec:
             name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
             name: cni-net-dir
-{{- if .Values.cniConfig.enabled }}
+          {{- if .Values.cniConfig.enabled }}
             # The dockerfile copies the baked in config to this location, so overwrite it with ours.
             # The entrypoint process will then copy our config to /host/etc/cni/net.d on boot.
           - name: cni-config
             mountPath: /app/10-aws.conflist
             subPath: 10-aws.conflist
-{{- end }}
+          {{- end }}
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
           - mountPath: /var/run/aws-node
@@ -116,6 +120,7 @@ spec:
           {{- with .Values.extraVolumeMounts  }}
           {{- toYaml .| nindent 10 }}
           {{- end }}
+        {{- if .Values.nodeAgent.enabled }}
         - name: aws-eks-nodeagent
           image: {{ include "aws-vpc-cni.nodeAgentImage" . }}
           env:
@@ -131,34 +136,41 @@ spec:
             - --enable-policy-event-logs={{ .Values.nodeAgent.enablePolicyEventLogs }}
             - --metrics-bind-addr={{ include "aws-vpc-cni.nodeAgentMetricsBindAddr" . }}
             - --health-probe-bind-addr={{ include "aws-vpc-cni.nodeAgentHealthProbeBindAddr" . }}
+          {{- with default .Values.resources .Values.nodeAgent.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.nodeAgent.securityContext | nindent 12 }}
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
+          {{- if .Values.nodeAgent.enabled }}
           - mountPath: /sys/fs/bpf
             name: bpf-pin-path
+          {{- end }}
           - mountPath: /var/log/aws-routed-eni
             name: log-dir
           - mountPath: /var/run/aws-node
             name: run-dir
+      {{- end }}
       volumes:
+      {{- if .Values.nodeAgent.enabled }}
       - name: bpf-pin-path
         hostPath:
           path: /sys/fs/bpf
+      {{- end }}
       - name: cni-bin-dir
         hostPath:
           path: /opt/cni/bin
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
-{{- if .Values.cniConfig.enabled }}
+      {{- if .Values.cniConfig.enabled }}
       - name: cni-config
         configMap:
           name: {{ include "aws-vpc-cni.fullname" . }}
-{{- end }}
+      {{- end }}
       - name: log-dir
         hostPath:
           path: /var/log/aws-routed-eni

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.15.1
+    tag: v1.15.3
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -22,10 +22,12 @@ init:
     ENABLE_IPv6: "false"
   securityContext:
     privileged: true
+  resources: {}
 
 nodeAgent:
+  enabled: true
   image:
-    tag: v1.0.4
+    tag: v1.0.5
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -44,9 +46,10 @@ nodeAgent:
   enableIpv6: "false"
   metricsBindAddr: "8162"
   healthProbeBindAddr: "8163"
+  resources: {}
 
 image:
-  tag: v1.15.1
+  tag: v1.15.3
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr
@@ -79,7 +82,7 @@ env:
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
-  VPC_CNI_VERSION: "v1.15.1"
+  VPC_CNI_VERSION: "v1.15.3"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.15.1
-appVersion: v1.15.1
+version: 1.15.3
+appVersion: v1.15.3
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.15.1            |
+| image.tag                    | Image tag                                                     | v1.15.3            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.15.1
+  tag: v1.15.3
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image


### PR DESCRIPTION
### Issue
N/A

### Description of changes
This PR contains chart updates for `aws-vpc-cni` and `cni-metrics-helper` for the v1.15.3 release. The changes are:
`aws-vpc-cni`:
- image tag update for VPC CNI and network policy agent
- ability to not render the network policy agent container in the daemonset by setting `nodeAgent.enable` to `false`
- ability to specify resources for the init container and network policy agent container (instead of inheriting from the main container)

`cni-metrics-helper`:
- image tag update

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Manually verified that chart can be rendered and applied

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
