### PR TITLE
chore: update efa supported instance types for gb200

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.13
+version: v0.5.14
 appVersion: "v0.5.8"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -152,6 +152,7 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - p5e.48xlarge
     - p5en.48xlarge
     - p6-b200.48xlarge
+    - p6e-gb200.36xlarge
     - trn1.32xlarge
     - trn1n.32xlarge
     - trn2.48xlarge


### PR DESCRIPTION
### Issue

Adding `p6e-gb200.36xlarge` to the supported instance type list for UltraServer support of GB200

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
