### PR TITLE
 chore(efa-device-plugin): add latest EFA instance types 

### DIFF
--- a/.github/workflows/update-eks-chart.yaml
+++ b/.github/workflows/update-eks-chart.yaml
@@ -1,0 +1,51 @@
+name: Update EFA Device Plugin Instance Types
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 17 * * 1-5" # Every Mon-Friday at 09:00 PST
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-limits:
+    environment: efa-updater
+    if: github.repository == 'aws/eks-charts'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # refs/tags/v4.1.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # refs/tags/v4.0.2
+        with:
+          role-to-assume: ${{ secrets.UPDATE_CHARTS_AWS_ROLE_ARN }}
+          role-duration-seconds: 900
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Run ./hack/update-efa-instance-types.sh
+        run: |
+              YQ_VERSION=v4.2.0
+              YQ_PLATFORM=linux_amd64
+              wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_${YQ_PLATFORM} -O /usr/local/bin/yq &&\
+                chmod +x /usr/local/bin/yq
+
+              ./hack/update-efa-instance-types.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # refs/tags/v7.0.9
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(efa-device-plugin): add latest EFA instance types"
+          title: "chore(efa-device-plugin): add latest EFA instance types"
+          body: |
+            This PR updates adds the latest EFA supported instance types to the EFA device plugin chart by running `./hack/update-efa-instance-types.sh`.
+            
+            ## Testing
+            Please verify that the chart version is correctly bumped and no in-use instance types are removed.
+          branch: automated/update-efa-instance-types
+          base: master
+          delete-branch: true

--- a/hack/update-efa-instance-types.sh
+++ b/hack/update-efa-instance-types.sh
@@ -10,13 +10,12 @@ EFA_CHART_DIRECTORY="${PROJECT_ROOT}/stable/aws-efa-k8s-device-plugin"
 CHART_FILE="${EFA_CHART_DIRECTORY}/Chart.yaml"
 if git diff --quiet --exit-code -- "$CHART_FILE" || \
    ! git diff "$CHART_FILE" | grep -q '^[-+]version:'; then
-    # Increment a minor version if version hasn't already been incremented
-    yq -i '
-      .version |= (
-        . as $v
-        | ($v | sub("^v"; "") | split(".") | .[2] = ((.[2] | tonumber) + 1) | "v" + (join(".")))
-      )
-    ' "$CHART_FILE"
+    # Increment patch version if version hasn't already been incremented
+    VERSION=$(yq eval '.version' "$CHART_FILE")
+    BARE="${VERSION#v}"
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$BARE"
+    NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+    yq eval -i ".version = \"${NEW_VERSION}\"" "$CHART_FILE"
 else
     echo "Version already changed; skipping increment"
 fi
@@ -47,14 +46,8 @@ for REGION in "${REGIONS[@]}"; do
   ALL_TYPES+=("${TYPES[@]}")
 done
 
-# Deduplicate + sort + extract JSON
-export NEW_VALUES=$(printf "%s\n" "${ALL_TYPES[@]}" \
-  | sort -u \
-  | jq -R . \
-  | jq -s .)
+# Deduplicate + sort, then build a yq array expression
+YQ_ARRAY=$(printf '%s\n' "${ALL_TYPES[@]}" | sort -u | sed 's/.*/"&"/' | paste -sd, -)
 
-yq 'env(NEW_VALUES)' <<< '{}'
-
-yq -i '.supportedInstanceLabels.values = env(NEW_VALUES) 
-       | .supportedInstanceLabels.values style=""
-       | .supportedInstanceLabels.values[] style=""' "${EFA_CHART_DIRECTORY}/values.yaml"
+VALUES_FILE="${EFA_CHART_DIRECTORY}/values.yaml"
+yq eval -i ".supportedInstanceLabels.values = [${YQ_ARRAY}]" "$VALUES_FILE"

--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.22
+version: v0.5.23
 appVersion: "v0.5.16"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -18,29 +18,36 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - c6a.metal
     - c6gn.16xlarge
     - c6i.32xlarge
-    - c6i.metal
     - c6id.32xlarge
     - c6id.metal
+    - c6i.metal
     - c6in.32xlarge
     - c6in.metal
     - c7a.48xlarge
     - c7a.metal-48xl
     - c7g.16xlarge
-    - c7g.metal
     - c7gd.16xlarge
     - c7gd.metal
+    - c7g.metal
     - c7gn.16xlarge
     - c7gn.metal
     - c7i.48xlarge
     - c7i.metal-48xl
+    - c8a.48xlarge
+    - c8a.metal-48xl
     - c8g.24xlarge
     - c8g.48xlarge
-    - c8g.metal-24xl
-    - c8g.metal-48xl
+    - c8gb.16xlarge
+    - c8gb.24xlarge
+    - c8gb.48xlarge
+    - c8gb.metal-24xl
+    - c8gb.metal-48xl
     - c8gd.24xlarge
     - c8gd.48xlarge
     - c8gd.metal-24xl
     - c8gd.metal-48xl
+    - c8g.metal-24xl
+    - c8g.metal-48xl
     - c8gn.16xlarge
     - c8gn.24xlarge
     - c8gn.48xlarge
@@ -48,6 +55,10 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - c8gn.metal-48xl
     - c8i.48xlarge
     - c8i.96xlarge
+    - c8id.48xlarge
+    - c8id.96xlarge
+    - c8id.metal-48xl
+    - c8id.metal-96xl
     - c8i.metal-48xl
     - c8i.metal-96xl
     - dl1.24xlarge
@@ -72,6 +83,10 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - g6e.24xlarge
     - g6e.48xlarge
     - g6e.8xlarge
+    - g7e.12xlarge
+    - g7e.24xlarge
+    - g7e.48xlarge
+    - g7e.8xlarge
     - gr6.8xlarge
     - hpc6a.48xlarge
     - hpc6id.32xlarge
@@ -82,6 +97,7 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - hpc7g.16xlarge
     - hpc7g.4xlarge
     - hpc7g.8xlarge
+    - hpc8a.96xlarge
     - i3en.12xlarge
     - i3en.24xlarge
     - i3en.metal
@@ -90,12 +106,13 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - i4i.metal
     - i7i.24xlarge
     - i7i.48xlarge
-    - i7i.metal-48xl
     - i7ie.48xlarge
     - i7ie.metal-48xl
+    - i7i.metal-48xl
     - i8g.48xlarge
     - i8ge.48xlarge
     - i8ge.metal-48xl
+    - i8g.metal-48xl
     - im4gn.16xlarge
     - inf1.24xlarge
     - m5dn.24xlarge
@@ -107,33 +124,49 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - m6a.48xlarge
     - m6a.metal
     - m6i.32xlarge
-    - m6i.metal
     - m6id.32xlarge
     - m6id.metal
     - m6idn.32xlarge
     - m6idn.metal
+    - m6i.metal
     - m6in.32xlarge
     - m6in.metal
     - m7a.48xlarge
     - m7a.metal-48xl
     - m7g.16xlarge
-    - m7g.metal
     - m7gd.16xlarge
     - m7gd.metal
+    - m7g.metal
     - m7i.48xlarge
     - m7i.metal-48xl
     - m8a.48xlarge
     - m8a.metal-48xl
+    - m8azn.24xlarge
+    - m8azn.metal-24xl
     - m8g.24xlarge
     - m8g.48xlarge
-    - m8g.metal-24xl
-    - m8g.metal-48xl
+    - m8gb.16xlarge
+    - m8gb.24xlarge
+    - m8gb.48xlarge
+    - m8gb.metal-24xl
+    - m8gb.metal-48xl
     - m8gd.24xlarge
     - m8gd.48xlarge
     - m8gd.metal-24xl
     - m8gd.metal-48xl
+    - m8g.metal-24xl
+    - m8g.metal-48xl
+    - m8gn.16xlarge
+    - m8gn.24xlarge
+    - m8gn.48xlarge
+    - m8gn.metal-24xl
+    - m8gn.metal-48xl
     - m8i.48xlarge
     - m8i.96xlarge
+    - m8id.48xlarge
+    - m8id.96xlarge
+    - m8id.metal-48xl
+    - m8id.metal-96xl
     - m8i.metal-48xl
     - m8i.metal-96xl
     - p3dn.24xlarge
@@ -153,19 +186,19 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - r6a.48xlarge
     - r6a.metal
     - r6i.32xlarge
-    - r6i.metal
     - r6id.32xlarge
     - r6id.metal
     - r6idn.32xlarge
     - r6idn.metal
+    - r6i.metal
     - r6in.32xlarge
     - r6in.metal
     - r7a.48xlarge
     - r7a.metal-48xl
     - r7g.16xlarge
-    - r7g.metal
     - r7gd.16xlarge
     - r7gd.metal
+    - r7g.metal
     - r7i.48xlarge
     - r7i.metal-48xl
     - r7iz.32xlarge
@@ -174,15 +207,17 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - r8a.metal-48xl
     - r8g.24xlarge
     - r8g.48xlarge
-    - r8g.metal-24xl
-    - r8g.metal-48xl
     - r8gb.16xlarge
     - r8gb.24xlarge
+    - r8gb.48xlarge
     - r8gb.metal-24xl
+    - r8gb.metal-48xl
     - r8gd.24xlarge
     - r8gd.48xlarge
     - r8gd.metal-24xl
     - r8gd.metal-48xl
+    - r8g.metal-24xl
+    - r8g.metal-48xl
     - r8gn.16xlarge
     - r8gn.24xlarge
     - r8gn.48xlarge
@@ -190,15 +225,19 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - r8gn.metal-48xl
     - r8i.48xlarge
     - r8i.96xlarge
+    - r8id.48xlarge
+    - r8id.96xlarge
+    - r8id.metal-48xl
+    - r8id.metal-96xl
     - r8i.metal-48xl
     - r8i.metal-96xl
     - trn1.32xlarge
     - trn1n.32xlarge
-    - trn2-ac.24xlarge
     - trn2.3xlarge
     - trn2.48xlarge
-    - trn2u-ac.24xlarge
+    - trn2-ac.24xlarge
     - trn2u.48xlarge
+    - trn2u-ac.24xlarge
     - u7i-12tb.224xlarge
     - u7i-6tb.112xlarge
     - u7i-8tb.112xlarge
@@ -212,10 +251,17 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - x2iedn.metal
     - x2iezn.12xlarge
     - x2iezn.metal
+    - x8aedz.24xlarge
+    - x8aedz.metal-24xl
     - x8g.24xlarge
     - x8g.48xlarge
     - x8g.metal-24xl
     - x8g.metal-48xl
+    - x8i.48xlarge
+    - x8i.64xlarge
+    - x8i.96xlarge
+    - x8i.metal-48xl
+    - x8i.metal-96xl
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
### Issue


<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

Updates instance types in the EFA device plugin chart to the latest set that support EFA, and also adds a `hack` script to help do this going forward.

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [ ] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

N/A

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
