### PR TITLE
🥳 aws-load-balancer-controller v2.13.1 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.13.0
-appVersion: v2.13.0
+version: 1.13.1
+appVersion: v2.13.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.13.0
+  tag: v2.13.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.13.0
+  tag: v2.13.1
   pullPolicy: IfNotPresent
 
 runtimeClassName: ""


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.13.1 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.13.1 (requires Kubernetes 1.22+)

##  [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.13/)

Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.13.1
Thanks to all our contributors! 😊

This release fixes the v2.13.0 release that contained a bug that erroneously published reconcile error metrics 