### PR TITLE
chore: add terminationGracePeriodSeconds parameter to aws-for-fluent-bit chart

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.35
+version: 0.1.36
 appVersion: 2.32.2.20240516
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -34,6 +34,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `podSecurityContext` | Security Context for pod | `{}` | 
 | `containerSecurityContext` | Security Context for container | `{}` | 
+| `terminationGracePeriodSeconds` | Time period for the pod to do a graceful shutdown | `0`
 | `rbac.pspEnabled` | Whether a pod security policy should be created | `false`
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -23,6 +23,9 @@ containerSecurityContext: {}
 #   drop:
 #   - ALL
 
+# Time period for the pod to do a graceful shutdown
+terminationGracePeriodSeconds: 0
+
 rbac:
   # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
   pspEnabled: false


### PR DESCRIPTION
### Issue

Fluent-bit pods do not have enough time to terminate gracefully, and therefore may lead to data loss.

### Description of changes

This PR is adding `terminationGracePeriodSeconds` to the aws-for-fluent-bit chart. This will allow to configure values to ensure that fluent-bit pods will have enough time to shut down gracefully.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Running `helm template .` with different values for `terminationGracePeriodSeconds` to verify correct YAML generation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
