### PR TITLE
Fix CRD installation path in aws-load-balancer-controller README

### DIFF
--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -79,7 +79,7 @@ If migrating from ALB ingress controller, grant [additional IAM permissions](htt
 - Additional IAM permissions required, ensure you have granted the [required IAM permissions](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json).
 - CRDs need to be updated as follows
 ```shell script
-kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+kubectl apply -k "github.com/aws/eks-charts//stable/aws-load-balancer-controller/crds?ref=master"
 ```
 - you can run helm upgrade without uninstalling the old chart completely
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
N/A

### Description of changes

<!-- Please explain the changes you made here. -->
Fixed incorrect kustomize path for CRD installation in the upgrade guide.
The double slashes should appear after the repository name, not within the path components.

**Before:**
```shell
kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
```

**After:**
```shell
kubectl apply -k "github.com/aws/eks-charts//stable/aws-load-balancer-controller/crds?ref=master"
```

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Verified the correct kustomize path structure by checking the repository layout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
