### PR TITLE
fix(efa-device-plugin): support EKS Auto Mode

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.30
+version: v0.5.31
 appVersion: "v0.5.20"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -1,6 +1,12 @@
 # AWS EFA Kubernetes Device Plugin
 This chart installs the AWS EFA Kubernetes Device Plugin daemonset
 
+The chart supports EFA-capable EKS Auto Mode nodes. Configure the EFA network
+interfaces on the Auto Mode NodeClass before deploying workloads that request
+`vpc.amazonaws.com/efa`. See [Manage EFA devices on Amazon
+EKS](https://docs.aws.amazon.com/eks/latest/userguide/device-management-efa.html)
+for the complete setup.
+
 ## Prerequisites
 - Helm v3
 

--- a/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/stable/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -57,10 +57,6 @@ spec:
                   values:
                     {{- toYaml $.Values.supportedInstanceLabels.values | nindent 20 }}
               {{- end }}
-                - key: eks.amazonaws.com/compute-type
-                  operator: NotIn
-                  values:
-                  - auto
       hostNetwork: true
       containers:
         - image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}


### PR DESCRIPTION
### Issue

Fixes #1358

### Description of changes

Remove the hard-coded affinity that excludes `eks.amazonaws.com/compute-type=auto`. Supported-instance affinity still restricts the DaemonSet to EFA-capable instances. Also document the Auto Mode NodeClass prerequisite and bump the chart to `v0.5.31`.

### Checklist
- [x] Added/modified documentation as required
- [x] Incremented the chart `version`
- [x] Manually tested
- [x] PR title is suitable for release notes

### Testing

- `helm lint stable/aws-efa-k8s-device-plugin`
- Strict `kubeconform` validation of the rendered DaemonSet
- Rendered with an Auto Mode node selector and verified no hard-coded exclusion remains
- Tested the equivalent DaemonSet on two EKS 1.35 Auto Mode `g5.8xlarge` nodes: 2/2 plugin pods ready, one EFA resource per node, `fi_info -p efa` selected EFA, and cross-node `fi_pingpong -p efa` succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.