### PR TITLE
[aws-cloudwatch-metrics] fix: grant permission to scrape api server metrics - Failed to scrape Prometheus endpoint

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.11
+version: 0.0.12
 appVersion: "1.300032.2b361"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
@@ -22,3 +22,5 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["cwagent-clusterleader"]
   verbs: ["get","update"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]


### PR DESCRIPTION
### Issue

https://github.com/aws/eks-charts/issues/1098 - Failed to scrape Prometheus endpoint

The CloudWatch agent fails to scrape metrics from the control plane, resulting in logs with `Failed to scrape Prometheus endpoint` and a `401` Unauthorized error.

```json
{
    "caller": "internal/transaction.go:123",
    "msg": "Failed to scrape Prometheus endpoint",
    "kind": "receiver",
    "name": "awscontainerinsightreceiver",
    "data_type": "metrics",
    "scrape_timestamp": 1760551208877,
    "target_labels": "{ClusterName=\"eks-clustername\", NodeName=\"<ip-redacted>.<region-redacted>.compute.internal\", Sources=\"[\\\"apiserver\\\"]\", Type=\"ControlPlane\", Version=\"0\", __name__=\"up\", instance=\"172.20.0.1:443\", job=\"containerInsightsKubeAPIServerScraper/172.20.0.1\"}"
}
```

### Description of changes

It appears the existing `ClusterRole` for the agent's service account lacks the permission to access this non-resource URL.

This change resolves the issue by adding a new rule to the ClusterRole, granting the `get` verb for the nonResourceURLs path `/metrics`. This permission allows the agent to successfully authenticate and scrape the control plane's Prometheus metrics.

See [Metrics For Kubernetes System Components](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/#metrics-in-kubernetes):

> "If your cluster uses [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), reading metrics requires authorization via a user, group or ServiceAccount with a ClusterRole that allows accessing /metrics. For example:"
> ```yaml
> apiVersion: rbac.authorization.k8s.io/v1
> kind: ClusterRole
> metadata:
>   name: prometheus
> rules:
>   - nonResourceURLs:
>       - "/metrics"
>     verbs:
>       - get
> ```

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I have duplicated the error mentioned above using the latest `0.0.11` version of this chart and have adjusted the existing cluster role to include the updated permission and verified I no longer see the error repeated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
