### PR TITLE
aws-efa-k8s-device-plugin: add g7 instance family to supportedInstanceLabels

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.29
+version: v0.5.30
 appVersion: "v0.5.20"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -91,6 +91,10 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - g6e.24xlarge
     - g6e.48xlarge
     - g6e.8xlarge
+    - g7.12xlarge
+    - g7.24xlarge
+    - g7.48xlarge
+    - g7.8xlarge
     - g7e.12xlarge
     - g7e.24xlarge
     - g7e.48xlarge


### PR DESCRIPTION
## Description

The EC2 **g7** instance family (NVIDIA RTX PRO 4500 Blackwell) supports EFA on the 8xlarge and larger sizes, but `supportedInstanceLabels` currently only lists **g7e** — g7 is missing.

Because `supportedInstanceLabels` is rendered into the DaemonSet's `nodeAffinity`, an instance type absent from the list means the DaemonSet **silently stays at desired=0** on those nodes (no pods, no events), and `vpc.amazonaws.com/efa` is never registered. A `nodeSelector` override does not help — nodeSelector and nodeAffinity are ANDed.

## Change

Adds the EFA-capable g7 sizes to the list, in alphabetical order:

- `g7.8xlarge`
- `g7.12xlarge`
- `g7.24xlarge`
- `g7.48xlarge`

These are all g7 sizes with `EfaSupported=true` per `aws ec2 describe-instance-types` (2xlarge/4xlarge have no EFA and are intentionally omitted, matching how g6e/g7e smaller sizes are handled). Chart version bumped v0.5.29 → v0.5.30.

## Testing

Verified on `g7.48xlarge` (EKS 1.34, us-east-1): with g7 added to the list the DaemonSet schedules and the node reports `vpc.amazonaws.com/efa: 2`; a pod requesting `vpc.amazonaws.com/efa: 2` schedules and sees `/dev/infiniband/uverbs0,uverbs1`.