### PR TITLE
[Draft] EFA daemonset changes for Neuron instances

### DIFF
--- a/scripts/validate-charts.sh
+++ b/scripts/validate-charts.sh
@@ -15,6 +15,17 @@ for d in */; do
     if [ -f ${STABLE}/${d}/ci/extra_args ]; then
         EXTRA_ARGS=$(cat ${STABLE}/${d}/ci/extra_args)
     fi
+    
+    # Efa device plugin specific validation: check for duplicate instances in both lists
+    if [ "${d}" = "aws-efa-k8s-device-plugin/" ]; then
+        echo "Running aws-efa-k8s-device-plugin validation for ${d}"
+        if [ -f ${STABLE}/${d}/scripts/validate-instance-lists.sh ]; then
+            cd ${STABLE}/${d}
+            bash scripts/validate-instance-lists.sh || FAILED+=("${d} (instance-lists)")
+            cd ${STABLE}
+        fi
+    fi
+    
     echo "Validating chart ${d} w/ helm"
     helm template ${STABLE}/${d} ${EXTRA_ARGS}| kubeval --strict --ignore-missing-schemas || FAILED+=("${d}")
 done

--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.14
-appVersion: "v0.5.8"
+version: v0.5.15
+appVersion: "v0.5.9"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -23,8 +23,10 @@ Parameter | Description | Default
 --- | --- | ---
 `image.repository` | EFA image repository | `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin`
 `image.tag` | EFA image tag | `v0.5.8`
-`securityContext.allowPrivilegeEscalation` | Controls whether a process can gain more privilege than its parent process | `false`
-`securityContext` | EFA plugin security context | `capabilities: drop: ["ALL"] runAsNonRoot: false`
+`securityContext` | EFA plugin security context for standard instances | `allowPrivilegeEscalation: false capabilities.drop: ["ALL"] runAsNonRoot: false`
+`privilegedSecurityContext` | EFA plugin security context for privileged instances | `allowPrivilegeEscalation: true privileged: true runAsNonRoot: false runAsUser: 0`
+`privilegedSupportedInstanceLabels.keys` | Kubernetes key to interpret as privileged instance type | `node.kubernetes.io/instance-type`
+`privilegedSupportedInstanceLabels.values` | List of EFA supported instances which require privileged security context | `["inf1.24xlarge", "trn1.32xlarge", "trn1n.32xlarge", "trn2.48xlarge", "trn2u.48xlarge"]`
 `supportedInstanceLabels.keys` | Kubernetes key to interpret as instance type | `nodes.kubernetes.io/instance-type`
 `supportedInstanceLabels.values` | List of instances which currently support EFA devices | `see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types`
 `resources` | Resources for containers in pod | `requests.cpu: 10m requests.memory: 20Mi`

--- a/stable/aws-efa-k8s-device-plugin/scripts/validate-instance-lists.sh
+++ b/stable/aws-efa-k8s-device-plugin/scripts/validate-instance-lists.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# Validate that no instance appears in both supportedInstanceLabels and privilegedSupportedInstanceLabels
+
+CHART_DIR="$(dirname "$0")/.."
+VALUES_FILE="$CHART_DIR/values.yaml"
+
+if [ ! -f "$VALUES_FILE" ]; then
+    echo "ERROR: values.yaml not found at $VALUES_FILE"
+    exit 1
+fi
+
+# Extract instance lists using yq
+STANDARD_INSTANCES=$(yq '.supportedInstanceLabels.values[]' "$VALUES_FILE" 2>/dev/null || echo "")
+PRIVILEGED_INSTANCES=$(yq '.privilegedSupportedInstanceLabels.values[]' "$VALUES_FILE" 2>/dev/null || echo "")
+
+if [ -z "$STANDARD_INSTANCES" ] && [ -z "$PRIVILEGED_INSTANCES" ]; then
+    echo "WARNING: Could not extract instance lists. Ensure yq is installed."
+    exit 0
+fi
+
+# Check for duplicates
+DUPLICATES=""
+for instance in $PRIVILEGED_INSTANCES; do
+    if echo "$STANDARD_INSTANCES" | grep -q "^$instance$"; then
+        DUPLICATES="$DUPLICATES $instance"
+    fi
+done
+
+if [ -n "$DUPLICATES" ]; then
+    echo "ERROR: The following instances appear in both supportedInstanceLabels and privilegedSupportedInstanceLabels:"
+    for dup in $DUPLICATES; do
+        echo "  - $dup"
+    done
+    echo ""
+    echo "Each instance should appear in exactly one list to prevent dual DaemonSets."
+    exit 1
+fi
+
+echo "✅ Validation passed: No instances appear in both lists"
+exit 0

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset-privileged.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset-privileged.yaml
@@ -1,13 +1,14 @@
+{{- if .Values.privilegedSupportedInstanceLabels.values }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "aws-efa-k8s-device-plugin.fullname" . }}
+  name: {{ include "aws-efa-k8s-device-plugin.fullname" . }}-privileged
   labels:
     {{- include "aws-efa-k8s-device-plugin.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      name:  {{ include "aws-efa-k8s-device-plugin.fullname" . }}
+      name: {{ include "aws-efa-k8s-device-plugin.fullname" . }}
   updateStrategy:
     type: RollingUpdate
   template:
@@ -48,12 +49,12 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              {{- range .Values.supportedInstanceLabels.keys }}
+              {{- range .Values.privilegedSupportedInstanceLabels.keys }}
               - matchExpressions:
                 - key: {{ . }}
                   operator: In
                   values:
-                    {{- toYaml $.Values.supportedInstanceLabels.values | nindent 20 }}
+                    {{- toYaml $.Values.privilegedSupportedInstanceLabels.values | nindent 20 }}
               {{- end }}
                 - key: eks.amazonaws.com/compute-type
                   operator: NotIn
@@ -64,7 +65,7 @@ spec:
         - image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           name: aws-efa-k8s-device-plugin
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.privilegedSecurityContext | nindent 12 }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -74,6 +75,8 @@ spec:
               name: device-plugin
             - mountPath: /dev/infiniband/
               name: infiniband-volume
+            - mountPath: /opt/aws/neuron/
+              name: neuron-tools
       volumes:
         - hostPath:
             path: /var/lib/kubelet/device-plugins
@@ -83,3 +86,8 @@ spec:
             path: /dev/infiniband/
             type: ""
           name: infiniband-volume
+        - hostPath:
+            path: /opt/aws/neuron
+            type: DirectoryOrCreate
+          name: neuron-tools
+{{- end }}

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -1,12 +1,29 @@
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.5.8"
+  tag: "v0.5.9-rc1"
+# Security context for standard EFA instances
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
   runAsNonRoot: false
+# Security context for privileged instances (inf/trn)
+privilegedSecurityContext:
+  allowPrivilegeEscalation: true
+  privileged: true
+  runAsNonRoot: false
+  runAsUser: 0
+# EFA supported instances that require privileged security context. Tjis list should only include neuron instances(inf/trn)
+privilegedSupportedInstanceLabels:
+  keys:
+    - "node.kubernetes.io/instance-type"
+  values:
+    - inf1.24xlarge
+    - trn1.32xlarge
+    - trn1n.32xlarge
+    - trn2.48xlarge
+    - trn2u.48xlarge
 supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
   keys:
     - "node.kubernetes.io/instance-type"
@@ -144,7 +161,6 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - g6e.24xlarge
     - g6e.48xlarge
     - gr6.8xlarge
-    - inf1.24xlarge
     - p3dn.24xlarge
     - p4d.24xlarge
     - p4de.24xlarge
@@ -153,10 +169,6 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - p5en.48xlarge
     - p6-b200.48xlarge
     - p6e-gb200.36xlarge
-    - trn1.32xlarge
-    - trn1n.32xlarge
-    - trn2.48xlarge
-    - trn2u.48xlarge
     - vt1.24xlarge
     - hpc6a.48xlarge
     - hpc6id.32xlarge


### PR DESCRIPTION
### Issue
Update daemonset config changes required for neuron instances

### Description of changes
1. Dual DaemonSet Architecture
* Split into two DaemonSets: regular and privileged
* Regular DaemonSet: targets standard EFA instances with restricted security context
* Privileged DaemonSet: targets inf/trn instances with privileged security context
* Mutually exclusive node targeting ensures no conflicts

2. Security Context Differentiation
* Added privilegedSecurityContext in values.yaml for neuron instances
* privileged: true, allowPrivilegeEscalation: true, runAsUser: 0
* Existing securityContext unchanged for backward compatibility

3. Instance Type Lists
* Added privilegedSupportedInstanceLabels for neuron instances (inf1.24xlarge, trn1.32xlarge, etc.)
* Existing supportedInstanceLabels excludes privileged instances
* Lists are mutually exclusive by design

4. Neuron-Specific Volume Mounts
* Added /opt/aws/neuron/ volume mount only to privileged DaemonSet
* Required for neuron tooling access on inf/trn instances

Backward compatible 

### Testing
Will update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
