### PR TITLE
Removing tailing spaces

### DIFF
--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -35,10 +35,10 @@ service:
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
     HTTP_PORT    2020
-    Health_Check On 
-    HC_Errors_Count 5 
-    HC_Retry_Failure_Count 5 
-    HC_Period 5 
+    Health_Check On
+    HC_Errors_Count 5
+    HC_Retry_Failure_Count 5
+    HC_Period 5
 
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf


### PR DESCRIPTION
Removing tailing spaces that cause `kubectl edit` to display the string in a messy way

### Issue

None

### Description of changes

Removed tailing spaces to allow `kubectl edit` and similar operations to display the string properly in editors.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
