### PR TITLE
Add image registry support for CNI metrics helper

### DIFF
--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cni-metrics-helper
-version: 1.21.2
+version: 1.21.3
 appVersion: v1.21.2
 description: A Helm chart for the AWS VPC CNI Metrics Helper
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/cni-metrics-helper/README.md
+++ b/stable/cni-metrics-helper/README.md
@@ -61,6 +61,8 @@ The following table lists the configurable parameters for this chart and their d
 | `affinity`                     | Map of node/pod affinities                                    | `{}`                                |
 | `fullnameOverride`             | Override the fullname of the chart                            | `cni-metrics-helper`                |
 | `image.tag`                    | Image tag                                                     | `v1.21.2`                           |
+| `image.registry`               | Image registry/repository path without the tag                | `nil`                               |
+| `image.override`               | Full image override                                           | `nil`                               |
 | `image.domain`                 | ECR repository domain                                         | `amazonaws.com`                     |
 | `image.region`                 | ECR repository region to use. Should match your cluster       | `us-west-2`                         |
 | `image.account`                | ECR repository account number                                 | `602401143452`                      |

--- a/stable/cni-metrics-helper/templates/_helpers.tpl
+++ b/stable/cni-metrics-helper/templates/_helpers.tpl
@@ -61,3 +61,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+The cni-metrics-helper image to use
+*/}}
+{{- define "cni-metrics-helper.image" -}}
+{{- if .Values.image.override -}}
+{{- .Values.image.override -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s:%s" .Values.image.registry .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s.dkr.ecr.%s.%s/cni-metrics-helper:%s" .Values.image.account .Values.image.region .Values.image.domain .Values.image.tag -}}
+{{- end -}}
+{{- end }}

--- a/stable/cni-metrics-helper/templates/deployment.yaml
+++ b/stable/cni-metrics-helper/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         securityContext: {{ toYaml .Values.containerSecurityContext | nindent 10 }}
 {{- end }}
         name: cni-metrics-helper
-        image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
+        image: "{{ include "cni-metrics-helper.image" . }}"
 {{- if eq (get .Values.env "USE_PROMETHEUS") "true" }}
         ports:
         - containerPort: 61681

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -7,6 +7,8 @@ image:
   tag: v1.21.2
   account: "602401143452"
   domain: "amazonaws.com"
+  registry:
+  # registry: "repo/org/image"
   # Set to use custom image
   # override: "repo/org/image:tag"
 


### PR DESCRIPTION
### Description
- Adds image.registry for cni-metrics-helper as an image path without the tag.
- Keeps image.override as the highest-precedence full image override.
- Keeps the default AWS ECR image rendering unchanged.
- Bumps the cni-metrics-helper chart version to 1.21.3.

### Validation
- helm lint stable/cni-metrics-helper
- helm template checks for default image, image.registry/image.tag, image.override precedence, and the Prometheus string env path