### PR TITLE
Revert "🥳 appmesh-controller v1.12.5 Automated Release! 🥑"

### DIFF
--- a/stable/appmesh-controller/Chart.yaml
+++ b/stable/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.12.5
-appVersion: 1.12.5
+version: 1.12.3
+appVersion: 1.12.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/appmesh-controller/ci/values.yaml
+++ b/stable/appmesh-controller/ci/values.yaml
@@ -5,5 +5,5 @@ accountId: 123456789
 region: us-west-2
 image:
   repository: public.ecr.aws/appmesh/appmesh-controller
-  tag: v1.12.5
+  tag: v1.12.3
   pullPolicy: IfNotPresent

--- a/stable/appmesh-controller/crds/crds.yaml
+++ b/stable/appmesh-controller/crds/crds.yaml
@@ -3914,6 +3914,7 @@ spec:
                           type: object
                       required:
                       - action
+                      - match
                       type: object
                   required:
                   - name

--- a/stable/appmesh-controller/test.yaml
+++ b/stable/appmesh-controller/test.yaml
@@ -12,13 +12,13 @@ useAwsFIPSEndpoint: false
 
 image:
   repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.12.5
+  tag: v1.12.3
   pullPolicy: IfNotPresent
 
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.27.2.0-prod
+    tag: v1.25.4.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/stable/appmesh-controller/values.yaml
+++ b/stable/appmesh-controller/values.yaml
@@ -13,13 +13,13 @@ useAwsFIPSEndpoint: false
 
 image:
   repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.12.5
+  tag: v1.12.3
   pullPolicy: IfNotPresent
 
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.27.2.0-prod
+    tag: v1.25.4.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901


### PR DESCRIPTION
Reverts aws/eks-charts#1022

A bad sed command updated the envoy version unintentionally.