### PR TITLE
🥳 aws-load-balancer-controller v2.15.0 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.14.1
-appVersion: v2.14.1
+version: 1.15.0
+appVersion: v2.15.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/crds/aga-crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/aga-crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: globalaccelerators.aga.k8s.aws
 spec:
   group: aga.k8s.aws
@@ -196,7 +196,6 @@ spec:
                                 For example, you can create a port override in which the listener receives user traffic on ports 80 and 443,
                                 but your accelerator routes that traffic to ports 1080 and 1443, respectively, on the endpoints.
 
-
                                 For more information, see Port overrides in the AWS Global Accelerator Developer Guide:
                                 https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-port-override.html
                               properties:
@@ -303,16 +302,8 @@ spec:
               conditions:
                 description: Conditions represent the current conditions of the GlobalAccelerator.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -353,12 +344,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/stable/aws-load-balancer-controller/crds/crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressclassparams.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -301,7 +301,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -729,6 +729,8 @@ spec:
                 - TLS
                 - UDP
                 - TCP_UDP
+                - QUIC
+                - TCP_QUIC
                 type: string
               targetType:
                 description: targetType is the TargetType of TargetGroup. If unspecified,

--- a/stable/aws-load-balancer-controller/crds/gateway-crds.yaml
+++ b/stable/aws-load-balancer-controller/crds/gateway-crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: listenerruleconfigurations.gateway.k8s.aws
 spec:
   group: gateway.k8s.aws
@@ -50,10 +50,8 @@ spec:
                   Actions defines the set of actions to be performed when conditions match.
                   This CRD implementation currently supports only  authenticate-oidc, authenticate-cognito, and fixed-response action types fully and forward and redirect actions partially
 
-
                   For other fields in forward and redirect actions, please use the standard Gateway API HTTPRoute or other route resources, which provide
                   native support for those conditions through the Gateway API specification.
-
 
                   At most one authentication action can be specified (either authenticate-oidc or authenticate-cognito).
                 items:
@@ -83,7 +81,6 @@ spec:
                           default: openid
                           description: |-
                             The set of user claims to be requested from the IdP. The default is openid .
-
 
                             To verify which scope values your IdP supports and how to separate multiple
                             values, see the documentation for your IdP.
@@ -154,7 +151,6 @@ spec:
                           default: openid
                           description: |-
                             The set of user claims to be requested from the IdP. The default is openid .
-
 
                             To verify which scope values your IdP supports and how to separate multiple
                             values, see the documentation for your IdP.
@@ -313,7 +309,6 @@ spec:
                   Conditions defines the circumstances under which the rule actions will be performed.
                   This CRD implementation currently supports only the source-ip condition type
 
-
                   For other condition types (such as path-pattern, host-header, http-header, etc.),
                   please use the standard Gateway API HTTPRoute or other route resources, which provide
                   native support for those conditions through the Gateway API specification.
@@ -402,7 +397,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: loadbalancerconfigurations.gateway.k8s.aws
 spec:
   group: gateway.k8s.aws
@@ -449,6 +444,12 @@ spec:
                   customerOwnedIpv4Pool [Application LoadBalancer]
                   is the ID of the customer-owned address for Application Load Balancers on Outposts pool.
                 type: string
+              disableSecurityGroup:
+                description: |-
+                  disableSecurityGroup provisions a load balancer with no security groups.
+                  Allows an NLB to be provisioned with no security groups.
+                  [Network Load Balancer]
+                type: boolean
               enableICMP:
                 description: |-
                   EnableICMP [Network LoadBalancer]
@@ -736,7 +737,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: targetgroupconfigurations.gateway.k8s.aws
 spec:
   group: gateway.k8s.aws
@@ -815,9 +816,9 @@ spec:
                           with the target. The GENEVE, TLS, UDP, and TCP_UDP protocols
                           are not supported for health checks.
                         enum:
-                        - http
-                        - https
-                        - tcp
+                        - HTTP
+                        - HTTPS
+                        - TCP
                         type: string
                       healthCheckTimeout:
                         description: healthCheckTimeout The amount of time, in seconds,
@@ -1008,9 +1009,9 @@ spec:
                                 and TCP_UDP protocols are not supported for health
                                 checks.
                               enum:
-                              - http
-                              - https
-                              - tcp
+                              - HTTP
+                              - HTTPS
+                              - TCP
                               type: string
                             healthCheckTimeout:
                               description: healthCheckTimeout The amount of time,
@@ -1173,7 +1174,6 @@ spec:
                     description: |-
                       Kind is the Kubernetes resource kind of the referent. For example
                       "Service".
-
 
                       Defaults to "Service" when not specified.
                     type: string

--- a/stable/aws-load-balancer-controller/templates/cert-manager.yaml
+++ b/stable/aws-load-balancer-controller/templates/cert-manager.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.enableCertManager (not .Values.certManager.issuerRef) -}}
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-cert
+  duration: {{ .Values.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  issuerRef:
+    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+  commonName: "ca.webhook.aws-load-balancer-controller"
+  isCA: true
+  subject:
+    organizations:
+      - aws-load-balancer-controller
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-cert
+{{- end -}}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -12,9 +12,9 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 webhooks:
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -56,11 +56,56 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+- clientConfig:
+    {{- if not $.Values.enableCertManager }}
+    caBundle: {{ $tls.caCert }}
+    {{- end }}
+    service:
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
+      namespace: {{ $.Release.Namespace }}
+      path: /mutate-v1-pod-server-id
+  failurePolicy: Fail
+  name: quicid.elbv2.k8s.aws
+  admissionReviewVersions:
+    - v1beta1
+  namespaceSelector:
+    matchExpressions:
+    {{ if .Values.webhookNamespaceSelectors }}
+    {{ toYaml .Values.webhookNamespaceSelectors | nindent 4 }}
+    {{ else }}
+      - key: elbv2.k8s.aws/quic-server-id-inject
+        operator: In
+        values:
+          - enabled
+    {{ end }}
+  objectSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - {{ include "aws-load-balancer-controller.name" . }}
+    {{- if .Values.objectSelector.matchExpressions }}
+    {{- toYaml .Values.objectSelector.matchExpressions | nindent 4 }}
+    {{- end }}
+    {{- if .Values.objectSelector.matchLabels }}
+    matchLabels:
+    {{- toYaml .Values.objectSelector.matchLabels | nindent 6 }}
+    {{- end }}
+  rules:
+    - apiGroups:
+        - ""
+      apiVersions:
+        - v1
+      operations:
+        - CREATE
+      resources:
+        - pods
+  sideEffects: None
 {{- if .Values.enableServiceMutatorWebhook }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -95,9 +140,9 @@ webhooks:
   sideEffects: None
 {{- end }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -130,9 +175,9 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 webhooks:
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -159,9 +204,9 @@ webhooks:
     - ingressclassparams
   sideEffects: None
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -183,9 +228,9 @@ webhooks:
   sideEffects: None
 {{- if not $.Values.webhookConfig.disableIngressValidation }}
 - clientConfig:
-    {{ if not $.Values.enableCertManager -}}
+    {{- if not $.Values.enableCertManager }}
     caBundle: {{ $tls.caCert }}
-    {{ end }}
+    {{- end }}
     service:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
@@ -222,6 +267,9 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
+{{- $secretName := (include "aws-load-balancer-controller.webhookCertSecret" .) -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not (and .Values.keepTLSSecret $secret) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -234,12 +282,16 @@ spec:
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster.dnsDomain }}
   issuerRef:
+    {{- if .Values.certManager.issuerRef }}
+    {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
+    {{- else }}
     kind: Issuer
-    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
+    name: {{ template "aws-load-balancer-controller.namePrefix" . }}-root-issuer
+    {{- end }}
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
   {{- with .Values.certManager -}}
   {{ if .duration }}
-  duration: {{ .duration }}
+  duration: {{ .duration | default "8760h0m0s" | quote }}
   {{- end }}
   {{- if .renewBefore }}
   renewBefore: {{ .renewBefore }}
@@ -248,14 +300,5 @@ spec:
   revisionHistoryLimit: {{ .revisionHistoryLimit }}
   {{- end }}
   {{- end }}
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
-spec:
-  selfSigned: {}
+{{- end }}
 {{- end }}

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.14.1
+  tag: v2.15.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.14.1
+  tag: v2.15.0
   pullPolicy: IfNotPresent
 
 runtimeClassName: ""
@@ -117,9 +117,19 @@ enableCertManager: false
 
 # Overrideable variables when enableCertManager is set to true
 certManager:
-  duration:
-  renewBefore:
+  # Webhook serving certificate configuration
+  duration: "8760h0m0s"  # 1 year
+  renewBefore: "720h0m0s"  # 30 days
   revisionHistoryLimit:
+
+  # Root CA certificate configuration
+  rootCert:
+    duration: "43800h0m0s"  # 5 years
+
+  # Optional: custom issuer reference
+  # issuerRef:
+  #   name: my-issuer
+  #   kind: ClusterIssuer
 
 # The name of the Kubernetes cluster. A non-empty value is required
 clusterName:
@@ -375,7 +385,7 @@ controllerConfig:
   # NLBHealthCheckAdvancedConfig: true
   # ALBSingleSubnet: false
   # LBCapacityReservation: true
-  # AGAController: true
+  # AGAController: false
   # EnhancedDefaultBehavior: false
   # EnableDefaultTagsLowPriority: false
 


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.15.0 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## 📚 Quick Links

## v2.15.0 (requires Kubernetes 1.22+) 

### Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.15.0
### [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)

### Thanks to all our contributors!💜💜💜
* * *

## What’s new

We're excited to announce two new features!

- ALB has added the ability to configure JWT validation. See the what's new post for more information. https://aws.amazon.com/about-aws/whats-new/2025/11/application-load-balancer-jwt-verification. For more information, check out the new ingress annotation, `alb.ingress.kubernetes.io/jwt-validation`.
- NLB has added a new protocol, QUIC pass through. See the what's new post for more information. https://aws.amazon.com/about-aws/whats-new/2025/11/aws-network-load-balancer-quic-passthrough-mode. To see how to get started with QUIC and the load balancer controller, checkout the new use case: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.15/guide/use_cases/quic/

## What's Changed
* fix: Race condition in webhook certificate renewal with cert-manager self-signed issuer without a dedicated CA certificate by @praddy26 in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4359
* [feat: aga] add accelerator model builder by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4403
* [gw api] add disable security group flag to lb config for gateway users by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4404
* [gw api] discover certs for route hostnames by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4407
* [gw api] Support literal target group ARNs by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4406
* Fix EIP Allocations annotation in docs by @arcdigital in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4409
* [feat gw-api]return multiple types in listener status by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4411
* [gw api] Support SG rule generation for no SG LBs by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4413
* Add generic tag processing system for controllers by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4415
* update to go 1.24.9 by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4421
* [gw api] fix listener config generation when port is duplicated by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4419
* [feat gw-api]handle hostname intersection by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4417
* [feat gw-api]add conformance test setup by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4422
* Correct hostname by @wweiwei-li in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4425
* Add eusc iam policy by @wweiwei-li in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4426
* New use case "Legacy App Integration" by @dumlutimuralp in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4424
* Support URLRewrite in HTTPRoutes by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4418
* [gw api] Implement ALB target of NLB by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4430
* Correct enum for healthCheckProtocol field by @dex4er in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4432
* [feat aga] Disable AGAController as its in ready yet by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4435
* add shuqz in owner file by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4441
* update to use controller-gen v0.19.0 by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4444
* Add support for jwt validation action at the ingress level by @sarevalo2002 in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4445
* Add support QUIC Passthrough for NLB by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4448
* v2.15.0 release by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4449

## New Contributors
* @arcdigital made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4409
* @dumlutimuralp made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4424
* @dex4er made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4432

**Full Changelog**: https://github.com/kubernetes-sigs/aws-load-balancer-controller/compare/v2.14.1...v2.15.0