### PR TITLE
Add aws-dranet helm chart for DRA network driver

### DIFF
--- a/stable/aws-dranet/.helmignore
+++ b/stable/aws-dranet/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/aws-dranet/Chart.yaml
+++ b/stable/aws-dranet/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: aws-dranet
+description: A Helm chart for the dranet network driver for AWS EC2 instances.
+version: 1.0.0
+appVersion: "v1.2.0-eksbuild.2"
+home: https://github.com/aws/eks-charts
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/eks-charts

--- a/stable/aws-dranet/README.md
+++ b/stable/aws-dranet/README.md
@@ -1,0 +1,68 @@
+# aws-dranet
+
+A Helm chart for the dranet network driver for AWS EC2 instances.
+
+dranet is a Kubernetes DRA (Dynamic Resource Allocation) network driver that runs as a DaemonSet on every eligible node. It discovers and publishes EFA devices so that workloads can request them through the Kubernetes DRA API.
+
+## Prerequisites
+
+- Kubernetes 1.35+ (with DRA feature gate enabled)
+- Helm 3+
+
+## Installation
+
+Add the EKS charts repository:
+
+```bash
+helm repo add eks https://aws.github.io/eks-charts
+helm repo update
+```
+
+Install the chart:
+
+```bash
+helm install aws-dranet eks/aws-dranet --namespace kube-system
+```
+
+To upgrade an existing release:
+
+```bash
+helm upgrade aws-dranet eks/aws-dranet --namespace kube-system
+```
+
+To uninstall:
+
+```bash
+helm uninstall aws-dranet --namespace kube-system
+```
+
+## Configuration
+
+The following table lists the configurable parameters and their default values.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `image.repository` | Container image repository | `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/dranet` |
+| `image.tag` | Container image tag | `v1.2.0-eksbuild.2` |
+| `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
+| `securityContext` | Container security context | See `values.yaml` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `50Mi` |
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `256Mi` |
+| `serviceAccount.create` | Whether to create a ServiceAccount | `true` |
+| `serviceAccount.name` | Override ServiceAccount name (uses fullname if empty) | `""` |
+| `tolerations` | Additional tolerations for the DaemonSet pods | `[]` |
+| `nodeSelector` | Node selector for the DaemonSet pods | `{}` |
+| `podAnnotations` | Additional pod annotations | `{}` |
+| `podLabels` | Additional pod labels | `{}` |
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the fully qualified name | `""` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+| `updateStrategy` | DaemonSet update strategy | `{}` |
+| `priorityClassName` | Pod priority class | `system-node-critical` |
+| `deviceClass.create` | Whether to create a default DeviceClass for EFA devices | `true` |
+| `deviceClass.name` | Name of the DeviceClass | `efa.networking.k8s.aws` |
+| `healthPort` | Port for the healthz/metrics server (`--bind-address` flag) | `9177` |
+| `verbosity` | Log verbosity level (`--v` flag) | `4` |
+| `filter` | CEL filter expression (`--filter` flag); set to `""` to disable | See `values.yaml` |

--- a/stable/aws-dranet/templates/NOTES.txt
+++ b/stable/aws-dranet/templates/NOTES.txt
@@ -1,0 +1,13 @@
+aws-dranet has been deployed as a DaemonSet in the {{ .Release.Namespace }} namespace.
+
+dranet is a Kubernetes DRA (Dynamic Resource Allocation) network driver that
+discovers and publishes EFA devices on each node. It enables workloads to 
+request them through the Kubernetes DRA API.
+
+To verify the DaemonSet is running:
+
+  kubectl get daemonset {{ include "aws-dranet.fullname" . }} -n {{ .Release.Namespace }}
+
+To check the resource slices published by dranet:
+
+  kubectl get resourceslices

--- a/stable/aws-dranet/templates/_helpers.tpl
+++ b/stable/aws-dranet/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-dranet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-dranet.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-dranet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-dranet.labels" -}}
+helm.sh/chart: {{ include "aws-dranet.chart" . }}
+{{ include "aws-dranet.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aws-dranet.selectorLabels" -}}
+app: {{ include "aws-dranet.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-dranet.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "aws-dranet.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/aws-dranet/templates/clusterrole.yaml
+++ b/stable/aws-dranet/templates/clusterrole.yaml
@@ -1,0 +1,46 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "aws-dranet.fullname" . }}
+  labels:
+    {{- include "aws-dranet.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceslices
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims
+      - deviceclasses
+    verbs:
+      - get
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/driver
+    verbs:
+      - associated-node:patch
+      - associated-node:update
+    resourceNames:
+      - dra.net

--- a/stable/aws-dranet/templates/clusterrolebinding.yaml
+++ b/stable/aws-dranet/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "aws-dranet.fullname" . }}
+  labels:
+    {{- include "aws-dranet.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aws-dranet.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "aws-dranet.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/stable/aws-dranet/templates/daemonset.yaml
+++ b/stable/aws-dranet/templates/daemonset.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "aws-dranet.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-dranet.labels" . | nindent 4 }}
+    tier: node
+    app: {{ include "aws-dranet.name" . }}
+    k8s-app: {{ include "aws-dranet.name" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "aws-dranet.selectorLabels" . | nindent 6 }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "aws-dranet.labels" . | nindent 8 }}
+        {{- include "aws-dranet.selectorLabels" . | nindent 8 }}
+        tier: node
+        k8s-app: {{ include "aws-dranet.name" . }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      hostNetwork: true
+      hostPID: false
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+      {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "aws-dranet.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              {{- range .Values.supportedInstanceLabels.keys }}
+              - matchExpressions:
+                - key: {{ . }}
+                  operator: In
+                  values:
+                    {{- toYaml $.Values.supportedInstanceLabels.values | nindent 20 }}
+              {{- end }}
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                  - auto
+      containers:
+      - name: dranet
+        args:
+        - /dranet
+        - --v={{ .Values.verbosity }}
+        - --hostname-override=$(NODE_NAME)
+        - "--bind-address=:{{ .Values.healthPort }}"
+        - --cloud-provider-hint=AWS
+        {{- if .Values.filter }}
+        - --filter={{ .Values.filter }}
+        {{- end }}
+        {{- if not .Values.image.tag }}
+        {{- fail "image.tag is required" }}
+        {{- end }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.healthPort }}
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/plugins
+        - name: plugin-registry
+          mountPath: /var/lib/kubelet/plugins_registry
+        - name: nri-plugin
+          mountPath: /var/run/nri
+        - name: netns
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
+        - name: infiniband
+          mountPath: /dev/infiniband
+          mountPropagation: HostToContainer
+        - name: tmp
+          mountPath: /tmp
+        - name: dranet-run
+          mountPath: /var/run/dranet
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/plugins
+          type: DirectoryOrCreate
+      - name: plugin-registry
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: DirectoryOrCreate
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
+          type: DirectoryOrCreate
+      - name: netns
+        hostPath:
+          path: /var/run/netns
+          type: DirectoryOrCreate
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+          type: DirectoryOrCreate
+      - name: tmp
+        emptyDir:
+          medium: Memory
+          sizeLimit: 10Mi
+      - name: dranet-run
+        hostPath:
+          path: /var/run/dranet
+          type: DirectoryOrCreate

--- a/stable/aws-dranet/templates/deviceclass.yaml
+++ b/stable/aws-dranet/templates/deviceclass.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.deviceClass.create }}
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: {{ .Values.deviceClass.name }}
+  labels:
+    {{- include "aws-dranet.labels" . | nindent 4 }}
+spec:
+  selectors:
+  - cel:
+      expression: |
+        device.driver == "dra.net" &&
+        device.attributes["dra.net"].pciDevice == 'Elastic Fabric Adapter (EFA)'
+{{- end }}

--- a/stable/aws-dranet/templates/serviceaccount.yaml
+++ b/stable/aws-dranet/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aws-dranet.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-dranet.labels" . | nindent 4 }}
+{{- end }}

--- a/stable/aws-dranet/values.yaml
+++ b/stable/aws-dranet/values.yaml
@@ -1,0 +1,328 @@
+image:
+  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/dranet
+  tag: "v1.2.0-eksbuild.2"
+  pullPolicy: IfNotPresent
+
+securityContext:
+  privileged: false
+  runAsUser: 0
+  runAsGroup: 0
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "50Mi"
+  limits:
+    cpu: "500m"
+    memory: "256Mi"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+tolerations: []
+
+supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
+  keys:
+    - "node.kubernetes.io/instance-type"
+  values:
+    - c5n.18xlarge
+    - c5n.9xlarge
+    - c5n.metal
+    - c6a.48xlarge
+    - c6a.metal
+    - c6gn.16xlarge
+    - c6i.32xlarge
+    - c6i.metal
+    - c6id.32xlarge
+    - c6id.metal
+    - c6in.32xlarge
+    - c6in.metal
+    - c7a.48xlarge
+    - c7a.metal-48xl
+    - c7g.16xlarge
+    - c7g.metal
+    - c7gd.16xlarge
+    - c7gd.metal
+    - c7gn.16xlarge
+    - c7gn.metal
+    - c7i.48xlarge
+    - c7i.metal-48xl
+    - c8a.48xlarge
+    - c8a.metal-48xl
+    - c8g.24xlarge
+    - c8g.48xlarge
+    - c8g.metal-24xl
+    - c8g.metal-48xl
+    - c8gb.16xlarge
+    - c8gb.24xlarge
+    - c8gb.48xlarge
+    - c8gb.metal-24xl
+    - c8gb.metal-48xl
+    - c8gd.24xlarge
+    - c8gd.48xlarge
+    - c8gd.metal-24xl
+    - c8gd.metal-48xl
+    - c8gn.16xlarge
+    - c8gn.24xlarge
+    - c8gn.48xlarge
+    - c8gn.metal-24xl
+    - c8gn.metal-48xl
+    - c8i.48xlarge
+    - c8i.96xlarge
+    - c8i.metal-48xl
+    - c8i.metal-96xl
+    - c8id.48xlarge
+    - c8id.96xlarge
+    - c8id.metal-48xl
+    - c8id.metal-96xl
+    - dl1.24xlarge
+    - dl2q.24xlarge
+    - f2.48xlarge
+    - g4dn.12xlarge
+    - g4dn.16xlarge
+    - g4dn.8xlarge
+    - g4dn.metal
+    - g5.12xlarge
+    - g5.16xlarge
+    - g5.24xlarge
+    - g5.48xlarge
+    - g5.8xlarge
+    - g6.12xlarge
+    - g6.16xlarge
+    - g6.24xlarge
+    - g6.48xlarge
+    - g6.8xlarge
+    - g6e.12xlarge
+    - g6e.16xlarge
+    - g6e.24xlarge
+    - g6e.48xlarge
+    - g6e.8xlarge
+    - g7e.12xlarge
+    - g7e.24xlarge
+    - g7e.48xlarge
+    - g7e.8xlarge
+    - gr6.8xlarge
+    - hpc6a.48xlarge
+    - hpc6id.32xlarge
+    - hpc7a.12xlarge
+    - hpc7a.24xlarge
+    - hpc7a.48xlarge
+    - hpc7a.96xlarge
+    - hpc7g.16xlarge
+    - hpc7g.4xlarge
+    - hpc7g.8xlarge
+    - hpc8a.96xlarge
+    - i3en.12xlarge
+    - i3en.24xlarge
+    - i3en.metal
+    - i4g.16xlarge
+    - i4i.32xlarge
+    - i4i.metal
+    - i7i.24xlarge
+    - i7i.48xlarge
+    - i7i.metal-48xl
+    - i7ie.48xlarge
+    - i7ie.metal-48xl
+    - i8g.48xlarge
+    - i8g.metal-48xl
+    - i8ge.48xlarge
+    - i8ge.metal-48xl
+    - im4gn.16xlarge
+    - inf1.24xlarge
+    - m5dn.24xlarge
+    - m5dn.metal
+    - m5n.24xlarge
+    - m5n.metal
+    - m5zn.12xlarge
+    - m5zn.metal
+    - m6a.48xlarge
+    - m6a.metal
+    - m6i.32xlarge
+    - m6i.metal
+    - m6id.32xlarge
+    - m6id.metal
+    - m6idn.32xlarge
+    - m6idn.metal
+    - m6in.32xlarge
+    - m6in.metal
+    - m7a.48xlarge
+    - m7a.metal-48xl
+    - m7g.16xlarge
+    - m7g.metal
+    - m7gd.16xlarge
+    - m7gd.metal
+    - m7i.48xlarge
+    - m7i.metal-48xl
+    - m8a.48xlarge
+    - m8a.metal-48xl
+    - m8azn.24xlarge
+    - m8azn.metal-24xl
+    - m8g.24xlarge
+    - m8g.48xlarge
+    - m8g.metal-24xl
+    - m8g.metal-48xl
+    - m8gb.16xlarge
+    - m8gb.24xlarge
+    - m8gb.48xlarge
+    - m8gb.metal-24xl
+    - m8gb.metal-48xl
+    - m8gd.24xlarge
+    - m8gd.48xlarge
+    - m8gd.metal-24xl
+    - m8gd.metal-48xl
+    - m8gn.16xlarge
+    - m8gn.24xlarge
+    - m8gn.48xlarge
+    - m8gn.metal-24xl
+    - m8gn.metal-48xl
+    - m8i.48xlarge
+    - m8i.96xlarge
+    - m8i.metal-48xl
+    - m8i.metal-96xl
+    - m8id.48xlarge
+    - m8id.96xlarge
+    - m8id.metal-48xl
+    - m8id.metal-96xl
+    - p3dn.24xlarge
+    - p4d.24xlarge
+    - p4de.24xlarge
+    - p5.48xlarge
+    - p5.4xlarge
+    - p5e.48xlarge
+    - p5en.48xlarge
+    - p6-b200.48xlarge
+    - p6-b300.48xlarge
+    - p6e-gb200.36xlarge
+    - p6e-gb300.36xlarge
+    - r5dn.24xlarge
+    - r5dn.metal
+    - r5n.24xlarge
+    - r5n.metal
+    - r6a.48xlarge
+    - r6a.metal
+    - r6i.32xlarge
+    - r6i.metal
+    - r6id.32xlarge
+    - r6id.metal
+    - r6idn.32xlarge
+    - r6idn.metal
+    - r6in.32xlarge
+    - r6in.metal
+    - r7a.48xlarge
+    - r7a.metal-48xl
+    - r7g.16xlarge
+    - r7g.metal
+    - r7gd.16xlarge
+    - r7gd.metal
+    - r7i.48xlarge
+    - r7i.metal-48xl
+    - r7iz.32xlarge
+    - r7iz.metal-32xl
+    - r8a.48xlarge
+    - r8a.metal-48xl
+    - r8g.24xlarge
+    - r8g.48xlarge
+    - r8g.metal-24xl
+    - r8g.metal-48xl
+    - r8gb.16xlarge
+    - r8gb.24xlarge
+    - r8gb.48xlarge
+    - r8gb.metal-24xl
+    - r8gb.metal-48xl
+    - r8gd.24xlarge
+    - r8gd.48xlarge
+    - r8gd.metal-24xl
+    - r8gd.metal-48xl
+    - r8gn.16xlarge
+    - r8gn.24xlarge
+    - r8gn.48xlarge
+    - r8gn.metal-24xl
+    - r8gn.metal-48xl
+    - r8i.48xlarge
+    - r8i.96xlarge
+    - r8i.metal-48xl
+    - r8i.metal-96xl
+    - r8id.48xlarge
+    - r8id.96xlarge
+    - r8id.metal-48xl
+    - r8id.metal-96xl
+    - trn1.32xlarge
+    - trn1n.32xlarge
+    - trn2-ac.24xlarge
+    - trn2.3xlarge
+    - trn2.48xlarge
+    - trn2u-ac.24xlarge
+    - trn2u.48xlarge
+    - trn3.48xlarge
+    - trn3-dev0.48xlarge
+    - trn3-dev1.48xlarge
+    - trn3p.48xlarge
+    - trn3pd98.48xlarge
+    - trn3s.48xlarge
+    - u7i-12tb.224xlarge
+    - u7i-6tb.112xlarge
+    - u7i-8tb.112xlarge
+    - u7in-16tb.224xlarge
+    - u7in-24tb.224xlarge
+    - u7in-32tb.224xlarge
+    - vt1.24xlarge
+    - x2idn.32xlarge
+    - x2idn.metal
+    - x2iedn.32xlarge
+    - x2iedn.metal
+    - x2iezn.12xlarge
+    - x2iezn.metal
+    - x8aedz.24xlarge
+    - x8aedz.metal-24xl
+    - x8g.24xlarge
+    - x8g.48xlarge
+    - x8g.metal-24xl
+    - x8g.metal-48xl
+    - x8i.48xlarge
+    - x8i.64xlarge
+    - x8i.96xlarge
+    - x8i.metal-48xl
+    - x8i.metal-96xl
+
+nodeSelector: {}
+
+podAnnotations: {}
+
+podLabels: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+updateStrategy: {}
+
+priorityClassName: "system-node-critical"
+
+deviceClass:
+  # Specifies whether a default DeviceClass for EFA devices should be created
+  create: true
+  name: efa.networking.k8s.aws
+
+# Port for the healthz/metrics server (--bind-address flag)
+healthPort: 9177
+
+# Log verbosity level (--v flag)
+verbosity: 4
+
+# CEL filter expression (--filter flag). Set to "" to disable filtering.
+# This filter includes only EFA/RDMA devices for DRA allocation,
+# excluding virtual (veth), ENA, and other non-EFA network devices.
+filter: >-
+  "dra.net/pciDevice" in attributes && attributes["dra.net/pciDevice"].StringValue == "Elastic Fabric Adapter (EFA)"


### PR DESCRIPTION
### Description of changes

Adds a new Helm chart (stable/aws-dranet) for deploying dranet, a Kubernetes DRA (Dynamic Resource Allocation) network driver that discovers and publishes EFA devices so that workloads can request them through the Kubernetes DRA API.

  What's included                                                                                                                                
                                                                                                                                                 
  - DaemonSet with host networking and below mounts required for device discovery and DRA plugin registration:
      - /var/lib/kubelet/plugins
      - /var/lib/kubelet/plugins_registry
      - /var/run/nri
      - /var/run/netns
      - /dev/infiniband
      - /var/run/dranet
  - ClusterRole/ClusterRoleBinding for ResourceSlice CRUD permissions                                                                            
  - ServiceAccount                                                                                                                               
  - Readiness probe on /healthz (port 9177)                                                                                                      
  - Configurable CEL filter to exclude non-relevant devices (ENA, veth) by default                                                               
  - Configurable image, resources, tolerations, nodeSelector, and log verbosity   
  - Added node affinity to a list of instances which are efa capable.                                                               
                                                                                                                                                 
  Default configuration                                                                                                                          
                                                                                                                                                 
  - Image: 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/dranet:v1.2.0-eksbuild.2
  - Filter: Excludes ENA and veth devices, exposing only EFA/RDMA devices                                                                        
  - Log verbosity: 4                                                                                                                             

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing
  - Deployed on a trn1.32xlarge cluster with Neuron DRA driver — verified EFA + Neuron device co-scheduling with topology-aware matchAttribute constraints                                                                                                                                    
  - Deployed on a p5.48xlarge cluster with NVIDIA DRA driver — verified EFA + GPU co-scheduling with pcieRoot matchAttribute
  - Ran NCCL/NCCOM multi-node tests across both instance types                                                                                   
  - Ran a 25-cycle pod churn test validating device allocation/deallocation under rapid create/delete                                            
  - Deployed on m5.large instance. dranet pods are not scheduled since does not adhere to node affinity

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
