### PR TITLE
Update deployment.yaml to use the fullname helper

### DIFF
--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ include "aws-load-balancer-controller.fullname" . }}
         args:
         - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
         {{- if .Values.ingressClass }}


### PR DESCRIPTION
### Issue

We use this as a subchart with an Alias so it throws errors like this 

```
Error: Deployment.apps "aws-load-balancer-controller" is invalid: spec.template.spec.containers[0].name: Invalid value: "awsLoadBalancerController": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

### Description of changes



### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Confirmed `helm install` works locally with our `alias` and `fullnameOverride` set

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
