### PR TITLE
aws-for-fluent-bit: Add extraLabels parameter

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.32
+version: 0.1.33
 appVersion: 2.31.12.20231011
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -49,6 +49,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `input.memBufLimit` | Limit the [buffer memory](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/oomkill-prevention) used by the tail input. | `5MB` |
 | `input.skipLongLines` | `On` means that long lines will be skipped [instead of the entire log file](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#tail-input-skipping-file) | `On` |
 | `input.refreshInterval` | The interval to refresh the list of watched files in seconds. | `10` |
+| `extraLabels` | Dict of Kubernetes labels to add to the defaults shipped by this chart | `{}` |
 | `extraInputs` | Append to existing input with this value | `""` |
 | `additionalInputs` | Adding more inputs with this value | `""` |
 | `filter.*` | Values for kubernetes filter | |

--- a/stable/aws-for-fluent-bit/templates/_helpers.tpl
+++ b/stable/aws-for-fluent-bit/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "aws-for-fluent-bit.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -10,6 +10,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+extraLabels: {}
 
 podSecurityContext: {}
 # runAsUser: 1000


### PR DESCRIPTION
This adds an "extraLabels" parameter to add labels to an internal helper that maintains the labels for the various resources.

### Issue

I didn't open an issue for this, didn't seem big enough

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Tested with `helm template . --values testvalues.yaml | tee result.yaml` with several modifications in `testvalues.yaml` including null extraLabels, `{}` extraLabels (the default), and 

```yaml
extraLabels:
  foo: bar
```

and confirmed each case compiled properly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
