### PR TITLE
Fix formatting of default-tags argument in deployment.yaml

### DIFF
--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
         - --external-managed-tags={{ join "," .Values.externalManagedTags }}
         {{- end }}
         {{- if .Values.defaultTags }}
-        - --default-tags={{ include "aws-load-balancer-controller.convertMapToCsv" .Values.defaultTags | trimSuffix "," }}
+        - "--default-tags={{ include "aws-load-balancer-controller.convertMapToCsv" .Values.defaultTags | trimSuffix "," }}"
         {{- end }}
         {{- if kindIs "bool" .Values.enableEndpointSlices }}
         - --enable-endpoint-slices={{ .Values.enableEndpointSlices }}


### PR DESCRIPTION
### Issue

[Load Balancer Controller: defaultTags with special YAML characters](https://github.com/aws/eks-charts/issues/1301)

### Description of changes

Adds YAML quoting around the --default-tags argument. 

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md` for modified charts)
- [ ] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [X] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

### Testing

1. patched local chart template
2. Upgrade the release with the patched chart
```
helm upgrade aws-load-balancer-controller /tmp/aws-load-balancer-controller \
  -n kube-system \
  --reuse-values \
  --set 'defaultTags.Owner=github: @jeff-d' \
  --set 'defaultTags.testTag=value'
```

3. Create a test ingress
```
kubectl apply -f - <<'EOF'
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-ingress
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
spec:
  ingressClassName: alb
  rules:
  - http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: some-service
            port:
              number: 80
EOF
```

4. Check ALB tags in AWS
aws elbv2 describe-tags --resource-arns <ALB_ARN>


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
