### PR TITLE
aws-for-fluent-bit: bump chart version to 0.1.34

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.33
+version: 0.1.34
 appVersion: 2.32.2.20240516
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
### Issue

Bump the chart version to fix the CI checking issue for aws-for-fluent-bit. Example: https://github.com/aws/eks-charts/actions/runs/9586473814/job/26434522860

### Description of changes

aws-for-fluent-bit: bump chart version to 0.1.34

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
