### PR TITLE
Update cloudwatch-metrics chart to allow env vars to passed in

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.11
+version: 0.0.12
 appVersion: "1.300032.2b361"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -25,6 +25,7 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `image.repository` | Image to deploy | `amazon/cloudwatch-agent` | ✔
 | `image.tag` | Image tag to deploy | `1.247345.36b249270`
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
+| `env` | Environment variables to be passed for the daemonset | {} |
 | `clusterName` | Name of your cluster | `cluster_name` | ✔
 | `enhancedContainerInsights` | EKS cluster with enhanced monitoring | `true` | 
 | `serviceAccount.create` | Whether a new service account should be created | `true` |

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -22,6 +22,10 @@ spec:
         {{- include "aws-cloudwatch-metrics.statsdConfig" . | nindent 8 -}}
         # Please don't change below envs
         env:
+        {{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
         - name: HOST_IP
           valueFrom:
             fieldRef:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -8,6 +8,8 @@ clusterName: cluster_name
 enhancedContainerInsights:
   enabled: true
 
+env: {}
+
 resources:
   limits:
     cpu: 200m


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

This adds the ability to pass in additional environment variables into the cloudwatch-agent daemonset. This is particuarly useful for using `RUN_WITH_IRSA`.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I ran this locally, testing different environment variables, bools, strings and numbers all seem to work as expected. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
