### PR TITLE
Enabling metrics via service-monitor for vpc-cni

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.18.2
+version: 1.18.3
 appVersion: "v1.18.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -99,6 +99,8 @@ The following table lists the configurable parameters for this chart and their d
 | `readinessProbe`        | Readiness probe settings for daemonset                  | (see `values.yaml`)                 |
 | `tolerations`           | Optional deployment tolerations                         | `[{"operator": "Exists"}]`          |
 | `updateStrategy`        | Optional update strategy                                | `type: RollingUpdate`               |
+| `serviceMonitor.enabled`   | Optional service monitor                                  | `false`               |
+| `serviceAnnotations`   | Optional labels for service                                 | `{}`                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/aws-vpc-cni/templates/service.yaml
+++ b/stable/aws-vpc-cni/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aws-vpc-cni.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+spec:
+  ports:
+    - port: 61678
+      name: metrics
+      targetPort: metrics
+  selector:
+    k8s-app: aws-node
+{{- end }}

--- a/stable/aws-vpc-cni/templates/servicemonitor.yaml
+++ b/stable/aws-vpc-cni/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if.Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "aws-vpc-cni.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  labels:
+{{ include "aws-vpc-cni.labels" . | indent 4 }}
+  {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: app.kubernetes.io/instance
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{ include "aws-vpc-cni.labels" . | indent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+    {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout  }}
+      scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end -}}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -210,3 +210,22 @@ eniConfig:
     #   id: subnet-789
     #   securityGroups:
     #   - sg-789
+
+serviceAnnotations: {}
+
+serviceMonitor:
+  # Specifies whether a service monitor should be created
+  enabled: true
+  # Namespace to create the service monitor in
+  namespace:
+  # Labels to add to the service monitor
+  additionalLabels:
+    release: prom-op
+  # Prometheus scrape interval
+  interval: 1m
+  # Prometheus scrape timeout
+  scrapeTimeout:
+  # Relabelings to apply to samples before ingestion
+  relabelings:
+  # Metric relabelings to apply to samples before ingestion
+  metricRelabelings:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -215,12 +215,11 @@ serviceAnnotations: {}
 
 serviceMonitor:
   # Specifies whether a service monitor should be created
-  enabled: true
+  enabled: false
   # Namespace to create the service monitor in
   namespace:
   # Labels to add to the service monitor
-  additionalLabels:
-    release: prom-op
+  additionalLabels: {}
   # Prometheus scrape interval
   interval: 1m
   # Prometheus scrape timeout


### PR DESCRIPTION
### Description of changes

Right now this chart doesn't provide a default service monitor and service for metrics. This PR will enable default service and service monitors for users.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I ran helm template command and also installed this chart on my kubernetes cluster to test this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
