### PR TITLE
feat(vpc-cni): replace hardcoded ConfigMap name with configurable value

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.21.1
-appVersion: "v1.21.1" 
+version: 1.21.2
+appVersion: "v1.21.2"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -34,6 +34,8 @@ The following table lists the configurable parameters for this chart and their d
 | `affinity`              | Map of node/pod affinities                              | `{}`                                |
 | `cniConfig.enabled`     | Enable overriding the default 10-aws.conflist file      | `false`                             |
 | `cniConfig.fileContents`| The contents of the custom cni config file              | `nil`                               |
+| `configMap.enabled`     | Enable configMap deployment                             | `true`                              |
+| `configMap.nameOverride`| Overrides configMap name                                | `amazon-vpc-cni`                    |
 | `eniConfig.create`      | Specifies whether to create ENIConfig resource(s)       | `false`                             |
 | `eniConfig.region`      | Region to use when generating ENIConfig resource names  | `us-west-2`                         |
 | `eniConfig.subnets`     | A map of AZ identifiers to config per AZ                | `nil`                               |

--- a/stable/aws-vpc-cni/templates/configmap.yaml
+++ b/stable/aws-vpc-cni/templates/configmap.yaml
@@ -9,10 +9,11 @@ binaryData:
   10-aws.conflist: {{ .Values.cniConfig.fileContents | b64enc }}
 {{- end }}
 ---
+{{- if .Values.configMap.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: amazon-vpc-cni
+  name: {{ .Values.configMap.nameOverride | default "amazon-vpc-cni-settings" }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-vpc-cni.labels" . | indent 4 }}
@@ -24,3 +25,4 @@ data:
   warm-ip-target: {{ .Values.warmWindowsIPTarget | quote }}
   minimum-ip-target: {{ .Values.minimumWindowsIPTarget | quote }}
   branch-eni-cooldown: {{ .Values.branchENICooldown | quote }}
+{{- end }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -137,6 +137,10 @@ cniConfig:
   enabled: false
   fileContents: ""
 
+configMap:
+  enabled: true
+  nameOverride: ""
+
 imagePullSecrets: []
 
 fullnameOverride: "aws-node"
@@ -242,7 +246,7 @@ eniConfig:
     #   - sg-789
 
 podMonitor:
-  # Create Prometheus podMonitor 
+  # Create Prometheus podMonitor
   create: false
   # Annotations to add to the Prometheus podMonitor
   annotations: {}


### PR DESCRIPTION
### Issue

N/A (prevents multiple instantiations of VPC CNI chart in the same namespace)

### Description of changes

The legacy `configMap` name for VPC CNI settings was hardcoded.  
This PR makes the configMap name configurable, allowing multiple instances of the chart in the same namespace.

### Checklist
- [X] Added/modified documentation as required (such as the `README.md` for modified charts)  
- [X] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)  
- [X] Manually tested (see Testing section)  
- [X] Ensure the PR title is descriptive for release notes  

### Testing

- Verified Helm template rendering with both default (legacy) and custom configMap names:

```bash
helm template .
helm template . --set configMap.nameOverride=test | yq -r '.. | select(.metadata.name == "test")'
```