### PR TITLE
Add extraOutputs support for kinesis_streams plugin ConfigMap

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.34
+version: 0.1.35
 appVersion: 2.32.2.20240516
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -109,6 +109,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `kinesis_streams.log_key` | By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to Kinesis. | |
 | `kinesis_streams.auto_retry_requests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to `true`. | |
 | `kinesis_streams.external_id` | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requries an external ID. | |
+| `kinesis_streams.extraOutputs` | Append extra outputs with value | `""` |
 | `kinesis.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) | `false` | ✔
 | `kinesis.match` | The log filter | `"*"` | ✔
 | `kinesis.region` | The region which your Kinesis Data Stream is in. | `"us-east-1"` | ✔

--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -269,6 +269,9 @@ data:
         {{- if .Values.kinesis_streams.log_key }}
         log_key         {{ .Values.kinesis_streams.log_key }}
         {{- end }}
+        {{- if .Values.kinesis_streams.extraOutputs }}
+{{ .Values.kinesis_streams.extraOutputs | indent 8 }}
+        {{- end }}
 {{- end }}
 
 {{- if .Values.elasticsearch.enabled }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -181,6 +181,8 @@ kinesis_streams:
   external_id:
   auto_retry_requests:
   log_key: 
+  # extraOutputs: |
+  #   ...
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
### Description of changes
- Added support for extraOutputs in the kinesis_streams plugin output within the ConfigMap template.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
I deployed the chart with the following config overrides for kinesis_streams:
```
kinesis_streams:
  enabled: true
  match: "*"
  region: eu-west-1
  stream: my-kinesis-stream
  extraOutputs: |
    Retry_Limit     False
```

- This correctly appended `"Retry_Limit False"` to the `[OUTPUT]` section in the generated ConfigMap.
- I verified that Fluent Bit recognized the new setting and that unlimited retries worked as expected.

  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
