### PR TITLE
 Add P5en to list of EFA supported instances

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.5
+version: v0.5.6
 appVersion: "v0.5.4"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -54,6 +54,10 @@ spec:
                   values:
                     {{- toYaml $.Values.supportedInstanceLabels.values | nindent 20 }}
               {{- end }}
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                  - auto
       hostNetwork: true
       containers:
         - image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -118,6 +118,7 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - p4de.24xlarge
     - p5.48xlarge
     - p5e.48xlarge
+    - p5en.48xlarge
     - trn1.32xlarge
     - trn1n.32xlarge
     - vt1.24xlarge


### PR DESCRIPTION
### Issue
Adding new instance type

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes
Add new instance type, P5en, to list of EFA supported instances and add anti-affinity for unsupported compute type
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
