### PR TITLE
aws-load-balancer-controller: v2.10.1

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.10.0
-appVersion: v2.10.0
+version: 1.10.1
+appVersion: v2.10.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.10.0
+  tag: v2.10.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.10.0
+  tag: v2.10.1
   pullPolicy: IfNotPresent
 
 runtimeClassName: ""


### PR DESCRIPTION
## v2.10.1 (requires Kubernetes 1.22+)

##  [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.10/)

Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.10.1
Thanks to all our contributors! 😊

## What's new
* Supports HTTP and HTTPS listener attributes on load balancers.
  * Application Load Balancer (ALB) now supports HTTP request and response header modification giving you greater controls to manage your application’s traffic and security posture without having to alter your application code. For more information checkout [what’s new post](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-application-load-balancer-header-modification-enhanced-traffic-control-security/) and the [ALB document](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/header-modification.html).

## Enhancement and Fixes
* Use pod target namespace to get pod info from repo when resolving endpoint.
* Remove sort by ID so that EIP allocations and subnet ID order is respected.
* [Doc] fixed documentation styling for Support UDP-based services over IPv6.
* Publish internal controller metrics, such as target register time.
* Trim control characters from OIDC secret

## Changelog since v2.10.0
* enable http and https listener attributes ([#3948](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3948), @wweiwei-li)
* FEAT: LBC metric collector ([#3941](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3941), @zac-nixon)
* fix: use pod target namespace to get pod info from repo when resolving endpoint ([#3914](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3914), @Revolution1)
* [BUG FIX] trim control characters from secret to prevent newlines in client secret [(#3936](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3936), @zac-nixon)
* Fix: order must match specified subnets ([#3925](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3925), @wweiwei-li)
* fixed documentation styling for Support UDP-based services over IPv6 ([#3928](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3928), @shethyogita83)

**Full Changelog**: https://github.com/kubernetes-sigs/aws-load-balancer-controller/compare/v2.10.0...v2.10.1
