### PR TITLE
aws-cloudwatch-metrics: extend permissions, update image

### DIFF
--- a/stable/aws-cloudwatch-metrics/Chart.yaml
+++ b/stable/aws-cloudwatch-metrics/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-cloudwatch-metrics
 description: A Helm chart to deploy aws-cloudwatch-metrics project
-version: 0.0.11
-appVersion: "1.300032.2b361"
+version: 0.0.12
+appVersion: "1.300069.0b1529"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/clusterrole.yaml
@@ -22,3 +22,10 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["cwagent-clusterleader"]
   verbs: ["get","update"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["list", "watch" ]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["list", "watch" ]
+  namespace: {{ .Release.Namespace }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: amazon/cloudwatch-agent
-  tag: 1.300032.2b361
+  tag: 1.300069.0b1529
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name


### PR DESCRIPTION
* aws-cloudwatch-metrics: add list + watch permissions on endpointslices

* aws-cloudwatch-metrics: add list + watch permissions on servi
* ces

* aws-cloudwatch-metrics: bump image version to the latest available

* aws-cloudwatch-metrics: bump chart version to 0.0.12


### Description of changes

With recent k8s versions (we're using 1.35 here), aws-cloudwatch metrics reports the following errors:

`reflector.go:166] \"Unhandled Error\" err=\"k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Failed to watch *v1.EndpointSlice: failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User \\\"system:serviceaccount:amazon-cloudwatch:aws-cw-agent\\\" cannot list resource \\\"endpointslices\\\" in API group \\\"discovery.k8s.io\\\" at the cluster scope\" logger=\"UnhandledError\"","k8":{"pod_name":"aws-cloudwatch-metrics-8d8tj","host":"...","pod_ip":"..."},"kubernetes":{"namespace_name":"amazon-cloudwatch","container_name":"aws-cloudwatch-metrics"}}`

and

`reflector.go:569] k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: failed to list *v1.Service: services is forbidden User "system:serviceaccount:amazon-cloudwatch:aws-cw-agent" cannot list resource "services" in API group "" in the namespace "amazon-cloudwatch" `

This pull request adds the required permissions to the ClusterRole, although I'm not sure if the list/watch services permissions should be more limited.

Additionally it updates the app and image versions to the most recent image available (currently 1.300069.0b1529).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.