### PR TITLE
Update aws-vpc-cni and cni-metrics-helper charts for v1.16.0 release

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.15.5
-appVersion: "v1.15.5"
+version: 1.16.0
+appVersion: "v1.16.0"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -42,8 +42,13 @@ The following table lists the configurable parameters for this chart and their d
 | `env`                   | List of environment variables. See [here](https://github.com/aws/amazon-vpc-cni-k8s#cni-configuration-variables) for options | (see `values.yaml`) |
 | `enableWindowsIpam`     | Enable windows support for your cluster                 | `false`                             |
 | `enableNetworkPolicy`   | Enable Network Policy Controller and Agent for your cluster | `false`                         |
+| `enableWindowsPrefixDelegation` | Enable windows prefix delegation support for your cluster | `false`                   |
+| `warmWindowsPrefixTarget` | Warm prefix target value for Windows prefix delegation | `0`                                |
+| `warmWindowsIPTarget`   | Warm IP target value for Windows prefix delegation      | `1`                                 |
+| `minimumWindowsIPTarget`| Minimum IP target value for Windows prefix delegation   | `3`                                 |
+| `branchENICooldown`     | Number of seconds that branch ENIs remain in cooldown   | `60`                                |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.15.5`                           |
+| `image.tag`             | Image tag                                               | `v1.16.0`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -51,7 +56,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`      | Container pull policy                                   | `IfNotPresent`                      |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.15.5`                           |
+| `init.image.tag`        | Image tag                                               | `v1.16.0`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |

--- a/stable/aws-vpc-cni/templates/configmap.yaml
+++ b/stable/aws-vpc-cni/templates/configmap.yaml
@@ -19,3 +19,8 @@ metadata:
 data:
   enable-windows-ipam: {{ .Values.enableWindowsIpam | quote }}
   enable-network-policy-controller: {{ .Values.enableNetworkPolicy | quote }}
+  enable-windows-prefix-delegation: {{ .Values.enableWindowsPrefixDelegation | quote }}
+  warm-prefix-target: {{ .Values.warmWindowsPrefixTarget | quote }}
+  warm-ip-target: {{ .Values.warmWindowsIPTarget | quote }}
+  minimum-ip-target: {{ .Values.minimumWindowsIPTarget | quote }}
+  branch-eni-cooldown: {{ .Values.branchENICooldown | quote }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,7 +8,7 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.15.5
+    tag: v1.16.0
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
@@ -50,7 +50,7 @@ nodeAgent:
   resources: {}
 
 image:
-  tag: v1.15.5
+  tag: v1.16.0
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr
@@ -83,14 +83,24 @@ env:
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
-  VPC_CNI_VERSION: "v1.15.5"
+  VPC_CNI_VERSION: "v1.16.0"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release
 originalMatchLabels: false
 
-enableWindowsIpam: "false"
+# Settings for aws-vpc-cni ConfigMap
+# - Network Policy settings
 enableNetworkPolicy: "false"
+# - Windows settings
+enableWindowsIpam: "false"
+# - Windows Prefix Delegation settings
+enableWindowsPrefixDelegation: "false"
+warmWindowsPrefixTarget: 0
+warmWindowsIPTarget: 1
+minimumWindowsIPTarget: 3
+# - Security Groups for Pods settings
+branchENICooldown: 60
 
 cniConfig:
   enabled: false

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.15.5
-appVersion: v1.15.5
+version: 1.16.0
+appVersion: v1.16.0
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -47,10 +47,11 @@ The following table lists the configurable parameters for this chart and their d
 |------------------------------|---------------------------------------------------------------|--------------------|
 | fullnameOverride             | Override the fullname of the chart                            | cni-metrics-helper |
 | image.region                 | ECR repository region to use. Should match your cluster       | us-west-2          |
-| image.tag                    | Image tag                                                     | v1.15.5            |
+| image.tag                    | Image tag                                                     | v1.16.0            |
 | image.account                | ECR repository account number                                 | 602401143452       |
 | image.domain                 | ECR repository domain                                         | amazonaws.com      |
 | env.USE_CLOUDWATCH           | Whether to export CNI metrics to CloudWatch                   | true               |
+| env.USE_PROMETHEUS           | Whether to export CNI metrics to Prometheus                   | false              |
 | env.AWS_CLUSTER_ID           | ID of the cluster to use when exporting metrics to CloudWatch | default            |
 | env.AWS_VPC_K8S_CNI_LOGLEVEL | Log verbosity level (ie. FATAL, ERROR, WARN, INFO, DEBUG)     | INFO               |
 | env.METRIC_UPDATE_INTERVAL   | Interval at which to update CloudWatch metrics, in seconds.   |                    |
@@ -58,6 +59,9 @@ The following table lists the configurable parameters for this chart and their d
 | serviceAccount.name          | The name of the ServiceAccount to use                         | nil                |
 | serviceAccount.create        | Specifies whether a ServiceAccount should be created          | true               |
 | serviceAccount.annotations   | Specifies the annotations for ServiceAccount                  | {}                 |
+| revisionHistoryLimit         | The number of revisions to keep                               | 10                 |
+| podSecurityContext           | SecurityContext to set on the pod                             | {}                 |
+| containerSecurityContext     | SecurityContext to set on the container                       | {}                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/cni-metrics-helper/templates/deployment.yaml
+++ b/stable/cni-metrics-helper/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: cni-metrics-helper
 spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       k8s-app: cni-metrics-helper
@@ -23,6 +24,12 @@ spec:
 {{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
+{{- if .Values.containerSecurityContext }}
+        securityContext: {{ toYaml .Values.containerSecurityContext | nindent 10 }}
+{{- end }}
         name: cni-metrics-helper
         image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
       serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }}
+{{- if .Values.podSecurityContext }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
+{{- end }}

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.15.5
+  tag: v1.16.0
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image
@@ -12,6 +12,7 @@ image:
 
 env:
   USE_CLOUDWATCH: "true"
+  USE_PROMETHEUS: "false"
   AWS_CLUSTER_ID: ""
   AWS_VPC_K8S_CNI_LOGLEVEL: "INFO"
 
@@ -27,3 +28,9 @@ serviceAccount:
     # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  
 
 resources: {}
+
+revisionHistoryLimit: 10
+
+podSecurityContext: {}
+
+containerSecurityContext: {}


### PR DESCRIPTION
### Issue
N/A

### Description of changes
[aws-vpc-cni]
- updated VPC CNI image tags to v1.16.0
- added variables for Windows prefix delegation in `amazon-vpc-cni` ConfigMap
- added variable for branch ENI cooldown in `amazon-vpc-cni` ConfigMap

[cni-metrics-helper]
ref: https://github.com/aws/amazon-vpc-cni-k8s/pull/2670
- added variable for revision history limit
- added variable for pod security context
- added variable for container security context

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
Manually verified that charts can be applied and integration tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
