### PR TITLE
Provide more customization options for the service mutator webhook

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 2.0.0-alpha.2
+version: 1.8.0
 appVersion: v2.7.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.7.2
+version: 2.0.0-alpha.2
 appVersion: v2.7.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -56,7 +56,7 @@ webhooks:
     resources:
     - pods
   sideEffects: None
-{{- if .Values.enableServiceMutatorWebhook }}
+{{- if or .Values.enableServiceMutatorWebhook .Values.serviceMutatorWebhook.enabled }}
 - clientConfig:
     {{ if not $.Values.enableCertManager -}}
     caBundle: {{ $tls.caCert }}
@@ -65,7 +65,7 @@ webhooks:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
       path: /mutate-v1-service
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.serviceMutatorWebhook.failurePolicy }}
   name: mservice.elbv2.k8s.aws
   admissionReviewVersions:
   - v1beta1
@@ -75,13 +75,21 @@ webhooks:
       operator: NotIn
       values:
       - {{ include "aws-load-balancer-controller.name" . }}
+    {{- if .Values.serviceMutatorWebhook.objectSelector.matchExpressions }}
+    {{- toYaml .Values.serviceMutatorWebhook.objectSelector.matchExpressions | nindent 4 }}
+    {{- end }}
+
+    {{- if .Values.serviceMutatorWebhook.objectSelector.matchLabels }}
+    matchLabels:
+    {{- toYaml .Values.serviceMutatorWebhook.objectSelector.matchLabels | nindent 6 }}
+    {{- end }}
   rules:
   - apiGroups:
     - ""
     apiVersions:
     - v1
     operations:
-    - CREATE
+    {{- toYaml .Values.serviceMutatorWebhook.operations | nindent 4 }}
     resources:
     - services
   sideEffects: None

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -56,7 +56,7 @@ webhooks:
     resources:
     - pods
   sideEffects: None
-{{- if or .Values.enableServiceMutatorWebhook .Values.serviceMutatorWebhook.enabled }}
+{{- if and .Values.enableServiceMutatorWebhook .Values.serviceMutatorWebhook.enabled }}
 - clientConfig:
     {{ if not $.Values.enableCertManager -}}
     caBundle: {{ $tls.caCert }}

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -330,3 +330,27 @@ clusterSecretsPermissions:
 # ingressClassConfig contains configurations specific to the ingress class
 ingressClassConfig:
   default: false
+
+# enableServiceMutatorWebhook allows you enable the webhook which makes this controller the default for all new services of type LoadBalancer
+# should deprecate this in favor of serviceMutatorWebhook.enabled
+enableServiceMutatorWebhook: true
+
+# serviceMutatorWebhook contains configurations specific to the service mutator webhook
+serviceMutatorWebhook:
+  # Specifies whether a service mutator webhook should be created
+  enabled: true
+  # whether or not to fail the service creation if the webhook fails
+  failurePolicy: Fail
+  # limit webhook to only mutate services matching the objectSelector
+  objectSelector:
+    matchExpressions: []
+    # - key: <key>
+    #   operator: <operator>
+    #   values:
+    #   - <value>
+    matchLabels: {}
+      # key: value
+  # which operations trigger the webhook
+  operations:
+    - CREATE
+    # - UPDATE

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -352,5 +352,5 @@ serviceMutatorWebhook:
       # key: value
   # which operations trigger the webhook
   operations:
-    - CREATE
-    # - UPDATE
+  - CREATE
+  # - UPDATE

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -406,7 +406,7 @@ serviceMutatorWebhook:
       # key: value
   # which operations trigger the webhook
   operations:
-    - CREATE
+  - CREATE
     # - UPDATE
 
 # serviceTargetENISGTags specifies AWS tags, in addition to the cluster tags, for finding the target ENI SG to which to add inbound rules from NLBs.

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -209,7 +209,7 @@ webhookTLS:
   cert:
   key:
 
-# array of namespace selectors for the webhook
+# array of namespace selectors for the pod mutator webhook
 webhookNamespaceSelectors:
 # - key: elbv2.k8s.aws/pod-readiness-gate-inject
 #   operator: In
@@ -350,7 +350,7 @@ controllerConfig:
   # NLBHealthCheckAdvancedConfig: true
   # ALBSingleSubnet: false
 
-certDiscovery: 
+certDiscovery:
   allowedCertificateAuthorityARNs: "" # empty means all CAs are in scope
 
 # objectSelector for webhook
@@ -388,6 +388,26 @@ ingressClassConfig:
 
 # enableServiceMutatorWebhook allows you enable the webhook which makes this controller the default for all new services of type LoadBalancer
 enableServiceMutatorWebhook: true
+
+# serviceMutatorWebhook contains configurations specific to the service mutator webhook
+serviceMutatorWebhook:
+  # Specifies whether a service mutator webhook should be created
+  enabled: true
+  # whether or not to fail the service creation if the webhook fails
+  failurePolicy: Fail
+  # limit webhook to only mutate services matching the objectSelector
+  objectSelector:
+    matchExpressions: []
+    # - key: <key>
+    #   operator: <operator>
+    #   values:
+    #   - <value>
+    matchLabels: {}
+      # key: value
+  # which operations trigger the webhook
+  operations:
+    - CREATE
+    # - UPDATE
 
 # serviceTargetENISGTags specifies AWS tags, in addition to the cluster tags, for finding the target ENI SG to which to add inbound rules from NLBs.
 serviceTargetENISGTags:


### PR DESCRIPTION
### Issue

- https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3641
- https://github.com/aws/eks-charts/issues/1063

### Description of changes

For https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3641, the webhook configuration needs to support at least `operations` customization, but being able to exclude certain services by a selector is important for https://github.com/aws/eks-charts/issues/1063.

This PR adds a new section for service mutator webhook configuration. Defaults are set to match the existing configuration, so that this change does not unexpectedly enable service mutation behavior from https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3641.

I've not updated the README, want to get feedback first.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

This change was tested with AWS LBC v2.7.2, and also with AWS LBC built from https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3641.

For testing, I had no `UPDATE` operation first, then I enabled it in the chart.

Tested by creating a Service via `kubectl apply`, updating it via `kubectl apply`, and then replacing it via `kubectl replace`. `kubectl replace` previously would fail with validation error due to attempt to modify `spec.loadBalancerClass`. No longer fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
