### PR TITLE
Add trn2.48xlarge to list of EFA supported instances

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.6
+version: v0.5.7
 appVersion: "v0.5.4"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -121,6 +121,7 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - p5en.48xlarge
     - trn1.32xlarge
     - trn1n.32xlarge
+    - trn2.48xlarge
     - vt1.24xlarge
     - hpc6a.48xlarge
     - hpc6id.32xlarge


### PR DESCRIPTION
### Description of changes

Add trn2.48xlarge to list of EFA supported instances, bump chart version.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
