### PR TITLE
aws-for-fluent-bit: allow extraParsers to override default parsers

### DIFF
--- a/stable/aws-for-fluent-bit/templates/configmap.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap.yaml
@@ -11,11 +11,11 @@ data:
 {{- if .Values.service.extraService }}
 {{ .Values.service.extraService | indent 8 }}
 {{- end }}
-{{- range .Values.service.parsersFiles }}
-        Parsers_File {{ . }}
-{{- end }}
 {{- if .Values.service.extraParsers }}
         Parsers_File /fluent-bit/etc/parser_extra.conf
+{{- end }}
+{{- range .Values.service.parsersFiles }}
+        Parsers_File {{ . }}
 {{- end }}
 
 {{- if .Values.input.enabled }}


### PR DESCRIPTION
### Issue

When a parser defined in `extraParsers` has the same name as one of the default parsers, it will be ignored with the following message:

```console
[2025/02/08 05:00:54] [error] [parser] parser named 'json' already exists, skip.
```

### Description of changes

After changing the order of the `Parsers_File` directives, `extraParsers` will take precedence over the default parsers in cases where there is a naming collisions.

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Create a parser named e.g. `json` with a time format other than the default one, and put it into `values.yaml` 

```yaml
service:
  extraParsers: |
    [PARSER]
      Name        json
      Format      json
      Time_Key    time
      Time_Format %Y-%m-%dT%H:%M:%S.%L
      Time_Keep   On
```

Run `fluent-bit` and check that it can parse log lines with the specified time format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
