### PR TITLE
Update efa device plugin daemonset config

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.15
-appVersion: "v0.5.8"
+version: v0.5.16
+appVersion: "v0.5.9"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -1,5 +1,5 @@
 # AWS EFA Kubernetes Device Plugin
-This chart installs the AWS EFA Kubernetes Device Plugin daemonset
+This chart installs the AWS EFA Kubernetes Device Plugin daemonset with privileged security context for EFA device management and neuron instance support.
 
 ## Prerequisites
 - Helm v3
@@ -23,8 +23,7 @@ Parameter | Description | Default
 --- | --- | ---
 `image.repository` | EFA image repository | `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin`
 `image.tag` | EFA image tag | `v0.5.8`
-`securityContext.allowPrivilegeEscalation` | Controls whether a process can gain more privilege than its parent process | `false`
-`securityContext` | EFA plugin security context | `capabilities: drop: ["ALL"] runAsNonRoot: false`
+`securityContext` | EFA plugin security context | `allowPrivilegeEscalation: true, privileged: true, runAsNonRoot: false, runAsUser: 0`
 `supportedInstanceLabels.keys` | Kubernetes key to interpret as instance type | `nodes.kubernetes.io/instance-type`
 `supportedInstanceLabels.values` | List of instances which currently support EFA devices | `see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types`
 `resources` | Resources for containers in pod | `requests.cpu: 10m requests.memory: 20Mi`

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -1,5 +1,5 @@
 # AWS EFA Kubernetes Device Plugin
-This chart installs the AWS EFA Kubernetes Device Plugin daemonset with privileged security context for EFA device management and neuron instance support.
+This chart installs the AWS EFA Kubernetes Device Plugin daemonset
 
 ## Prerequisites
 - Helm v3

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -74,6 +74,8 @@ spec:
               mountPath: /var/lib/kubelet/device-plugins
             - name: infiniband-volume
               mountPath: /dev/infiniband/
+            - name: neuron-tools
+              mountPath: /opt/aws/neuron/
       volumes:
         - name: device-plugin
           hostPath:
@@ -81,3 +83,7 @@ spec:
         - name: infiniband-volume
           hostPath:
             path: /dev/infiniband/
+        - name: neuron-tools
+          hostPath:
+            path: /opt/aws/neuron/
+            type: DirectoryOrCreate

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.5.8"
+  tag: "v0.5.9"
 securityContext:
   allowPrivilegeEscalation: true
   privileged: true

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -3,10 +3,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v0.5.8"
 securityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop: ["ALL"]
+  allowPrivilegeEscalation: true
+  privileged: true
   runAsNonRoot: false
+  runAsUser: 0
 supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
   keys:
     - "node.kubernetes.io/instance-type"


### PR DESCRIPTION
### Issue
We have added a new feature support to allocate EFA based on neuron-efa topology alignment. For this efa device plugin needs to access neuron devices info which required privilege access. 

### Description of changes
Security context and volume mounts were updated for efa device plugin

### Testing
Tested installing helm chart on the efa clusters
p5 instance 
```
EfaDeviceTopology initialized successfully with 8 GPUs and 32 EFAs
```
trn instance
```
EfaDeviceTopology initialized successfully with 16 Neurons and 8 EFAs
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
