### PR TITLE
Updating vpc-cni and cni-metrics charts update

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.21.1
-appVersion: "v1.21.1" 
+version: 1.21.2
+appVersion: "v1.21.2" 
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/README.md
+++ b/stable/aws-vpc-cni/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters for this chart and their d
 | `minimumWindowsIPTarget`| Minimum IP target value for Windows prefix delegation   | `3`                                 |
 | `branchENICooldown`     | Number of seconds that branch ENIs remain in cooldown   | `60`                                |
 | `fullnameOverride`      | Override the fullname of the chart                      | `aws-node`                          |
-| `image.tag`             | Image tag                                               | `v1.21.1`                           |
+| `image.tag`             | Image tag                                               | `v1.21.2`                           |
 | `image.domain`          | ECR repository domain                                   | `amazonaws.com`                     |
 | `image.region`          | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `image.endpoint`        | ECR repository endpoint to use.                         | `ecr`                               |
@@ -57,7 +57,7 @@ The following table lists the configurable parameters for this chart and their d
 | `image.overrideRepository` | Repository override for the image (does not change the tag) | `nil`                        |
 | `image.override`        | A custom docker image to use                            | `nil`                               |
 | `imagePullSecrets`      | Docker registry pull secret                             | `[]`                                |
-| `init.image.tag`        | Image tag                                               | `v1.21.1`                           |
+| `init.image.tag`        | Image tag                                               | `v1.21.2`                           |
 | `init.image.domain`     | ECR repository domain                                   | `amazonaws.com`                     |
 | `init.image.region`     | ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `init.image.endpoint`   | ECR repository endpoint to use.                         | `ecr`                               |
@@ -71,7 +71,7 @@ The following table lists the configurable parameters for this chart and their d
 | `originalMatchLabels`   | Use the original daemonset matchLabels                  | `false`                             |
 | `nameOverride`          | Override the name of the chart                          | `aws-node`                          |
 | `nodeAgent.enabled`     | If the Node Agent container should be created           | `true`                              |
-| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.3.1`                            |
+| `nodeAgent.image.tag`   | Image tag for Node Agent                                | `v1.3.5`                            |
 | `nodeAgent.image.domain`| ECR repository domain                                   | `amazonaws.com`                     |
 | `nodeAgent.image.region`| ECR repository region to use. Should match your cluster | `us-west-2`                         |
 | `nodeAgent.image.endpoint`   | ECR repository endpoint to use.                    | `ecr`                               |
@@ -86,6 +86,7 @@ The following table lists the configurable parameters for this chart and their d
 | `nodeAgent.metricsBindAddr` | Node Agent port for metrics                         | `8162`                              |
 | `nodeAgent.healthProbeBindAddr` | Node Agent port for health probes               | `8163`                              |
 | `nodeAgent.conntrackCacheCleanupPeriod` | Cleanup interval for network policy agent conntrack cache | 300               |
+| `nodeAgent.conntrackCacheTableSize` | Size of the conntrack cache table (valid range: 32K-1024K) | `524288`            |
 | `nodeAgent.enableIpv6`  | Enable IPv6 support for Node Agent                      | `false`                             |
 | `nodeAgent.resources`   | Node Agent resources, will defualt to .Values.resources if not set | `{}`                     |
 | `nodeAgent.logLevel`    | Node Agent logging verbosity level.                     | `debug`                             |

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -56,6 +56,9 @@ spec:
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.tolerations }}
       tolerations:
@@ -70,6 +73,7 @@ spec:
       containers:
         - name: aws-node
           image: {{ include "aws-vpc-cni.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 61678
               name: metrics
@@ -151,6 +155,7 @@ spec:
             - --metrics-bind-addr={{ include "aws-vpc-cni.nodeAgentMetricsBindAddr" . }}
             - --health-probe-bind-addr={{ include "aws-vpc-cni.nodeAgentHealthProbeBindAddr" . }}
             - --conntrack-cache-cleanup-period={{ .Values.nodeAgent.conntrackCacheCleanupPeriod }}
+            - --conntrack-cache-table-size={{ .Values.nodeAgent.conntrackCacheTableSize }}
             - --log-level={{ .Values.nodeAgent.logLevel }}
           {{- with default .Values.resources .Values.nodeAgent.resources }}
           resources:

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,12 +8,12 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.21.1
+    tag: v1.21.2
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
     account: "602401143452"
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Set to use custom image
     overrideRepository:
     # overrideRepository: "repo/org/image"
@@ -29,12 +29,12 @@ init:
 nodeAgent:
   enabled: true
   image:
-    tag: v1.3.1
+    tag: v1.3.5
     domain: amazonaws.com
     region: us-west-2
     endpoint: ecr
     account: "602401143452"
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Set to use custom image
     overrideRepository:
     # overrideRepository: "repo/org/image"
@@ -52,16 +52,17 @@ nodeAgent:
   metricsBindAddr: "8162"
   healthProbeBindAddr: "8163"
   conntrackCacheCleanupPeriod: 300
+  conntrackCacheTableSize: 524288
   logLevel: "debug"
   resources: {}
 
 image:
-  tag: v1.21.1
+  tag: v1.21.2
   domain: amazonaws.com
   region: us-west-2
   endpoint: ecr
   account: "602401143452"
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Set to use custom image
   overrideRepository:
   # overrideRepository: "repo/org/image"
@@ -92,7 +93,7 @@ env:
   ENABLE_IPv4: "true"
   ENABLE_IPv6: "false"
   ENABLE_SUBNET_DISCOVERY: "true"
-  VPC_CNI_VERSION: "v1.21.1"
+  VPC_CNI_VERSION: "v1.21.2"
   NETWORK_POLICY_ENFORCING_MODE: "standard"
   ENABLE_IMDS_ONLY_MODE: "false"
   ENABLE_MULTI_NIC: "false"

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.21.1
-appVersion: v1.21.1
+version: 1.21.2
+appVersion: v1.21.2
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters for this chart and their d
 | -------------------------------|---------------------------------------------------------------|-------------------------------------|
 | `affinity`                     | Map of node/pod affinities                                    | `{}`                                |
 | `fullnameOverride`             | Override the fullname of the chart                            | `cni-metrics-helper`                |
-| `image.tag`                    | Image tag                                                     | `v1.21.1`                           |
+| `image.tag`                    | Image tag                                                     | `v1.21.2`                           |
 | `image.domain`                 | ECR repository domain                                         | `amazonaws.com`                     |
 | `image.region`                 | ECR repository region to use. Should match your cluster       | `us-west-2`                         |
 | `image.account`                | ECR repository account number                                 | `602401143452`                      |

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -4,7 +4,7 @@ nameOverride: cni-metrics-helper
 
 image:
   region: us-west-2
-  tag: v1.21.1
+  tag: v1.21.2
   account: "602401143452"
   domain: "amazonaws.com"
   # Set to use custom image


### PR DESCRIPTION

  ### Release Notes 📝:

  ## What's Changed

* Amazon VPC CNI now propagates the EC2 security group idle connection tracking timeout settings from the instance's primary ENI to all secondary ENIs it creates, ensuring consistent connection tracking behavior across all network interfaces. To customize these settings on the primary ENI, use a custom launch template to configure the desired connection tracking timeout values.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts

## Features
* Replicate primary ENI connection tracking settings to secondary ENIs (https://github.com/aws/amazon-vpc-cni-k8s/pull/3666, @jaydeokar)
* Add support for extra volume mounts in aws-vpc-cni-init container (https://github.com/aws/amazon-vpc-cni-k8s/pull/3633, @phbergsmann)
* Add conntrack-cache-table-size to helm chart (https://github.com/aws/amazon-vpc-cni-k8s/pull/3617, @viveksb007)

## Bug Fixes
* Fix panic in air-gapped regions: use awshttp.BuildableClient instead of *http.Client for AWS SDK HTTP client (https://github.com/aws/amazon-vpc-cni-k8s/pull/3672, @haouc)
* Add HTTP request timeout (10s) to AWS SDK clients to prevent indefinite hangs (https://github.com/aws/amazon-vpc-cni-k8s/pull/3649, @haouc)
* Fix nil pointer panic in PodLogs when Stream fails (https://github.com/aws/amazon-vpc-cni-k8s/pull/3671, @haouc)
* Fix missing timeout in DescribeNetworkInterfaces call (https://github.com/aws/amazon-vpc-cni-k8s/pull/3644, @cdirubbio)
* Fix context cancellation with DescribeNetworkInterfaces timeout (https://github.com/aws/amazon-vpc-cni-k8s/pull/3644, @cdirubbio)
* Fix IMDS resource leak (https://github.com/aws/amazon-vpc-cni-k8s/pull/3617, @viveksb007)
* Restore clobbered context in pkg/publisher (https://github.com/aws/amazon-vpc-cni-k8s/pull/3595, @alrs)
* Fix dropped error in pkg/networkutils (https://github.com/aws/amazon-vpc-cni-k8s/pull/3595, @alrs)
* Fix address issue https://github.com/aws/amazon-vpc-cni-k8s/issues/3620 (https://github.com/aws/amazon-vpc-cni-k8s/pull/3646, @gabrnavarro)
* Add userAgent to AWS API calls (https://github.com/aws/amazon-vpc-cni-k8s/pull/3556, @cdirubbio)
* Fix image pull policy in helm chart (https://github.com/aws/amazon-vpc-cni-k8s/pull/3570, @OlTrenin)

## Improvements
* Enhance logging in ipamd (https://github.com/aws/amazon-vpc-cni-k8s/pull/3561, @supreeet)
* Improve custom networking integration tests (https://github.com/aws/amazon-vpc-cni-k8s/pull/3668, @yash97)
*  Improve TestNew_SetsHTTPClientTimeout to assert timeout is set (https://github.com/aws/amazon-vpc-cni-k8s/pull/3670, @haouc)
* Build images in separate arch runner (@yash97)
* Pick up EKS CVE patched container plugin binaries for internal builds (https://github.com/aws/amazon-vpc-cni-k8s/pull/3571, @jupdec)
* Bundle internal binaries when available and add integration test cases (https://github.com/aws/amazon-vpc-cni-k8s/pull/3627, @jupdec)

**Full Changelog**: https://github.com/aws/amazon-vpc-cni-k8s/compare/v1.21.1...v1.21.2


To manually apply this release:
```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.21/config/master/aws-k8s-cni.yaml
```

Note that the following regions use different manifests:

us-gov-east-1:
```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.21/config/master/aws-k8s-cni-us-gov-east-1.yaml
```
us-gov-west-1:
```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.21/config/master/aws-k8s-cni-us-gov-west-1.yaml
```
cn:
```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/refs/heads/release-1.21/config/master/aws-k8s-cni-cn.yaml
```
To apply this release using helm:
Follow the installation instructions in https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.21/charts/aws-vpc-cni/README.md#installing-the-chart

Verify the update:
```
$ kubectl describe daemonset aws-node -n kube-system | grep Image | cut -d "/" -f 2-3
```

```
amazon-k8s-cni-init:v1.21.2
amazon-k8s-cni:v1.21.2
amazon/aws-network-policy-agent:v1.3.5
```