### PR TITLE
Add nodeSelector, tolerations and affinity support for pod assignment in AWS SIGv4 Admission Controller

### DIFF
--- a/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-sigv4-proxy-admission-controller
 description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-sigv4-proxy-admission-controller/README.md
+++ b/stable/aws-sigv4-proxy-admission-controller/README.md
@@ -40,3 +40,6 @@ helm uninstall aws-sigv4-proxy-admission-controller --namespace <namespace>
 | `rbac.create` | Whether to create rbac resources or not | `true`
 | `webhookService.port` | Incoming port used by webhook service | `443`
 | `webhookService.targetPort` | Target port used by webhook service | `443`
+| `nodeSelector` | Node labels for pod assignment | `{}`
+| `tolerations` | Tolerations for pod assignment | `[]`
+| `affinity` | Affinity for pod assignment | `{}`

--- a/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
@@ -37,3 +37,15 @@ spec:
         - name: webhook-certs
           secret:
             secretName: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-certs
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/aws-sigv4-proxy-admission-controller/values.yaml
+++ b/stable/aws-sigv4-proxy-admission-controller/values.yaml
@@ -33,3 +33,12 @@ webhookService:
   port: 443
   # webhookService.targetPort: Target port used by webhook service
   targetPort: 443
+
+# nodeSelector: Node labels for pod assignment
+nodeSelector: {}
+
+# tolerations: Tolerations for pod assignment
+tolerations: []
+
+# affinity: Affinity for pod assignment
+affinity: {}


### PR DESCRIPTION
### Issue

[Support of tolerations and node selectors in aws-sigv4-proxy-admission-controller/ #1229](https://github.com/aws/eks-charts/issues/1229)

### Description of changes

This PR adds nodeSelector, tolerations and affinity support for pod assignment in AWS SIGv4 Admission Controller

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Was able to install HELM chart with properly passed nodeSelector, tolerations and affinity parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
