### PR TITLE
Add additional endpoint configuration for ServiceMonitor

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.7.1
+version: 1.7.2
 appVersion: v2.7.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
+++ b/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
@@ -32,4 +32,25 @@ spec:
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
+      {{- with .Values.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.bearerTokenFile }}
+      bearerTokenFile: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml .| nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end -}}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -369,6 +369,18 @@ serviceMonitor:
   interval: 1m
   # Namespace to create the service monitor in
   namespace:
+  # If set override the _Prometheus_ default scrape timeout.
+  scrapeTimeout:
+  # If set overrides the _Prometheus_ default scheme.
+  scheme:
+  # Configure the `ServiceMonitor` [TLS config](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig).
+  tlsConfig: {}
+  # Provide a bearer token file for the `ServiceMonitor`.
+  bearerTokenFile:
+  # [Relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before ingestion.
+  relabelings: []
+  # [Metric relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion.
+  metricRelabelings: []
 
 # clusterSecretsPermissions lets you configure RBAC permissions for secret resources
 # Access to secrets resource is required only if you use the OIDC feature, and instead of


### PR DESCRIPTION
### Issue

Added additional endpoint configuration for ServiceMonitor

### Description of changes

Added the following configuration options for ServiceMonitor:

```
  scrapeTimeout:
  # If set overrides the _Prometheus_ default scheme.
  scheme:
  # Configure the `ServiceMonitor` [TLS config](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig).
  tlsConfig: {}
  # Provide a bearer token file for the `ServiceMonitor`.
  bearerTokenFile:
  # [Relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before ingestion.
  relabelings: []
  # [Metric relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion.
  metricRelabelings: []
```

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Manually tested helm deployments with and without changes to values in serviceMonitor section. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
