### PR TITLE
Custom MULTILINE_PARSER support

### DIFF
--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -17,6 +17,9 @@ data:
 {{- if .Values.service.extraParsers }}
         Parsers_File /fluent-bit/etc/parser_extra.conf
 {{- end }}
+{{- if .Values.service.multilineParsers }}
+        Parsers_File /fluent-bit/etc/parsers_multiline.conf
+{{- end }}
 
 {{- if .Values.input.enabled }}
     [INPUT]
@@ -498,4 +501,9 @@ data:
 {{- if .Values.service.extraParsers }}
   parser_extra.conf: |-
 {{ .Values.service.extraParsers | indent 4 }}
+{{- end }}
+
+{{- if .Values.service.multilineParsers }}
+  parsers_multiline.conf: |-
+{{ .Values.service.multilineParsers | indent 4 }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -46,6 +46,15 @@ service:
   #   [PARSER]
   #       Name   logfmt
   #       Format logfmt
+  # multilineParsers: |
+  #  [MULTILINE_PARSER]
+  #    Name  multiline_logs
+  #    type  regex
+  #    flush_timeout 1000
+  #    # rules   |   state name   | regex pattern                   | next state name
+  #    # --------|----------------|--------------------------------------------------
+  #    rule  "start_state" "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} \[([^\]]*)\].*$"  "cont"
+  #    rule  "cont"  "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} \[([^\]]*)\]).*$" "cont"
 
 input:
   enabled: true


### PR DESCRIPTION
### Custom MULTILINE_PARSER
The current implementation of the AWS Fluent Bit Helm chart lacks support for custom MULTILINE_PARSER configurations in the extraParsers section of the values.yaml file. When attempting to define a custom multiline parser in this section, an error is encountered, specifically: [multiline_parser] multiline_logs not registered.

It's possible that there might be nuances or specific configurations required to enable the MULTILINE_PARSER functionality within the extraParsers section that I might not be aware of, if so please correct me.

### Description of changes
I added support for the MULTILINE_PARSER in the extraParsers section of the values.yaml file in the AWS Fluent Bit Helm chart. This enhancement allowed me to define custom multiline parsers.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
