### PR TITLE
efa: enable UpdateStrategy to be customizable through helm values

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.16
+version: v0.5.17
 appVersion: "v0.5.9"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -34,4 +34,5 @@ Parameter | Description | Default
 `nameOverride` | Override the name of the chart | `""`
 `fullnameOverride` | Override the full name of the chart | `""`
 `imagePullSecrets` | Docker registry pull secret | `[]`
+`updateStrategy` | Update strategy for deployment set | `type: RollingUpdate`
 

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -34,5 +34,5 @@ Parameter | Description | Default
 `nameOverride` | Override the name of the chart | `""`
 `fullnameOverride` | Override the full name of the chart | `""`
 `imagePullSecrets` | Docker registry pull secret | `[]`
-`updateStrategy` | Update strategy for deployment set | `type: RollingUpdate`
+`updateStrategy` | Update strategy for daemon set | `type: RollingUpdate`
 

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -8,8 +8,10 @@ spec:
   selector:
     matchLabels:
       name:  {{ include "aws-efa-k8s-device-plugin.fullname" . }}
+  {{- with .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- if .Values.additionalPodAnnotations }}

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -182,6 +182,8 @@ resources:
      memory:  20Mi
 nodeSelector: {}
 #  efa: present
+updateStrategy:
+  type: RollingUpdate
 tolerations: []
 # - key: aws.amazon.com/efa
 #   operator: Exists


### PR DESCRIPTION
### Description of changes

This commit enables `UpdateStrategy` for `efa-aws-efa-k8s-device-plugin` daemonset to be updated, through helm values. This helps users to set custom update strategy (eg: maxUnavailable, maxSurge etc.) for deployment

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

- Installed the chart from local, and verified that pods come up
- Updated chart to new release, and verified helm goes through

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
