### PR TITLE
Upgrade aws-for-fluent-bit chart to v0.2.0 (upstream version to 3.2.1)

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.1.35
-appVersion: 2.32.2.20240516
+version: 0.2.0
+appVersion: 3.2.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -34,7 +34,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
 | `podSecurityContext` | Security Context for pod | `{}` | 
 | `containerSecurityContext` | Security Context for container | `{}` | 
-| `rbac.pspEnabled` | Whether a pod security policy should be created | `false`
+| `rbac.pspEnabled` | **[DEPRECATED]** Whether a pod security policy should be created. PSP was removed in Kubernetes 1.25. See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/) for migration guidance | `false`
 | `imagePullSecrets` | Docker registry pull secret | `[]` |
 | `serviceAccount.create` | Whether a new service account should be created | `true` |
 | `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
-  tag: 2.32.2.20240516
+  tag: 3.2.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -24,7 +24,10 @@ containerSecurityContext: {}
 #   - ALL
 
 rbac:
-  # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
+  # DEPRECATED: PodSecurityPolicy was removed in Kubernetes 1.25.
+  # This setting has no effect on Kubernetes 1.25+.
+  # Migrate to Pod Security Standards (PSS) / Pod Security Admission instead.
+  # See: https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/
   pspEnabled: false
 
 service:


### PR DESCRIPTION
## Summary
This upgrade updates the aws-for-fluent-bit Helm chart from v0.1.35 to v0.2.0, which includes AWS for Fluent Bit 3.2.1 (based on Fluent Bit 4.2.2).

##  Tests

## Test 1: CloudWatch Logs (C Plugin)

### Helm Install Command
```bash
helm install aws-for-fluent-bit stable/aws-for-fluent-bit \
  --namespace kube-system \
  --set serviceAccount.create=false \
  --set serviceAccount.name=aws-for-fluent-bit \
  --set cloudWatchLogs.enabled=true \
  --set cloudWatchLogs.region=us-west-2 \
  --set cloudWatchLogs.logGroupName=/aws/eks/fluent-bit-test/cloudwatch-logs \
  --set cloudWatchLogs.autoCreateGroup=true
```

### Pod Status
```
NAME                       READY   STATUS    RESTARTS   AGE
aws-for-fluent-bit-6r4jt   1/1     Running   0          52s
aws-for-fluent-bit-sjlcx   1/1     Running   0          52s
```

### Fluent Bit Logs
```
[output:cloudwatch_logs:cloudwatch_logs.0] worker #0 started
[output:cloudwatch_logs:cloudwatch_logs.0] Log Group /aws/eks/fluent-bit-test/cloudwatch-logs not found. Will attempt to create it.
[output:cloudwatch_logs:cloudwatch_logs.0] Created log group /aws/eks/fluent-bit-test/cloudwatch-logs with storage class STANDARD
[output:cloudwatch_logs:cloudwatch_logs.0] Created log stream fluentbit-kube.var.log.containers...
```

### CloudWatch Verification
```bash
aws logs describe-log-streams --log-group-name /aws/eks/fluent-bit-test/cloudwatch-logs --region us-west-2 --limit 3
```
```json
{
    "logStreams": [
        {
            "logStreamName": "fluentbit-kube.var.log.containers.aws-for-fluent-bit-6r4jt_kube-system_aws-for-fluent-bit-...",
            "creationTime": 1769047291463,
            "firstEventTimestamp": 1769047291053,
            "lastEventTimestamp": 1769047291192
        }
    ]
}
```

---

## Test 2: CloudWatch (Go Plugin - Legacy)

### Helm Upgrade Command
```bash
helm upgrade aws-for-fluent-bit stable/aws-for-fluent-bit \
  --namespace kube-system \
  --set serviceAccount.create=false \
  --set serviceAccount.name=aws-for-fluent-bit \
  --set cloudWatchLogs.enabled=false \
  --set cloudWatch.enabled=true \
  --set cloudWatch.region=us-west-2 \
  --set cloudWatch.logGroupName=/aws/eks/fluent-bit-test/cloudwatch-go \
  --set cloudWatch.autoCreateGroup=true
```

### Fluent Bit Logs
```
time="2026-01-22T02:04:38Z" level=info msg="[cloudwatch 0] Created log group /aws/eks/fluent-bit-test/cloudwatch-go\n"
time="2026-01-22T02:04:38Z" level=info msg="[cloudwatch 0] Created log stream fluentbit-kube.var.log.containers... in group /aws/eks/fluent-bit-test/cloudwatch-go"
```

### CloudWatch Verification
```bash
aws logs describe-log-streams --log-group-name /aws/eks/fluent-bit-test/cloudwatch-go --region us-west-2 --limit 2
```
```json
{
    "logStreams": [
        {
            "logStreamName": "fluentbit-kube.var.log.containers.aws-for-fluent-bit-fsv4n_kube-system...",
            "creationTime": 1769047478848,
            "firstEventTimestamp": 1769047478591
        }
    ]
}
```

---

## Test 3: Kinesis Streams (C Plugin)

### Helm Upgrade Command
```bash
helm upgrade aws-for-fluent-bit stable/aws-for-fluent-bit \
  --namespace kube-system \
  --set serviceAccount.create=false \
  --set serviceAccount.name=aws-for-fluent-bit \
  --set cloudWatch.enabled=false \
  --set kinesis_streams.enabled=true \
  --set kinesis_streams.region=us-west-2 \
  --set kinesis_streams.stream=fluent-bit-test-stream
```

### Fluent Bit Logs
```
[output:kinesis_streams:kinesis_streams.1] worker #0 started
```

### Kinesis Verification
```bash
aws kinesis get-records --shard-iterator "$SHARD_ITERATOR" --region us-west-2 --limit 5 --query 'length(Records)'
```
```
5
```

---

## Test 4: Kinesis (Go Plugin)

### Helm Upgrade Command
```bash
helm upgrade aws-for-fluent-bit stable/aws-for-fluent-bit \
  --namespace kube-system \
  --set serviceAccount.create=false \
  --set serviceAccount.name=aws-for-fluent-bit \
  --set kinesis_streams.enabled=false \
  --set kinesis.enabled=true \
  --set kinesis.region=us-west-2 \
  --set kinesis.stream=fluent-bit-test-stream
```

### Kinesis Verification
```bash
aws kinesis get-records --shard-iterator "$SHARD_ITERATOR" --region us-west-2 --limit 3
```
```json
{
    "Records": [
        {
            "SequenceNumber": "49671078933949352870379830273367104338065091517155901442",
            "ApproximateArrivalTimestamp": 1769060693.6,
            "Data": "eyJfcCI6IkYiLCJrdWJlcm5ldGVzIjp7ImFubm90YXRpb25zIjp7...",
            "PartitionKey": "6Ozsv5nt"
        }
    ],
    "MillisBehindLatest": 7000
}
```

---

## Test 5: Firehose (Go Plugin)

### Prerequisites
```bash
# Create S3 bucket for Firehose destination
aws s3 mb s3://fluent-bit-test-803909145761 --region us-west-2

# Create IAM role for Firehose
aws iam create-role --role-name fluent-bit-firehose-role --assume-role-policy-document file:///tmp/firehose-role-policy.json
aws iam attach-role-policy --role-name fluent-bit-firehose-role --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess

# Create Firehose delivery stream
aws firehose create-delivery-stream \
  --delivery-stream-name fluent-bit-test-firehose \
  --delivery-stream-type DirectPut \
  --s3-destination-configuration "RoleARN=arn:aws:iam::803909145761:role/fluent-bit-firehose-role,BucketARN=arn:aws:s3:::fluent-bit-test-803909145761,Prefix=firehose/"
```

### Helm Upgrade Command
```bash
helm upgrade aws-for-fluent-bit stable/aws-for-fluent-bit \
  --namespace kube-system \
  --set serviceAccount.create=false \
  --set serviceAccount.name=aws-for-fluent-bit \
  --set kinesis_streams.enabled=false \
  --set firehose.enabled=true \
  --set firehose.region=us-west-2 \
  --set firehose.deliveryStream=fluent-bit-test-firehose
```

### Fluent Bit Logs
```
time="2026-01-22T05:59:20Z" level=info msg="[firehose 0] plugin parameter delivery_stream = 'fluent-bit-test-firehose'"
time="2026-01-22T05:59:20Z" level=info msg="[firehose 0] plugin parameter region = 'us-west-2'"
```

---

## Test 6: S3 (C Plugin)

### Helm Upgrade Command
```bash
helm upgrade aws-for-fluent-bit stable/aws-for-fluent-bit \
  --namespace kube-system \
  --set serviceAccount.create=false \
  --set serviceAccount.name=aws-for-fluent-bit \
  --set firehose.enabled=false \
  --set s3.enabled=true \
  --set s3.region=us-west-2 \
  --set s3.bucket=fluent-bit-test-803909145761 \
  --set s3.s3KeyFormat='/s3-direct/$TAG/%Y-%m-%d/%H-%M-%S' \
  --set s3.totalFileSize=15M \
  --set s3.uploadChunkSize=6M \
  --set s3.uploadTimeout=1m
```

### Fluent Bit Logs
```
[output:s3:s3.1] Using upload size 15000000 bytes
[output:s3:s3.1] initializing worker
[output:s3:s3.1] worker #0 started
[output:s3:s3.1] Running upload timer callback (cb_s3_upload)..
```

### S3 Verification
```bash
aws s3 ls s3://fluent-bit-test-803909145761/s3-direct/ --recursive
```
```
2026-01-21 22:05:18  46199 s3-direct/kube.var.log.containers.aws-for-fluent-bit-tf8kz.../2026-01-22/06-04-16-objects1o852vs
2026-01-21 22:06:28  11625 s3-direct/kube.var.log.containers.aws-for-fluent-bit-tf8kz.../2026-01-22/06-05-17-objectTIzLi19J
2026-01-21 22:05:19   3253 s3-direct/kube.var.log.containers.aws-for-fluent-bit-tpm4p.../2026-01-22/06-04-17-objectJcK5HQS2
2026-01-21 22:05:18 108263 s3-direct/kube.var.log.containers.kube-proxy-bttt7.../2026-01-22/06-02-12-objectDMIYzNyl
```

---

## Confirmed Fluent Bit Version

```bash
kubectl logs -n kube-system aws-for-fluent-bit-xxx | grep "version="
```
```
AWS for Fluent Bit Container Image Version 3.2.0
[fluent bit] version=4.2.2, commit=ddfef360d7, pid=1
[cmetrics] version=1.0.6
[ctraces ] version=0.6.6
```

--- 
## Upgrade test
Upgrade from v0.1.35: Helm upgrade completed without errors, pods restarted with new version, log collection continued without interruption
- Verified backward compatibility: Same values.yaml structure, existing configs work

  - Installed previous version first:
```
[fluent bit] version=1.9.10, commit=06145a501d, pid=1
```
  - Upgraded to v0.1.36:
```
Release "aws-for-fluent-bit" has been upgraded. Happy Helming!
STATUS: deployed
REVISION: 2
```
  - Helm history showing successful upgrade:
```
REVISION  UPDATED                   STATUS      CHART                      APP VERSION
1         Wed Jan 21 17:26:45 2026  superseded  aws-for-fluent-bit-0.1.35  2.32.2.20240516
2         Wed Jan 21 17:29:02 2026  deployed    aws-for-fluent-bit-0.1.36  3.2.0
```
  - Post-upgrade verification:
 ```
AWS for Fluent Bit Container Image Version 3.2.0
[fluent bit] version=4.2.2, commit=ddfef360d7, pid=1
```
Key version changes:
- Fluent Bit: 1.9.10 -> 4.2.2
- Base image: Amazon Linux 2 -> Amazon Linux 2023
- Image tag format: date suffix removed (2.32.2.20240516 -> 3.2.0)

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
