### PR TITLE
Add services to ClusterRole to fix RBAC issue

### DIFF
--- a/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "aws-cloudwatch-metrics.fullname" . }}
 rules:
 - apiGroups: [""]
-  resources: ["pods", "nodes", "endpoints"]
+  resources: ["pods", "nodes", "endpoints", "services"]
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]


### PR DESCRIPTION
### Issue

With the current ClusterRole, there is a permissions issue in the logs, when using the latest version of the cloudwatch-metrics image.

```
failed to list *v1.Service: services is forbidden: User "system:serviceaccount:kube-system:aws-cloudwatch-metrics" cannot list resource "services" in API group "" in the namespace "kube-system"
```

### Description of changes

Add `services` list/watch permissions to the ClusterRole.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
