### PR TITLE
efa: disable service account token auto mount

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.10
+version: v0.5.11
 appVersion: "v0.5.6"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: false
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists


### PR DESCRIPTION
### Description of changes

Update helm chart for eva-k8s-device-plugin to not automount the service-account token since it is not used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
