### PR TITLE
Update efa device plugin image to 0.5.19

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.27
+version: v0.5.28
 appVersion: "v0.5.19"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
 version: v0.5.27
-appVersion: "v0.5.18"
+appVersion: "v0.5.19"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -22,7 +22,7 @@ helm install efa ./aws-efa-k8s-device-plugin -n kube-system
 Parameter | Description | Default
 --- | --- | ---
 `image.repository` | EFA image repository | `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin`
-`image.tag` | EFA image tag | `v0.5.17`
+`image.tag` | EFA image tag | `v0.5.19`
 `securityContext` | EFA plugin security context | `allowPrivilegeEscalation: true, privileged: true, runAsNonRoot: false, runAsUser: 0`
 `supportedInstanceLabels.keys` | Kubernetes key to interpret as instance type | `nodes.kubernetes.io/instance-type`
 `supportedInstanceLabels.values` | List of instances which currently support EFA devices | `see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types`

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.5.18"
+  tag: "v0.5.19"
 securityContext:
   allowPrivilegeEscalation: true
   privileged: true


### PR DESCRIPTION
### Issue


### Description of changes

Update efa device plugin image to latest 0.5.19

tested by creating EKS EFA cluster



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.