### PR TITLE
ci: add contents: read to ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - "**/*.yaml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Single-workflow `ci.yaml` runs Helm chart linting on `.tpl` / `.yaml` changes. Pure read — no commits, releases, or comments. `contents: read` covers the `actions/checkout` step.