### PR TITLE
[aws-lbc] Do not render `.spec.replicas` if HPA is enabled 

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.11.0
+version: 1.11.1
 appVersion: v2.11.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -10,7 +10,9 @@ metadata:
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:
+  {{ if not .Values.autoscaling.enabled}}
   replicas: {{ .Values.replicaCount }}
+  {{ end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:
-  {{ if not .Values.autoscaling.enabled}}
+  {{ if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{ end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}


### PR DESCRIPTION
### Issue

The current chart template will render `.spec.replicas` even if Autoscaling is enabled. This causes a conflict in ownership of the `.spec.replicas` field between the HPA and whoever is installing/reconciling the manifests. 

The effect of this depends on the tool used to install the manifests:

1. Helm CLI -> the `.spec.replicas` is reset to the `.replicaCount` value everytime Helm Install/Update is invoked. 
2. AgroCD (or any GitOps tool) -> `.spec.replicas` is reset on each Sync... which can result into a constant back and forth between ArgoCD and the HPA that technically eliminate the benefits of the HPA. 


### Description of changes

Do not render `.spec.replicas` if Autoscaling is Enabled.

### Checklist
- [x ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Checking the Helm Diff between main and this branch. Validate that `.spec.replicas` is no rendered when Autoscaling is enabled, and is still rendered when Autoscaling is disabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
