### PR TITLE
aws-for-fluent-bit: add podLabels support

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.2.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -225,6 +225,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `tolerations`| Optional deployment tolerations |`[]`|
 | `nodeSelector`| Node labels for pod assignment |`{}`|
 | `annotations`| Optional pod annotations |`{}`|
+| `podLabels` | Optional pod labels |`{}`|
 | `volumes`| Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
 | `volumeMounts`| Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
 | `dnsPolicy`| Optional dnsPolicy |`ClusterFirst`|

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -19,7 +19,8 @@ spec:
         {{- toYaml .Values.annotations | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 8 }}
+        {{- $labels := merge (include "aws-for-fluent-bit.selectorLabels" . | fromYaml) (.Values.podLabels | default dict) }}
+        {{- toYaml $labels | nindent 8 }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -304,6 +304,8 @@ annotations:
   {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
 
+podLabels: {}
+
 # Specifies if aws-for-fluent-bit should be started in hostNetwork mode.
 #
 # This is required if using a custom CNI where the managed control plane nodes are unable to initiate


### PR DESCRIPTION
Add optional podLabels to the DaemonSet pod template, using merge to ensure selector labels cannot be overridden by user-provided values.

### Issue

#1008 

### Description of changes

Allow users to specify custom pod labels for the aws-for-fluent-bit chart.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
helm lint passes
```
$ helm lint ./stable/aws-for-fluent-bit
==> Linting ./stable/aws-for-fluent-bit

1 chart(s) linted, 0 chart(s) failed
```

helm template setting custom labels works correctly
```
$ helm template test ./stable/aws-for-fluent-bit --set 'podLabels.foo=bar,podLabels.env=staging' | yq 'select(.kind == "DaemonSet") | .spec.template.metadata.labels'
app.kubernetes.io/instance: test-aws-for-fluent-bit
app.kubernetes.io/name: aws-for-fluent-bit
env: staging
foo: bar
```

helm template without setting custom labels works correctly
```
$ helm template test ./stable/aws-for-fluent-bit | yq 'select(.kind == "DaemonSet") | .spec.template.metadata.labels'
app.kubernetes.io/instance: test-aws-for-fluent-bit
app.kubernetes.io/name: aws-for-fluent-bit
```

helm template setting custom labels conflicting with default labels do not override the value
```
$ helm template test ./stable/aws-for-fluent-bit --set 'podLabels.app\.kubernetes\.io/name=override' | yq 'select(.kind == "DaemonSet") | .spec.template.metadata.labels'
app.kubernetes.io/instance: test-aws-for-fluent-bit
app.kubernetes.io/name: aws-for-fluent-bit
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
