### PR TITLE
Update aws-vpc-cni and cni-metrics-helper charts for v1.15.4 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.15.3
-appVersion: "v1.15.3"
+version: 1.15.4
+appVersion: "v1.15.4"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `enableWindowsIpam`     | Enable windows support for your cluster                 | `false`                             |
 | `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.15.3`                           |
+| `image.tag`             | Image tag                                               | `v1.15.4`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +51,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.15.3`                           |
+| `init.image.tag`        | Image tag                                               | `v1.15.4`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -64,7 +64,7 @@ The following table lists the configurable parameters for this chart and their d
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
 | `nodeAgent.enabled`     | If the Node Agent container should be created           | `true`                              |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.5`                            |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.0.6`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.15.3
+    tag: v1.15.4
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -27,7 +27,7 @@ init:
 nodeAgent:
   enabled: true
   image:
-    tag: v1.0.5
+    tag: v1.0.6
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -49,7 +49,7 @@ nodeAgent:
   resources: {}
 
 image:
-  tag: v1.15.3
+  tag: v1.15.4
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr
@@ -82,7 +82,7 @@ env:
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
-  VPC_CNI_VERSION: "v1.15.3"
+  VPC_CNI_VERSION: "v1.15.4"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.15.3
-appVersion: v1.15.3
+version: 1.15.4
+appVersion: v1.15.4
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.15.3            |
+| image.tag                    | Image tag                                                     | v1.15.4            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.15.3
+  tag: v1.15.4
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image


### PR DESCRIPTION
### Issue
N/A

### Description of changes
This PR contains chart updates for `aws-vpc-cni` and `cni-metrics-helper` for the `v1.15.4` release. The changes are:
`aws-vpc-cni`:
- image tag update for VPC CNI and network policy agent

`cni-metrics-helper`:
- image tag update

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Manually verified that chart can be applied to cluster and integration tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
