### PR TITLE
Add revisionHistoryLimit support to aws-for-fluent-bit values

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.33
+version: 0.1.34
 appVersion: 2.32.2.20240425
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -208,6 +208,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `env`| Optional List of pod environment variables for the pods |`[]`|
 | `livenessProbe`| Optional yaml to define liveness probe - In order for liveness probe to work correctly defaults have been set in `service.extraService`, [details](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit) |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
 | `readinessProbe`| Optional yaml to define readiness probe |`{}`|
+| `revisionHistoryLimit`| Number of revisions to keep | 10 |
 | `serviceMonitor.enabled`| Whether serviceMonitor should be enabled or not, [details](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |`false`| ✔ |`[]`|
 | `serviceMonitor.service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer, ExternalName - [details](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |`ClusterIP`|
 | `serviceMonitor.service.port`| Incoming TCP port of the kubernetes service - Traffic is routed from this port to the targetPort to gain access to the application -  By default and for convenience, the targetPort is set to the same value as the port field. [details](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) | 2020 |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -283,6 +283,8 @@ resources:
     cpu: 50m
     memory: 50Mi
 
+revisionHistoryLimit: 10
+
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: system-node-critical
 


### PR DESCRIPTION
### Issue

Lack of support for `revisionHistoryLimit` in `aws-for-fluent-bit` chart values / `DaemonSet` leads to potentially unnecessary / annoying clutter of revision sets.

### Description of changes

Adds `revisionHistoryLimit` support in `aws-for-fluent-bit` with defaults set to K8s default, following the [lead in `aws-load-balancer-controller`](https://github.com/search?q=repo%3Aaws%2Feks-charts+revisionHistoryLimit+path%3A%2F%5Estable%5C%2Faws-load-balancer-controller%5C%2F%2F&type=code).


### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

`helm template` validation

[x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
