### PR TITLE
🥳 aws-load-balancer-controller v3.4.0 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 3.3.0
-appVersion: v3.3.0
+version: 3.4.0
+appVersion: v3.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -22,7 +22,7 @@ webhooks:
   failurePolicy: {{ .Values.podMutatorWebhookConfig.failurePolicy }}
   name: mpod.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   namespaceSelector:
     matchExpressions:
     {{ if .Values.webhookNamespaceSelectors }}
@@ -67,7 +67,7 @@ webhooks:
   failurePolicy: Fail
   name: quicid.elbv2.k8s.aws
   admissionReviewVersions:
-    - v1beta1
+    - v1
   namespaceSelector:
     matchExpressions:
     {{ if .Values.webhookNamespaceSelectors }}
@@ -113,7 +113,7 @@ webhooks:
   failurePolicy: {{ .Values.serviceMutatorWebhookConfig.failurePolicy }}
   name: mservice.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   {{- if .Values.serviceMutatorWebhookConfig.namespaceSelectors }}
   namespaceSelector:
     matchExpressions:
@@ -155,7 +155,7 @@ webhooks:
   failurePolicy: Fail
   name: alb-target-control.namespace.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   namespaceSelector:
     matchExpressions:
     - key: elbv2.k8s.aws/alb-target-control-agent-injection
@@ -193,7 +193,7 @@ webhooks:
   failurePolicy: Fail
   name: alb-target-control.object.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   namespaceSelector:
     matchExpressions:
     - key: elbv2.k8s.aws/alb-target-control-agent-injection
@@ -229,7 +229,7 @@ webhooks:
   failurePolicy: Fail
   name: mtargetgroupbinding.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   rules:
   - apiGroups:
     - elbv2.k8s.aws
@@ -264,7 +264,7 @@ webhooks:
   failurePolicy: Fail
   name: vingressclassparams.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name
@@ -293,7 +293,7 @@ webhooks:
   failurePolicy: Fail
   name: vtargetgroupbinding.elbv2.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   rules:
   - apiGroups:
     - elbv2.k8s.aws
@@ -340,7 +340,7 @@ webhooks:
     {{- end }}
   {{- end }}
   admissionReviewVersions:
-  - v1beta1
+  - v1
   rules:
   - apiGroups:
     - networking.k8s.io
@@ -367,7 +367,7 @@ webhooks:
   matchPolicy: Equivalent
   name: vglobalaccelerator.aga.k8s.aws
   admissionReviewVersions:
-  - v1beta1
+  - v1
   namespaceSelector: {}
   objectSelector: {}
   rules:

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v3.3.0
+  tag: v3.4.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 10
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v3.3.0
+  tag: v3.4.0
   pullPolicy: IfNotPresent
 
 runtimeClassName: ""
@@ -428,6 +428,7 @@ controllerConfig:
   # ALBGatewayAPI: true
   # GatewayListenerSet: true
   # GlobalAcceleratorController: false
+  # IngressPlanAnnotation: false
   # EnhancedDefaultBehavior: false
   # EnableDefaultTagsLowPriority: false
   # ALBTargetControlAgent: false


### PR DESCRIPTION
# v3.4.0 release notes

## 📚 Quick Links
v3.4.0 (requires Kubernetes 1.22+)

[Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)

Image: public.ecr.aws/eks/aws-load-balancer-controller:v3.4.0
Thanks to all our contributors! 😊


## 🎉 Ingress to Gateway Migration Tool

We are excited to introduce the Ingress to Gateway Migration Tool, the biggest addition in this release! This tooling helps you migrate AWS Load Balancer Controller (LBC) Ingress resources to Gateway API resources, step by step. The migration is designed to be safe and non-disruptive — new ALBs are created alongside your existing ones, so current workloads keep running throughout the entire process.

Two tools are provided to help you migrate with confidence:s


* [lbc-migrate CLI](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress2gateway/lbc_migrate_reference/): Translates your Ingress manifests (annotations, rules, and IngressGroups) into equivalent Gateway API YAML. Supports cluster scraping (--from-cluster), file input (-f), directory input (--input-dir), single-Ingress and multi-namespace scoping, and per-namespace output splitting.
* [Migration Console](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress2gateway/in_cluster_console/): A local, in-cluster web UI that compares the AWS resource stack produced by both the Ingress and Gateway controllers, field by field. This lets you verify equivalence before applying your Gateway manifests for real.

To get started, see the [Migration Guide](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress2gateway/migrate_from_ingress/) for the end-to-end walkthrough.

We encourage you to try it out and welcome any feedback via [GitHub Issues](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues).


## ⚠️ Gateway API Behavior Change

Only one L4 route per listener is eligible for traffic when using an NLB Gateway

* Change: When multiple L4 (TCP/UDP/TLS) routes target the same listener, the controller only forwards traffic to the oldest route. ([#4745](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4745)).
* Impact: If you currently attach more than one TCP/UDP/TLS route to the same listener, only the oldest route will continue serving traffic after upgrading. Review your L4 route configurations and consolidate to a single route per listener to avoid unexpected traffic changes.

## 🔧 Enhancements and Fixes

* Regex path reconcile loop: Ignore the top-level RegexValues field that AWS mirrors in DescribeRules responses, preventing an unnecessary ModifyRule on every reconcile ([#4749](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4749))
* Service reconciler nil check: Return early in the service reconciler when the load balancer is nil ([#4751](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4751))
* TGC health check for ALB target groups: Fixed an error when updating health check settings in TargetGroupConfiguration for Gateway API ALB target groups ([#4741](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4741))
* NLB weighted target groups: Allow weight 0 for NLB weighted target groups, with a guard requiring at least one non-zero weight ([#4738](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4738))
* Capacity units validation: Validate CapacityUnits on capacity reservation annotations instead of silently dropping parse errors (which reset the reservation to 0) ([#4750](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4750))
* Checkpoint early-exit race: Ensure pods with pending readiness gates are always reconciled, fixing a checkpoint early-exit race with same-IP re-registration ([#4737](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4737))
* Retryable error wrapping: Wrap the last retryable error with a timeout error for clearer failure reporting ([#4761](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4761))
* Readiness gate efficiency: The TargetGroupBinding controller now watches pod events instead of requeueing on a fixed timer when using readiness gates, responding faster while avoiding unnecessary requeues ([#4678](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4678))
* Unit-test workflow permissions: Declare contents: read on the unit-test workflow to pin the default GITHUB_TOKEN to read-only ([#4736](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4736))
* Webhooks upgraded to v1: Admission webhooks were upgraded from v1beta1 to v1. Applied automatically on upgrade — no action needed ([#4743](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4743))
* Listener rule tag reconcile:  Reconcile listener rule tags for all matched rules ([#4772](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4772))


## 🌟 Complete Change Log
* [feat i2g]support split by namespace output by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4733
* [feat i2g] Fix user tag propagation to ListenerRuleConfigurations in lbc-migrate by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4735
* [feat i2g] Add IngressPlanAnnotation feature gate for dry-run plan by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4734
* fix checkpoint early-exit by @wweiwei-li in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4737
* [fix]allow weight zero in NLB target group by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4738
* Watch pod events for updating TargetGroupBindings with ReadinessGates by @cezarsa in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4678
* [feat i2g] multi-ingress TGC with RouteConfigurations by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4742
* upgrade webhooks to v1 by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4743
* Fix error when updating health check settings in TGC for Gateway API ALB target groups by @shraddhabang in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4741
* reject multiple l4 routes for same listener by @zac-nixon in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4745
* fix: return early in service reconciler when lb is nil by @wweiwei-li in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4751
* Validate load balancer capacity units annotations by @immanuwell in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4750
* [feat i2g] bug fix by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4746
* [feat i2g]setup e2e test for migration tool by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4739
* ci(test): declare contents: read on the unit-test workflow by @arpitjain099 in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4736
* [feat i2g]add in-cluster console for model comparison by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4728
* fix: ignore top-level RegexValues mirrored by AWS in DescribeRules response by @pataraktw in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4749
* [feat i2g] add e2e tests for ingress2gateway migration tool by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4771
* [feat i2g] docs: migration guide, lbc-migrate reference, and in-cluster console by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4759
* Add multiple ingress test that sorts rules based on priority by @jupdec in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4756
* Reconcile listener rule tags for all matched rules by @andreybutenko in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4772
* cut v3.4.0 release by @shuqz in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4776

## New Contributors
* @immanuwell made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4750
* @arpitjain099 made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4736
* @pataraktw made their first contribution in https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4749

**Full Changelog**: https://github.com/kubernetes-sigs/aws-load-balancer-controller/compare/v3.3.0...v3.4.0