### PR TITLE
[aws-cloudwatch-metrics] fix: update `enhanced_container_insights` template from string to boolean

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.10
+version: 0.0.11
 appVersion: "1.300032.2b361"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
-            "enhanced_container_insights": "{{ .Values.enhancedContainerInsights.enabled }}",
+            "enhanced_container_insights": {{ .Values.enhancedContainerInsights.enabled }},
             "metrics_collection_interval": 60
           }
         },


### PR DESCRIPTION
### Issue

This value was being passed as a `true` string which was not been handled or considered in the CW Agent and was ultimately ignored. 

Related issue - https://github.com/aws/amazon-cloudwatch-agent/issues/1030

### Description of changes

Modified the template to not wrap the boolean as a string.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Updated ConfigMap generated by this helm to have `true` instead of `"true"`. Applied changes and rolled out new daemonset resulting in Enhanced Observability metrics being sent to CW.

```
2024/02/11 19:39:07 D! config connectors: {}
exporters:
    awsemf/containerinsights:
        ...
        enhanced_container_insights: true
        imds_retries: 1
        local_mode: false
        log_group_name: /aws/containerinsights/{ClusterName}/performance
        log_retention: 0
        log_stream_name: '{NodeName}'
        ....
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
