### PR TITLE
aws-for-fluent-bit: add serviceAnnotations and daemonSetAnnotations

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.2.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -225,6 +225,8 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `tolerations`| Optional deployment tolerations |`[]`|
 | `nodeSelector`| Node labels for pod assignment |`{}`|
 | `annotations`| Optional pod annotations |`{}`|
+| `daemonSetAnnotations`| Optional annotations for the DaemonSet object itself |`{}`|
+| `serviceAnnotations`| Optional annotations for the monitoring Service |`{}`|
 | `volumes`| Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
 | `volumeMounts`| Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
 | `dnsPolicy`| Optional dnsPolicy |`ClusterFirst`|

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -3,6 +3,10 @@ kind: DaemonSet
 metadata:
   name: {{ include "aws-for-fluent-bit.fullname" . }}
   namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+  {{- with .Values.daemonSetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
 spec:

--- a/stable/aws-for-fluent-bit/templates/service.yaml
+++ b/stable/aws-for-fluent-bit/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
   name: {{ include "aws-for-fluent-bit.fullname" . }}
   namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - name: monitor-agent

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -304,6 +304,13 @@ annotations:
   {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
 
+# daemonSetAnnotations contains annotations for the DaemonSet object itself.
+# Set pod annotations with `annotations` above.
+daemonSetAnnotations: {}
+
+# serviceAnnotations contains annotations for the monitoring Service resource
+serviceAnnotations: {}
+
 # Specifies if aws-for-fluent-bit should be started in hostNetwork mode.
 #
 # This is required if using a custom CNI where the managed control plane nodes are unable to initiate


### PR DESCRIPTION
### Issue

No open issue. Related: #1305 (podLabels) is the complementary change — see Scope below.

### Description of changes

The chart can annotate the **pods** (`annotations`) and the **ServiceAccount**
(`serviceAccount.annotations`), but there is no way to annotate the two objects
themselves:

* `templates/service.yaml` renders no `metadata.annotations` block at all.
* `templates/daemonset.yaml` renders `.Values.annotations` at
  `spec.template.metadata`, i.e. on the pods — the DaemonSet object's own
  metadata takes only `name`/`namespace`/`labels`.

That blocks the ordinary uses of object annotations — IaC/controller hints,
`prometheus.io/*` on the Service, ArgoCD sync options, external-dns. In our case
a Pulumi deployment needs `pulumi.com/skipAwait` on both objects and has to
post-process the rendered manifests to get it.

This adds two values, following `aws-load-balancer-controller` in this repo,
which already ships exactly this pair:

| key | object |
|---|---|
| `serviceAnnotations` | the monitoring `Service` |
| `daemonSetAnnotations` | the `DaemonSet` itself (pods stay on `annotations`) |

Both are top-level, matching `aws-load-balancer-controller`'s
`serviceAnnotations`/`deploymentAnnotations`. Note `service.annotations` was not
an option: the top-level `service:` key is the Fluent Bit `[SERVICE]` config
stanza, not the Kubernetes Service.

For reference, the community `fluent/helm-charts` `fluent-bit` chart already
supports annotations *and* labels on both objects; this brings the AWS chart
closer to parity.

### Scope

Deliberately does **not** touch `podLabels` — that is #1305, which I have not
duplicated. The two changes are independent and compose cleanly.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

`helm template`, chart `version` held equal so only the template change is compared:

| values | result |
|---|---|
| both keys unset (default) | **byte-identical** to the unmodified chart — 188 lines, 6 documents |
| `serviceAnnotations` + `daemonSetAnnotations` set | exactly two additions, 4 lines, the two `metadata.annotations` blocks |

```
$ diff before.yaml after.yaml      # keys unset
$ diff after_unset.yaml after_set.yaml
111a112,113
>   annotations:
>     pulumi.com/skipAwait: "true"
129a132,133
>   annotations:
>     pulumi.com/skipAwait: "true"
```

`helm lint` passes. Existing users see no change: both keys default to `{}` and
each block is guarded with `{{- with }}`.
