### PR TITLE
🥳 aws-load-balancer-controller v2.14.1 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/crds/aga-crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/aga-crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: globalaccelerators.aga.k8s.aws
 spec:
   group: aga.k8s.aws
@@ -196,7 +196,6 @@ spec:
                                 For example, you can create a port override in which the listener receives user traffic on ports 80 and 443,
                                 but your accelerator routes that traffic to ports 1080 and 1443, respectively, on the endpoints.
 
-
                                 For more information, see Port overrides in the AWS Global Accelerator Developer Guide:
                                 https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-port-override.html
                               properties:
@@ -303,16 +302,8 @@ spec:
               conditions:
                 description: Conditions represent the current conditions of the GlobalAccelerator.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -353,12 +344,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/stable/aws-load-balancer-controller/crds/crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressclassparams.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -301,7 +301,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws

--- a/stable/aws-load-balancer-controller/crds/gateway-crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/gateway-crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: listenerruleconfigurations.gateway.k8s.aws
 spec:
   group: gateway.k8s.aws
@@ -50,10 +50,8 @@ spec:
                   Actions defines the set of actions to be performed when conditions match.
                   This CRD implementation currently supports only  authenticate-oidc, authenticate-cognito, and fixed-response action types fully and forward and redirect actions partially
 
-
                   For other fields in forward and redirect actions, please use the standard Gateway API HTTPRoute or other route resources, which provide
                   native support for those conditions through the Gateway API specification.
-
 
                   At most one authentication action can be specified (either authenticate-oidc or authenticate-cognito).
                 items:
@@ -83,7 +81,6 @@ spec:
                           default: openid
                           description: |-
                             The set of user claims to be requested from the IdP. The default is openid .
-
 
                             To verify which scope values your IdP supports and how to separate multiple
                             values, see the documentation for your IdP.
@@ -154,7 +151,6 @@ spec:
                           default: openid
                           description: |-
                             The set of user claims to be requested from the IdP. The default is openid .
-
 
                             To verify which scope values your IdP supports and how to separate multiple
                             values, see the documentation for your IdP.
@@ -313,7 +309,6 @@ spec:
                   Conditions defines the circumstances under which the rule actions will be performed.
                   This CRD implementation currently supports only the source-ip condition type
 
-
                   For other condition types (such as path-pattern, host-header, http-header, etc.),
                   please use the standard Gateway API HTTPRoute or other route resources, which provide
                   native support for those conditions through the Gateway API specification.
@@ -402,7 +397,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: loadbalancerconfigurations.gateway.k8s.aws
 spec:
   group: gateway.k8s.aws
@@ -449,6 +444,12 @@ spec:
                   customerOwnedIpv4Pool [Application LoadBalancer]
                   is the ID of the customer-owned address for Application Load Balancers on Outposts pool.
                 type: string
+              disableSecurityGroup:
+                description: |-
+                  disableSecurityGroup provisions a load balancer with no security groups.
+                  Allows an NLB to be provisioned with no security groups.
+                  [Network Load Balancer]
+                type: boolean
               enableICMP:
                 description: |-
                   EnableICMP [Network LoadBalancer]
@@ -736,7 +737,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: targetgroupconfigurations.gateway.k8s.aws
 spec:
   group: gateway.k8s.aws
@@ -815,9 +816,9 @@ spec:
                           with the target. The GENEVE, TLS, UDP, and TCP_UDP protocols
                           are not supported for health checks.
                         enum:
-                        - http
-                        - https
-                        - tcp
+                        - HTTP
+                        - HTTPS
+                        - TCP
                         type: string
                       healthCheckTimeout:
                         description: healthCheckTimeout The amount of time, in seconds,
@@ -1008,9 +1009,9 @@ spec:
                                 and TCP_UDP protocols are not supported for health
                                 checks.
                               enum:
-                              - http
-                              - https
-                              - tcp
+                              - HTTP
+                              - HTTPS
+                              - TCP
                               type: string
                             healthCheckTimeout:
                               description: healthCheckTimeout The amount of time,
@@ -1173,7 +1174,6 @@ spec:
                     description: |-
                       Kind is the Kubernetes resource kind of the referent. For example
                       "Service".
-
 
                       Defaults to "Service" when not specified.
                     type: string

--- a/stable/aws-load-balancer-controller/templates/cert-manager.yaml
+++ b/stable/aws-load-balancer-controller/templates/cert-manager.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.enableCertManager (not .Values.certManager.issuerRef) -}}
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-cert
+  duration: {{ .Values.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  issuerRef:
+    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  commonName: "ca.webhook.aws-load-balancer-controller"
+  isCA: true
+  subject:
+    organizations:
+      - aws-load-balancer-controller
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-cert
+{{- end -}}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -12,9 +12,9 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 webhooks:
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -58,9 +58,9 @@ webhooks:
   sideEffects: None
 {{- if .Values.enableServiceMutatorWebhook }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -95,9 +95,9 @@ webhooks:
   sideEffects: None
 {{- end }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -130,9 +130,9 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 webhooks:
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -159,9 +159,9 @@ webhooks:
     - ingressclassparams
   sideEffects: None
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -183,9 +183,9 @@ webhooks:
   sideEffects: None
 {{- if not $.Values.webhookConfig.disableIngressValidation }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -222,6 +222,9 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
+{{- $secretName := (include "aws-load-balancer-controller.webhookCertSecret" .) -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not (and .Values.keepTLSSecret $secret) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -234,12 +237,16 @@ spec:
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster.dnsDomain }}
   issuerRef:
+    {{- if .Values.certManager.issuerRef }}
+    {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
+    {{- else }}
     kind: Issuer
-    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-issuer
+    {{- end }}
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
   {{- with .Values.certManager -}}
   {{ if .duration }}
-  duration: {{ .duration }}
+  duration: {{ .duration | default "8760h0m0s" | quote }}
   {{- end }}
   {{- if .renewBefore }}
   renewBefore: {{ .renewBefore }}
@@ -248,14 +255,5 @@ spec:
   revisionHistoryLimit: {{ .revisionHistoryLimit }}
   {{- end }}
   {{- end }}
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
-spec:
-  selfSigned: {}
+{{- end }}
 {{- end }}

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -117,9 +117,19 @@ enableCertManager: false
 
 # Overrideable variables when enableCertManager is set to true
 certManager:
-  duration:
-  renewBefore:
+  # Webhook serving certificate configuration
+  duration: "8760h0m0s"  # 1 year
+  renewBefore: "720h0m0s"  # 30 days
   revisionHistoryLimit:
+
+  # Root CA certificate configuration
+  rootCert:
+    duration: "43800h0m0s"  # 5 years
+
+  # Optional: custom issuer reference
+  # issuerRef:
+  #   name: my-issuer
+  #   kind: ClusterIssuer
 
 # The name of the Kubernetes cluster. A non-empty value is required
 clusterName:
@@ -375,7 +385,7 @@ controllerConfig:
   # NLBHealthCheckAdvancedConfig: true
   # ALBSingleSubnet: false
   # LBCapacityReservation: true
-  # AGAController: true
+  # AGAController: false
   # EnhancedDefaultBehavior: false
   # EnableDefaultTagsLowPriority: false
 


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.14.1 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## 📚 Quick Links

## v2.14.1 (requires Kubernetes 1.22+) 

### Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.14.1
### [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)

### Thanks to all our contributors!💜💜💜
* * *

## What’s new

We’re excited to announce support for ALB URL Rewrite! You can use this new feature to transform request URLs using regex patterns (e.g., rewrite /api/v1/users to /users, or ^/api/v1/(.*)$ to /$1). Check out [the new use case in our documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/url_rewrite/) on how to configure your ingress resources to utilize this new capability. For more information about the feature, [please see the AWS launch announcement.](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-url-and-host-header-rewrite-with-aws-application-load-balancers/)

Enhancement and Fixes

* Introduced ALB URL Rewrite support! ( Too many feature request issues to link here ;) )
* Fixed ListenerAttribute string parsing to allow for multiple values. (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4363)
* Added ability to configure maximum targets per TargetGroupBinding (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4360)
* Fixed ListenerRule comparison check that incorrectly marks rules as drifted.
* New Gateway Route & Listener Statuses
* Fixed WAF name retrieval (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4388)
* Added support for EKS Hybrid nodes (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4315)
* Added low priority tag additions (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4030)
* Fixed edge case that prevented Listener modifications if rule limit has been exceeded (https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4373)
* Updated docs for NLB healthchecks (https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3419)

## What's Changed
* feat: Add flag to limit the max number of targets added to an ELB by @mmiller-sh in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4361
* support comma in string pars value by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4375
* fix e2e tests by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4379
* feat(helm): support templating in service account annotations by @samuelmasuy in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4374
* fix sorting when comparing listener rule differences by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4382
* [feat gw-api]update gateway status based on observation generation by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4383
* test: replace AWS SDK v1 imports with v2 by @Juneezee in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4364
* fix waf name resolution by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4390
* [feat: aga] add AWS Global Accelerator CRD with comprehensive validation by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4389
* [feat: aga] add basic framework for AGA controller by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4392
* feat: add EKS Hybrid Nodes support by @sanbyk in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4336
* Implement support for URL and Host Header Rewrite for Application Load Balancer by @andreybutenko in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4396
* feat: add feature toggle to allow controller default tags to be overridden by annotation supplied tags by @mwhittington21 in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4384
* Update annotations documentation to include support for named ports in NLB health check configuration by @igor-kupczynski in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4386
* re-enable tls tests with new certs by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4397
* fix bad merge conflict resolution by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4401
* [bug fix] handle rules exceeded error in listener rule synthesizer by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4393
* cut v2.14.1 release by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4402

## New Contributors
* @mmiller-sh made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4361
* @samuelmasuy made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4374
* @Juneezee made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4364
* @sanbyk made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4336
* @mwhittington21 made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4384
* @igor-kupczynski made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4386

**Full Changelog**: https://github.com/kubernetes-sigs/aws-load-balancer-controller/compare/v2.14.0...v2.14.1