### PR TITLE
Added EFA helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ helm repo add eks https://aws.github.io/eks-charts
 
 * [cni-metrics-helper](stable/cni-metrics-helper): A helm chart for [CNI Metrics Helper](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/cmd/cni-metrics-helper/README.md)
 
+### EKS EFA Plugin
+* [aws-efa-k8s-device-plugin](stable/aws-efa-k8s-device-plugin): A helm chart for the [Elastic Fabric Adapter](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html) plugin, which automatically discovers and mounts EFA devices into pods that request them
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/stable/aws-efa-k8s-device-plugin/.helmignore
+++ b/stable/aws-efa-k8s-device-plugin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: aws-efa-k8s-device-plugin
+description: A Helm chart for EFA device plugin.
+version: v0.4.2
+appVersion: "v0.4.2"
+home: https://github.com/aws/eks-charts
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/eks-charts

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -1,0 +1,38 @@
+# AWS EFA Kubernetes Device Plugin
+This chart installs the AWS EFA Kubernetes Device Plugin daemonset
+
+## Prerequisites
+- Helm v3
+
+## Installing the Chart
+First add the EKS repository to Helm:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+To install the chart with the release name `efa` in the `kube-system` namespace and default configuration:
+
+```shell
+helm install efa ./aws-efa-k8s-device-plugin -n kube-system
+```
+
+# Configuration
+
+Paramter | Description | Default
+--- | --- | ---
+`image.repository` | EFA image repository | `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin`
+`image.tag` | EFA image tag | `v0.4.2`
+`securityContext.allowPrivilegeEscalation` | Controls whether a process can gain more privilege than its parent process | `false`
+`securityContext` | EFA plugin security context | `capabilities: drop: ["ALL"] runAsNonRoot: false`
+`supportedInstanceLabels.keys` | Kubernetes key to interpret as instance type | `nodes.kubernetes.io/instance-type`
+`supportedInstanceLabels.values` | List of instances which currently support EFA devices | `see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types`
+`resources` | Resources for containers in pod | `requests.cpu: 10m requests.memory: 20Mi`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`tolerations` | Optional deployment tolerations | `[]`
+`additionalPodAnnotations` | Pod annotations to apply in addition to the default ones | `{}`
+`additionalPodLabels` | Pod labels to apply in addition to the defualt ones | `{}`
+`nameOverride` | Override the name of the chart | `""`
+`fullnameOverride` | Override the full name of the chart | `""`
+`imagePullSecrets` | Docker registry pull secret | `[]`
+

--- a/stable/aws-efa-k8s-device-plugin/templates/NOTES.txt
+++ b/stable/aws-efa-k8s-device-plugin/templates/NOTES.txt
@@ -1,0 +1,1 @@
+EFA device plugin is installed, it can be requested as `vpc.amazonaws.com/efa` resource.

--- a/stable/aws-efa-k8s-device-plugin/templates/_helpers.tpl
+++ b/stable/aws-efa-k8s-device-plugin/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-efa-k8s-device-plugin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-efa-k8s-device-plugin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-efa-k8s-device-plugin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-efa-k8s-device-plugin.labels" -}}
+helm.sh/chart: {{ include "aws-efa-k8s-device-plugin.chart" . }}
+{{ include "aws-efa-k8s-device-plugin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aws-efa-k8s-device-plugin.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aws-efa-k8s-device-plugin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-efa-k8s-device-plugin.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "aws-efa-k8s-device-plugin.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "aws-efa-k8s-device-plugin.fullname" . }}
+  labels:
+    {{- include "aws-efa-k8s-device-plugin.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      name:  {{ include "aws-efa-k8s-device-plugin.fullname" . }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      {{- if .Values.additionalPodAnnotations }}
+      annotations:
+        {{- with .Values.additionalPodAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+      labels:
+        name: {{ include "aws-efa-k8s-device-plugin.fullname" . }}
+        {{- with .Values.additionalPodLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      # Mark this pod as a critical add-on; when enabled, the critical add-on
+      # scheduler reserves resources for critical add-on pods so that they can
+      # be rescheduled after a failure.
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      priorityClassName: "system-node-critical"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              {{- range .Values.supportedInstanceLabels.keys }}
+              - matchExpressions:
+                - key: {{ . }}
+                  operator: In
+                  values:
+                    {{- toYaml $.Values.supportedInstanceLabels.values | nindent 20 }}
+              {{- end }}
+      hostNetwork: true
+      containers:
+        - image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          name: aws-efa-k8s-device-plugin
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12}}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -1,0 +1,136 @@
+image:
+  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.4.2"
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: false
+supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
+  keys:
+    - "node.kubernetes.io/instance-type"
+  values:
+    - c5n.18xlarge
+    - c5n.9xlarge
+    - c5n.metal
+    - c6a.48xlarge
+    - c6a.metal
+    - c6gn.16xlarge
+    - c6i.32xlarge
+    - c6i.metal
+    - c6id.32xlarge
+    - c6id.metal
+    - c6in.32xlarge
+    - c6in.metal
+    - c7a.48xlarge
+    - c7a.metal-48xl
+    - c7g.16xlarge
+    - c7g.metal
+    - c7gd.16xlarge
+    - c7gn.16xlarge
+    - c7i.48xlarge
+    - c7i.metal-48xl
+    - dl1.24xlarge
+    - dl2q.24xlarge
+    - g4dn.12xlarge
+    - g4dn.16xlarge
+    - g4dn.8xlarge
+    - g4dn.metal
+    - g5.12xlarge
+    - g5.16xlarge
+    - g5.24xlarge
+    - g5.48xlarge
+    - g5.8xlarge
+    - hpc6a.48xlarge
+    - hpc7g.16xlarge
+    - hpc7g.8xlarge
+    - hpc7g.4xlarge
+    - i3en.12xlarge
+    - i3en.24xlarge
+    - i3en.metal
+    - i4g.16xlarge
+    - i4i.32xlarge
+    - i4i.metal
+    - im4gn.16xlarge
+    - inf1.24xlarge
+    - m5dn.24xlarge
+    - m5dn.metal
+    - m5n.24xlarge
+    - m5n.metal
+    - m5zn.12xlarge
+    - m5zn.metal
+    - m6a.48xlarge
+    - m6a.metal
+    - m6i.32xlarge
+    - m6i.metal
+    - m6id.32xlarge
+    - m6id.metal
+    - m6idn.32xlarge
+    - m6idn.metal
+    - m6in.32xlarge
+    - m6in.metal
+    - m7a.48xlarge
+    - m7a.metal-48xl
+    - m7g.16xlarge
+    - m7g.metal
+    - m7gd.16xlarge
+    - m7i.48xlarge
+    - m7i.metal-48xl
+    - p3dn.24xlarge
+    - p4d.24xlarge
+    - p5.48xlarge
+    - r5dn.24xlarge
+    - r5dn.metal
+    - r5n.24xlarge
+    - r5n.metal
+    - r6a.48xlarge
+    - r6a.metal
+    - r6i.32xlarge
+    - r6i.metal
+    - r6id.32xlarge
+    - r6id.metal
+    - r6idn.32xlarge
+    - r6idn.metal
+    - r6in.32xlarge
+    - r6in.metal
+    - r7a.48xlarge
+    - r7a.metal-48xl
+    - r7g.16xlarge
+    - r7g.metal
+    - r7gd.16xlarge
+    - r7i.48xlarge
+    - r7i.metal-48xl
+    - r7iz.32xlarge
+    - r7iz.metal-32xl
+    - trn1.32xlarge
+    - trn1n.32xlarge
+    - vt1.24xlarge
+    - x2idn.32xlarge
+    - x2idn.metal
+    - x2iedn.32xlarge
+    - x2iedn.metal
+    - x2iezn.12xlarge
+    - x2iezn.metal 
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+   requests:
+     cpu:     10m
+     memory:  20Mi
+nodeSelector: {}
+#  efa: present
+tolerations: []
+# - key: aws.amazon.com/efa
+#   operator: Exists
+#   effect: NoSchedule
+additionalPodAnnotations: {}
+additionalPodLabels: {}
+nameOverride: ""
+fullnameOverride: ""
+imagePullSecrets: []


### PR DESCRIPTION
### Issue
N/A
<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
* Added the EFA helm chart from https://github.com/aws-samples/efa-device-plugin-helm 
* Added a `README.md` to the EFA helm chart
* Added a reference to the EFA helm chart in the root `README.md`

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
ran `make verify`

Results (only for EFA chart):
```
Validating chart aws-efa-k8s-device-plugin/ w/ helm v3
WARN - Set to ignore missing schemas
PASS - aws-efa-k8s-device-plugin/templates/daemonset.yaml contains a valid DaemonSet (release-name-aws-efa-k8s-device-plugin)
Validating chart aws-efa-k8s-device-plugin/ w/ helm v2
WARN - Set to ignore missing schemas
PASS - aws-efa-k8s-device-plugin/templates/daemonset.yaml contains a valid DaemonSet (release-name-aws-efa-k8s-device-plugin)

Linting chart aws-efa-k8s-device-plugin/ w/ helm v3
==> Linting /Volumes/workplace/eks-charts/stable/aws-efa-k8s-device-plugin/

1 chart(s) linted, 0 chart(s) failed
Linting chart aws-efa-k8s-device-plugin/ w/ helm v2
==> Linting /Volumes/workplace/eks-charts/stable/aws-efa-k8s-device-plugin/
Lint OK
```
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
