### PR TITLE
bump aws-efa-k8s-device-plugin to v0.5.21-eksbuild.9

### DIFF
--- a/stable/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/stable/aws-efa-k8s-device-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
-version: v0.5.30
-appVersion: "v0.5.20"
+version: v0.5.31
+appVersion: "v0.5.21-eksbuild.9"
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-efa-k8s-device-plugin/README.md
+++ b/stable/aws-efa-k8s-device-plugin/README.md
@@ -22,7 +22,7 @@ helm install efa ./aws-efa-k8s-device-plugin -n kube-system
 Parameter | Description | Default
 --- | --- | ---
 `image.repository` | EFA image repository | `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin`
-`image.tag` | EFA image tag | `v0.5.20`
+`image.tag` | EFA image tag | `v0.5.21-eksbuild.9`
 `securityContext` | EFA plugin security context | `allowPrivilegeEscalation: true, privileged: true, runAsNonRoot: false, runAsUser: 0`
 `supportedInstanceLabels.keys` | Kubernetes key to interpret as instance type | `nodes.kubernetes.io/instance-type`
 `supportedInstanceLabels.values` | List of instances which currently support EFA devices | `see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types`

--- a/stable/aws-efa-k8s-device-plugin/values.yaml
+++ b/stable/aws-efa-k8s-device-plugin/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.5.20"
+  tag: "v0.5.21-eksbuild.9"
 securityContext:
   allowPrivilegeEscalation: true
   privileged: true


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description of changes

<!-- Please explain the changes you made here. -->
Bumping `aws-efa-k8s-device-plugin` to newest version `v0.5.21-eksbuild.9`
### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

```
     NAME: efa-test
     LAST DEPLOYED: Fri Aug 21 12:32:48 2026
     NAMESPACE: efa-test
     STATUS: deployed
     REVISION: 1
     DESCRIPTION: Install complete
     TEST SUITE: None
     NOTES:
     EFA device plugin is installed, it can be requested as `vpc.amazonaws.com/efa` resource.
```
Image pulls, this is just crashloop bc nodes are `c5.large` and dont actually have efas.
```
eks-charts on  master on ☁️  (us-east-1) ➜  kgp -n efa-test
NAME                                       READY   STATUS      RESTARTS      AGE
efa-test-aws-efa-k8s-device-plugin-5dvkw   0/1     Completed   2 (26s ago)   32s
efa-test-aws-efa-k8s-device-plugin-dlk86   0/1     Completed   2 (26s ago)   32s
```
```
eks-charts on  master on ☁️  (us-east-1) ➜  k logs -n efa-test efa-test-aws-efa-k8s-device-plugin-5dvkw
W0821 19:35:01.478390       1 mappings.go:82] Instance type c5.large is not EFA enabled
2026/08/21 19:35:01 Fetching EFA devices.
2026/08/21 19:35:01 Error to get IB device: %v. No valid EFA devices found
```
<!-- Please explain what testing was done. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
