### PR TITLE
Add artifacthub-repo.yaml to claim Artifact Hub ownership for the aws repo

### DIFF
--- a/artifacthub-repo.yaml
+++ b/artifacthub-repo.yaml
@@ -1,0 +1,18 @@
+# Artifact Hub repository metadata file
+#
+# This file claims ownership of the "aws" Helm charts repository on Artifact Hub
+# (https://artifacthub.io/packages/search?repo=aws), transferring it from the
+# Helm project admins to the AWS EKS team so that automated notifications reach
+# the correct owners.
+#
+# Ownership claim process:
+# https://artifacthub.io/docs/topics/repositories/#ownership-claim
+#
+# Only the `owners` section is required for the ownership claim. The email of the
+# user performing the claim in the Artifact Hub control panel must match one of
+# the emails listed below.
+owners:
+  - name: Jayanth Varavani
+    email: varavaj@amazon.com
+  - name: Christian DiRubbio
+    email: cdirubb@amazon.com


### PR DESCRIPTION
## What

Adds an `artifacthub-repo.yaml` metadata file to the root of the `gh-pages` branch so the AWS EKS team can claim ownership of the [`aws`](https://artifacthub.io/packages/search?repo=aws) repository on Artifact Hub.

Resolves aws/eks-charts#1290.

## Why

When these chart repos were onboarded to Artifact Hub, the Helm project admins were set as the default owners, so AWS does not receive the automated notifications for this repo. The [ownership claim process](https://artifacthub.io/docs/topics/repositories/#ownership-claim) requires a repository metadata file listing the claiming owners.

## Why this file lives on `gh-pages`

Artifact Hub fetches the metadata file over HTTP at the **same level as `index.yaml`** (it requests `<repo-url>/artifacthub-repo.yml`, then `.yaml`). The published Helm repo URL is `https://aws.github.io/eks-charts`, which is served from this `gh-pages` branch — so the file must live here to resolve at:

```
https://aws.github.io/eks-charts/artifacthub-repo.yaml
```

It is durable across releases: `scripts/publish-charts.sh` checks out `gh-pages`, moves in new `.tgz` files, regenerates `index.yaml`, and runs `git add .` — it never removes existing files, so this metadata file persists.

Per the docs, only the `owners` section is required for the claim, and `repositoryID` is intentionally omitted (it is only needed later for the verified-publisher flag).
