### PR TITLE
🥳 aws-load-balancer-controller v2.14.1 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.14.0
-appVersion: v2.14.0
+version: 1.14.1
+appVersion: v2.14.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/crds/aga-crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/aga-crds.yaml
@@ -1,0 +1,414 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: globalaccelerators.aga.k8s.aws
+spec:
+  group: aga.k8s.aws
+  names:
+    kind: GlobalAccelerator
+    listKind: GlobalAcceleratorList
+    plural: globalaccelerators
+    singular: globalaccelerator
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Global Accelerator name
+      jsonPath: .spec.name
+      name: NAME
+      type: string
+    - description: The Global Accelerator DNS name
+      jsonPath: .status.dnsName
+      name: DNS-NAME
+      type: string
+    - description: The Global Accelerator type
+      jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - description: The Global Accelerator status
+      jsonPath: .status.status
+      name: STATUS
+      type: string
+    - description: The Global Accelerator ARN
+      jsonPath: .status.acceleratorARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GlobalAccelerator is the Schema for the GlobalAccelerator API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalAcceleratorSpec defines the desired state of GlobalAccelerator
+            properties:
+              ipAddressType:
+                default: IPV4
+                description: IPAddressType is the value for the address type.
+                enum:
+                - IPV4
+                - DUAL_STACK
+                type: string
+              ipAddresses:
+                description: |-
+                  IpAddresses optionally specifies the IP addresses from your own IP address pool (BYOIP) to use for the accelerator's static IP addresses.
+                  You can specify one or two addresses. Do not include the /32 suffix.
+                  If you bring your own IP address pool to Global Accelerator (BYOIP), you can choose an IPv4 address from your own pool to use for the accelerator's static IPv4 address.
+                  After you bring an address range to AWS, it appears in your account as an address pool. When you create an accelerator, you can assign one IPv4 address from your range to it.
+                  Global Accelerator assigns you a second static IPv4 address from an Amazon IP address range. If you bring two IPv4 address ranges to AWS, you can assign one IPv4 address from each range to your accelerator.
+                  Note that you can't update IP addresses for an existing accelerator. To change them, you must create a new accelerator with the new addresses.
+                  For more information, see Bring your own IP addresses (BYOIP) in the AWS Global Accelerator Developer Guide.
+                  https://docs.aws.amazon.com/global-accelerator/latest/dg/using-byoip.html
+                items:
+                  type: string
+                maxItems: 2
+                minItems: 1
+                type: array
+              listeners:
+                description: Listeners defines the listeners for the Global Accelerator.
+                items:
+                  description: GlobalAcceleratorListener defines a listener for the
+                    Global Accelerator.
+                  properties:
+                    clientAffinity:
+                      default: NONE
+                      description: |-
+                        ClientAffinity lets you direct all requests from a user to the same endpoint, if you have stateful applications, regardless of the port and protocol of the client request.
+                        Client affinity gives you control over whether to always route each client to the same specific endpoint.
+                        AWS Global Accelerator uses a consistent-flow hashing algorithm to choose the optimal endpoint for a connection.
+                        If client affinity is NONE, Global Accelerator uses the "five-tuple" (5-tuple) properties—source IP address, source port, destination IP address, destination port, and protocol—to select the hash value, and then chooses the best endpoint.
+                        However, with this setting, if someone uses different ports to connect to Global Accelerator, their connections might not be always routed to the same endpoint because the hash value changes.
+                        If you want a given client to always be routed to the same endpoint, set client affinity to SOURCE_IP instead.
+                        When you use the SOURCE_IP setting, Global Accelerator uses the "two-tuple" (2-tuple) properties— source (client) IP address and destination IP address—to select the hash value.
+                        The default value is NONE.
+                      enum:
+                      - SOURCE_IP
+                      - NONE
+                      type: string
+                    endpointGroups:
+                      description: EndpointGroups defines a list of endpoint groups
+                        for a Global Accelerator listener.
+                      items:
+                        description: GlobalAcceleratorEndpointGroup defines an endpoint
+                          group for a Global Accelerator listener.
+                        properties:
+                          endpoints:
+                            description: Endpoints is the list of endpoint configurations
+                              for this endpoint group.
+                            items:
+                              description: GlobalAcceleratorEndpoint defines an endpoint
+                                for a Global Accelerator endpoint group.
+                              properties:
+                                clientIPPreservationEnabled:
+                                  default: true
+                                  description: |-
+                                    ClientIPPreservationEnabled indicates whether client IP address preservation is enabled for an Application Load Balancer endpoint.
+                                    The value is true or false. The default value is true for new accelerators.
+                                    If the value is set to true, the client's IP address is preserved in the X-Forwarded-For request header as traffic travels to applications on the Application Load Balancer endpoint fronted by the accelerator.
+                                    For more information, see Preserve Client IP Addresses in the AWS Global Accelerator Developer Guide:
+                                    https://docs.aws.amazon.com/global-accelerator/latest/dg/preserve-client-ip-address.html
+                                  type: boolean
+                                endpointID:
+                                  description: |-
+                                    EndpointID is the ID of the endpoint when type is EndpointID.
+                                    If the endpoint is a Network Load Balancer or Application Load Balancer, this is the Amazon Resource Name (ARN) of the resource.
+                                    A resource must be valid and active when you add it as an endpoint.
+                                    Mandatory for remote regions.
+                                  maxLength: 255
+                                  type: string
+                                name:
+                                  description: Name is the name of the Kubernetes
+                                    resource when type is Service, Ingress, or Gateway.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the Kubernetes resource when type is Service, Ingress, or Gateway.
+                                    If not specified, defaults to the same namespace as the GlobalAccelerator resource.
+                                  type: string
+                                type:
+                                  description: Type specifies the type of endpoint
+                                    reference.
+                                  enum:
+                                  - EndpointID
+                                  - Service
+                                  - Ingress
+                                  - Gateway
+                                  type: string
+                                weight:
+                                  default: 128
+                                  description: |-
+                                    Weight is the weight associated with the endpoint. When you add weights to endpoints, you configure Global Accelerator to route traffic based on proportions that you specify.
+                                    For example, you might specify endpoint weights of 4, 5, 5, and 6 (sum=20). The result is that 4/20 of your traffic, on average, is routed to the first endpoint,
+                                    5/20 is routed both to the second and third endpoints, and 6/20 is routed to the last endpoint.
+                                    For more information, see Endpoint Weights in the AWS Global Accelerator Developer Guide:
+                                    https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoints-endpoint-weights.html
+                                  format: int32
+                                  maximum: 255
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: endpointID is required and name must not
+                                  be set when type is EndpointID
+                                rule: self.type != 'EndpointID' || (has(self.endpointID)
+                                  && !has(self.name))
+                              - message: name is required and endpointID must not
+                                  be set when type is Service/Ingress/Gateway
+                                rule: self.type == 'EndpointID' || (has(self.name)
+                                  && !has(self.endpointID))
+                            type: array
+                          portOverrides:
+                            description: PortOverrides is a list of endpoint port
+                              overrides. Allows you to override the destination ports
+                              used to route traffic to an endpoint. Using a port override
+                              lets you map a list of external destination ports (that
+                              your users send traffic to) to a list of internal destination
+                              ports that you want an application endpoint to receive
+                              traffic on.
+                            items:
+                              description: |-
+                                PortOverride defines a port override for an endpoint group.
+                                Override specific listener ports used to route traffic to endpoints that are part of an endpoint group.
+                                For example, you can create a port override in which the listener receives user traffic on ports 80 and 443,
+                                but your accelerator routes that traffic to ports 1080 and 1443, respectively, on the endpoints.
+
+
+                                For more information, see Port overrides in the AWS Global Accelerator Developer Guide:
+                                https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-port-override.html
+                              properties:
+                                endpointPort:
+                                  description: |-
+                                    EndpointPort is the endpoint port that you want traffic to be routed to.
+                                    This is the port on the endpoint, such as the Application Load Balancer or Amazon EC2 instance.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                listenerPort:
+                                  description: |-
+                                    ListenerPort is the listener port that you want to map to a specific endpoint port.
+                                    This is the port that user traffic arrives to the Global Accelerator on.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - endpointPort
+                              - listenerPort
+                              type: object
+                            type: array
+                          region:
+                            description: |-
+                              Region is the AWS Region where the endpoint group is located.
+                              If unspecified, defaults to the current cluster region.
+                            maxLength: 255
+                            type: string
+                          trafficDialPercentage:
+                            default: 100
+                            description: |-
+                              TrafficDialPercentage is the percentage of traffic to send to an AWS Regions. Additional traffic is distributed to other endpoint groups for this listener
+                              Use this action to increase (dial up) or decrease (dial down) traffic to a specific Region. The percentage is applied to the traffic that would otherwise have been routed to the Region based on optimal routing.
+                            format: int32
+                            maximum: 100
+                            minimum: 0
+                            type: integer
+                        type: object
+                      type: array
+                    portRanges:
+                      description: |-
+                        PortRanges is the list of port ranges for the connections from clients to the accelerator.
+                        When not specified, the controller will automatically determine the port ranges by inspecting
+                        the referenced Kubernetes resources (Service, Ingress, or Gateway) in the endpoint groups.
+                      items:
+                        description: PortRange defines the port range for Global Accelerator
+                          listeners.
+                        properties:
+                          fromPort:
+                            description: FromPort is the first port in the range of
+                              ports, inclusive.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          toPort:
+                            description: ToPort is the last port in the range of ports,
+                              inclusive.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - fromPort
+                        - toPort
+                        type: object
+                      maxItems: 10
+                      minItems: 1
+                      type: array
+                    protocol:
+                      description: |-
+                        Protocol is the protocol for the connections from clients to the accelerator.
+                        When not specified, the controller will automatically determine the protocol by inspecting
+                        the referenced Kubernetes resources (Service, Ingress, or Gateway) in the endpoint groups.
+                      enum:
+                      - TCP
+                      - UDP
+                      type: string
+                  type: object
+                type: array
+              name:
+                description: |-
+                  Name is the name of the Global Accelerator.
+                  The name must contain only alphanumeric characters or hyphens (-), and must not begin or end with a hyphen.
+                maxLength: 64
+                minLength: 1
+                pattern: ^[a-zA-Z0-9_-]{1,64}$
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                description: Tags defines list of Tags on the Global Accelerator.
+                type: object
+            type: object
+          status:
+            description: GlobalAcceleratorStatus defines the observed state of GlobalAccelerator
+            properties:
+              acceleratorARN:
+                description: AcceleratorARN is the Amazon Resource Name (ARN) of the
+                  accelerator.
+                type: string
+              conditions:
+                description: Conditions represent the current conditions of the GlobalAccelerator.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              dnsName:
+                description: DNSName The Domain Name System (DNS) name that Global
+                  Accelerator creates that points to an accelerator's static IPv4
+                  addresses.
+                type: string
+              dualStackDnsName:
+                description: 'DualStackDnsName is the Domain Name System (DNS) name
+                  that Global Accelerator creates that points to a dual-stack accelerator''s
+                  four static IP addresses: two IPv4 addresses and two IPv6 addresses.'
+                type: string
+              ipSets:
+                description: IPSets is the static IP addresses that Global Accelerator
+                  associates with the accelerator.
+                items:
+                  description: IPSet is the static IP addresses that Global Accelerator
+                    associates with the accelerator.
+                  properties:
+                    ipAddressFamily:
+                      description: IpAddressFamily is the types of IP addresses included
+                        in this IP set.
+                      type: string
+                    ipAddresses:
+                      description: IpAddresses is the array of IP addresses in the
+                        IP address set.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the GlobalAccelerator controller.
+                format: int64
+                type: integer
+              status:
+                description: Status is the current status of the accelerator.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/stable/aws-load-balancer-controller/templates/rbac.yaml
+++ b/stable/aws-load-balancer-controller/templates/rbac.yaml
@@ -119,6 +119,15 @@ rules:
 - apiGroups: ["gateway.networking.k8s.io"]
   resources: [grpcroutes/status, httproutes/status, tcproutes/status, tlsroutes/status, udproutes/status]
   verbs: [get, patch, update]
+- apiGroups: ["aga.k8s.aws"]
+  resources: [globalaccelerators]
+  verbs: [get, list, patch, watch]
+- apiGroups: ["aga.k8s.aws"]
+  resources: [globalaccelerators/finalizers]
+  verbs: [patch, update]
+- apiGroups: ["aga.k8s.aws"]
+  resources: [globalaccelerators/status]
+  verbs: [patch, update]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/aws-load-balancer-controller/templates/serviceaccount.yaml
+++ b/stable/aws-load-balancer-controller/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- with .Values.serviceAccount.imagePullSecrets }}

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.14.0
+  tag: v2.14.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.14.0
+  tag: v2.14.1
   pullPolicy: IfNotPresent
 
 runtimeClassName: ""
@@ -375,7 +375,9 @@ controllerConfig:
   # NLBHealthCheckAdvancedConfig: true
   # ALBSingleSubnet: false
   # LBCapacityReservation: true
+  # AGAController: true
   # EnhancedDefaultBehavior: false
+  # EnableDefaultTagsLowPriority: false
 
 certDiscovery:
   allowedCertificateAuthorityARNs: "" # empty means all CAs are in scope


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.14.1 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## 📚 Quick Links

## v2.14.1 (requires Kubernetes 1.22+) 

### Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.14.1
### [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)

### Thanks to all our contributors!💜💜💜
* * *

## What’s new

We’re excited to announce support for ALB URL Rewrite! You can use this new feature to transform request URLs using regex patterns (e.g., rewrite /api/v1/users to /users, or ^/api/v1/(.*)$ to /$1). Check out [the new use case in our documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/url_rewrite/) on how to configure your ingress resources to utilize this new capability. For more information about the feature, [please see the AWS launch announcement.](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-url-and-host-header-rewrite-with-aws-application-load-balancers/)

Enhancement and Fixes

* Introduced ALB URL Rewrite support! ( Too many feature request issues to link here ;) )
* Fixed ListenerAttribute string parsing to allow for multiple values. (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4363)
* Added ability to configure maximum targets per TargetGroupBinding (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4360)
* Fixed ListenerRule comparison check that incorrectly marks rules as drifted.
* New Gateway Route & Listener Statuses
* Fixed WAF name retrieval (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4388)
* Added support for EKS Hybrid nodes (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4315)
* Added low priority tag additions (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4030)
* Fixed edge case that prevented Listener modifications if rule limit has been exceeded (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4373)
* Updated docs for NLB healthchecks (https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3419)

## What's Changed
* feat: Add flag to limit the max number of targets added to an ELB by @mmiller-sh in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4361
* support comma in string pars value by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4375
* fix e2e tests by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4379
* feat(helm): support templating in service account annotations by @samuelmasuy in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4374
* fix sorting when comparing listener rule differences by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4382
* [feat gw-api]update gateway status based on observation generation by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4383
* test: replace AWS SDK v1 imports with v2 by @Juneezee in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4364
* fix waf name resolution by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4390
* [feat: aga] add AWS Global Accelerator CRD with comprehensive validation by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4389
* [feat: aga] add basic framework for AGA controller by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4392
* feat: add EKS Hybrid Nodes support by @sanbyk in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4336
* Implement support for URL and Host Header Rewrite for Application Load Balancer by @andreybutenko in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4396
* feat: add feature toggle to allow controller default tags to be overridden by annotation supplied tags by @mwhittington21 in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4384
* Update annotations documentation to include support for named ports in NLB health check configuration by @igor-kupczynski in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4386
* re-enable tls tests with new certs by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4397
* fix bad merge conflict resolution by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4401
* [bug fix] handle rules exceeded error in listener rule synthesizer by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4393
* cut v2.14.1 release by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4402

## New Contributors
* @mmiller-sh made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4361
* @samuelmasuy made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4374
* @Juneezee made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4364
* @sanbyk made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4336
* @mwhittington21 made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4384
* @igor-kupczynski made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4386

**Full Changelog**: https://github.com/kubernetes-sigs/aws-load-balancer-controller/compare/v2.14.0...v2.14.1