### PR TITLE
Adds eks-pod-identity-agent chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ helm repo add eks https://aws.github.io/eks-charts
 ### EKS EFA Plugin
 * [aws-efa-k8s-device-plugin](stable/aws-efa-k8s-device-plugin): A helm chart for the [Elastic Fabric Adapter](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html) plugin, which automatically discovers and mounts EFA devices into pods that request them
 
+### EKS Pod Identity Agent
+* [eks-pod-identity-agent](stable/eks-pod-identity-agent/): A helm chart for the [EKS pod identity agent](https://github.com/aws/eks-pod-identity-agent/tree/main)
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/stable/eks-pod-identity-agent/Chart.yaml
+++ b/stable/eks-pod-identity-agent/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: eks-pod-identity-agent
+type: application
+version: 1.2.0
+appVersion: 0.1.6
+description: A Helm chart for eks-pod-identity-agent
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+
+
+home: https://github.com/aws/eks-pod-identity-agent
+sources:
+  - https://github.com/aws/eks-pod-identity-agent
+keywords:
+  - eks
+  - pod-identity
+

--- a/stable/eks-pod-identity-agent/README.md
+++ b/stable/eks-pod-identity-agent/README.md
@@ -1,0 +1,54 @@
+# EKS Pod Identity Agent
+
+This chart installs the [eks-pod-identity-agent](https://github.com/aws/eks-pod-identity-agent).
+
+This agent is required for EKS pods to get granular IAM permissions with EKS Pod Identity feature.
+
+## Prerequisites
+
+- Kubernetes v{?} running on AWS
+- Helm v3
+
+## Update below Env to your cluster and region in values.yaml
+
+* `EKS_CLUSTER_NAME` 
+* `AWS_REGION_NAME`
+
+## Installing the Chart
+
+First, add the EKS repository to Helm:
+
+```
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+To install the chart with the release name of `eks-pod-identity-agent` and default configuration:
+
+```
+helm install eks-pod-identity-agent --namespace kube-system eks/eks-pod-identity-agent
+```
+
+## Configuration
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter                 | Description                                             | Default                  |
+|---------------------------|---------------------------------------------------------|--------------------------|
+| `affinity`                | Map of node/pod affinities                              | (see `values.yaml`)      |
+| `agent.additionalArgs`    | Additional arguments to pass to the agent-container     | (see `values.yaml`)      |
+| `env`                     | List of environment variables.                          | (see `values.yaml`)      |
+| `fullnameOverride`        | Override the fullname of the chart                      | `eks-pod-identity-agent` |
+| `image.pullPolicy`        | Container pull policy                                   | `Always`                 |
+| `imagePullSecrets`        | Docker registry pull secret                             | `[]`                     |
+| `init.additionalArgs`     | Additional arguments to pass to the init-container      | (see `values.yaml`)      |
+| `init.create`             | Specifies whether init-container should be created      | `true`                   |
+| `nameOverride`            | Override the name of the chart                          | `eks-pod-identity-agent` |
+| `nodeSelector`            | Node labels for pod assignment                          | `{}`                     |
+| `podAnnotations`          | annotations to add to each pod                          | `{}`                     |
+| `priorityClassName`       | Name of the priorityClass                               | `system-node-critical`   |
+| `resources`               | Resources for containers in pod                         | `{}`                     |
+| `tolerations`             | Optional deployment tolerations                         | `all`                    |
+| `updateStrategy`          | Optional update strategy                                | `type: RollingUpdate`    |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file
+containing the values for the above parameters.

--- a/stable/eks-pod-identity-agent/templates/_helpers.tpl
+++ b/stable/eks-pod-identity-agent/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eks-pod-identity-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eks-pod-identity-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eks-pod-identity-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eks-pod-identity-agent.labels" -}}
+helm.sh/chart: {{ include "eks-pod-identity-agent.chart" . }}
+{{ include "eks-pod-identity-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eks-pod-identity-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eks-pod-identity-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The eks-pod-identity-agent image to use
+*/}}
+{{- define "eks-pod-identity-agent.image" -}}
+{{- if .Values.image.override }}
+{{- .Values.image.override }}
+{{- else }}
+{{- printf "%s/eks/eks-pod-identity-agent:%s" .Values.image.containerRegistry .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/stable/eks-pod-identity-agent/templates/daemonset.yaml
+++ b/stable/eks-pod-identity-agent/templates/daemonset.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "eks-pod-identity-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "eks-pod-identity-agent.labels" . | nindent 4 }}
+spec:
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "eks-pod-identity-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "eks-pod-identity-agent.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      priorityClassName: {{ .Values.priorityClassName }}
+      hostNetwork: true
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.init.create }}
+      initContainers:
+        - name: {{ .Chart.Name }}-init
+          image: {{ include "eks-pod-identity-agent.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{ .Values.init.command }}
+          {{- if .Values.init.additionalArgs }}
+          args:
+            {{- range $key, $value := .Values.init.additionalArgs }}
+            - {{ $key | quote }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          securityContext:
+            privileged: true
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "eks-pod-identity-agent.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{ .Values.agent.command }}
+          args:
+            - "--port"
+            - "80"
+            - "--cluster-name"
+            - {{ .Values.clusterName | quote }}
+            - "--probe-port"
+            - {{ .Values.agent.probePort | quote }}
+            {{- range $key, $value := .Values.agent.additionalArgs }}
+            - {{ $key | quote }}
+            - {{ $value | quote }}
+            {{- end }}
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: proxy
+            - containerPort: {{ .Values.agent.probePort }}
+              protocol: TCP
+              name: probes-port
+          env:
+          {{- range $key, $value := .Values.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          securityContext:
+            capabilities:
+              add:
+                - CAP_NET_BIND_SERVICE
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.agent.livenessEndpoint }}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              host: localhost
+              path: {{ .Values.agent.livenessEndpoint }}
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          {{- end }}
+          {{- if .Values.agent.readinessEndpoint }}
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              host: localhost
+              path: {{ .Values.agent.readinessEndpoint }}
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+          {{- end }}

--- a/stable/eks-pod-identity-agent/values.yaml
+++ b/stable/eks-pod-identity-agent/values.yaml
@@ -1,0 +1,82 @@
+# Default values for eks-pod-identity-agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "kubernetes.io/os"
+              operator: In
+              values:
+                - linux
+            - key: "kubernetes.io/arch"
+              operator: In
+              values:
+                - amd64
+                - arm64
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+                - fargate
+
+agent:
+  additionalArgs:
+  command: "['/go-runner', '/eks-pod-identity-agent', 'server']"
+  livenessEndpoint: /healthz
+  probePort: 2703
+  readinessEndpoint: /readyz
+
+clusterName: EKS_CLUSTER_NAME
+
+env:
+  AWS_REGION: AWS_REGION_NAME
+
+fullnameOverride: "eks-pod-identity-agent"
+
+image:
+  containerRegistry: "602401143452.dkr.ecr.us-west-2.amazonaws.com"
+  pullPolicy: Always
+  region: us-west-2
+  tag: 0.1.10
+
+  # Set to use custom image
+  # override: "repo/org/image:tag"
+  override:
+
+imagePullSecrets: []
+
+init:
+  additionalArgs:
+  command: "['/go-runner', '/eks-pod-identity-agent', 'initialize']"
+  # Specifies whether initContainer should be created
+  create: true
+
+nameOverride: "eks-pod-identity-agent"
+
+nodeSelector: {}
+
+podAnnotations: {}
+
+priorityClassName: system-node-critical
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+tolerations:
+  - operator: Exists
+
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: "10%"


### PR DESCRIPTION
### Issue

N/A -- but related issue [here](https://github.com/aws/eks-pod-identity-agent/issues/11).

### Description of changes

This PR adds a Helm chart for the [eks-pod-identity-agent](https://github.com/aws/eks-pod-identity-agent).

The eks-pod-identity-agent repo currently contains a [Helm chart](https://github.com/aws/eks-pod-identity-agent/tree/main/charts/eks-pod-identity-agent) that is not published to any repository.  This PR simply copies that Helm chart into this repo so that we get CI which publishes the chart to aws.github.io/charts.

I opened an issue in the eks-charts repo [here](https://github.com/aws/eks-pod-identity-agent/issues/11).  

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [X] Make sure the title of the PR is a good description that can go into the release notes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
