### PR TITLE
[aws-for-fluent-bit] Add optional luaScripts ConfigMap and volume mount

### DIFF
--- a/stable/aws-for-fluent-bit/Chart.yaml
+++ b/stable/aws-for-fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-for-fluent-bit
 description: A Helm chart to deploy aws-for-fluent-bit project
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.2.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -54,6 +54,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `filter.*` | Values for kubernetes filter | |
 | `filter.extraFilters` | Append to existing filter with value |
 | `additionalFilters` | Adding more filters with value |
+| `luaScripts` | Optional map of Lua script filename to content, mounted at `/fluent-bit/scripts/`. Empty default creates no extra ConfigMap or volume. Reference from extraFilters / custom fluent-bit config, e.g. `script /fluent-bit/scripts/helpers.lua`. | `{}` |
 | `cloudWatch.enabled` | Enable this to activate old golang plugin [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit). For guidance on choosing go vs c plugin, please refer to [debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins) | `false` | ✔
 | `cloudWatch.match` | The log filter | `*` | ✔
 | `cloudWatch.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔

--- a/stable/aws-for-fluent-bit/README.md
+++ b/stable/aws-for-fluent-bit/README.md
@@ -54,7 +54,7 @@ helm delete aws-for-fluent-bit --namespace kube-system
 | `filter.*` | Values for kubernetes filter | |
 | `filter.extraFilters` | Append to existing filter with value |
 | `additionalFilters` | Adding more filters with value |
-| `luaScripts` | Optional map of Lua script filename to content, mounted at `/fluent-bit/scripts/`. Empty default creates no extra ConfigMap or volume. Reference from extraFilters / custom fluent-bit config, e.g. `script /fluent-bit/scripts/helpers.lua`. | `{}` |
+| `luaScripts` | Optional map of Lua script filename to content, mounted at `/fluent-bit/scripts/` | `{}` |
 | `cloudWatch.enabled` | Enable this to activate old golang plugin [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit). For guidance on choosing go vs c plugin, please refer to [debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins) | `false` | ✔
 | `cloudWatch.match` | The log filter | `*` | ✔
 | `cloudWatch.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔

--- a/stable/aws-for-fluent-bit/templates/configmap-luascripts.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap-luascripts.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
 data:
   {{- range $key, $value := .Values.luaScripts }}
-  {{ $key }}: {{ tpl $value $ | toYaml | nindent 4 }}
+  {{ $key }}: |
+{{ tpl $value $ | indent 4 }}
   {{- end }}
 {{- end }}

--- a/stable/aws-for-fluent-bit/templates/configmap-luascripts.yaml
+++ b/stable/aws-for-fluent-bit/templates/configmap-luascripts.yaml
@@ -1,0 +1,13 @@
+{{- if gt (len .Values.luaScripts) 0 }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}-luascripts
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+  labels:
+    {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.luaScripts }}
+  {{ $key }}: {{ tpl $value $ | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/stable/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/stable/aws-for-fluent-bit/templates/daemonset.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if gt (len .Values.luaScripts) 0 }}
+        checksum/luascripts: {{ include (print $.Template.BasePath "/configmap-luascripts.yaml") . | sha256sum }}
+        {{- end }}
       {{- if .Values.annotations }}
         {{- toYaml .Values.annotations | nindent 8 }}
       {{- end }}
@@ -54,6 +57,10 @@ spec:
           volumeMounts:
             - name: fluentbit-config
               mountPath: /fluent-bit/etc/
+            {{- if gt (len .Values.luaScripts) 0 }}
+            - name: luascripts
+              mountPath: /fluent-bit/scripts/
+            {{- end }}
             {{- if .Values.volumeMounts }}
             {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
@@ -71,6 +78,11 @@ spec:
         - name: fluentbit-config
           configMap:
             name: {{ include "aws-for-fluent-bit.fullname" . }}
+        {{- if gt (len .Values.luaScripts) 0 }}
+        - name: luascripts
+          configMap:
+            name: {{ include "aws-for-fluent-bit.fullname" . }}-luascripts
+        {{- end }}
         {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 8 }}
         {{- end}}

--- a/stable/aws-for-fluent-bit/values.yaml
+++ b/stable/aws-for-fluent-bit/values.yaml
@@ -333,6 +333,19 @@ env: []
 #       fieldRef:
 #         fieldPath: spec.nodeName
 
+# Optional Lua scripts mounted at /fluent-bit/scripts/
+# Reference them from extraFilters / custom fluent-bit config, e.g.:
+#   [FILTER]
+#       Name lua
+#       Match *
+#       script /fluent-bit/scripts/helpers.lua
+#       call my_filter
+luaScripts: {}
+# helpers.lua: |
+#   function my_filter(tag, timestamp, record)
+#     return 2, timestamp, record
+#   end
+
 volumes:
   - name: varlog
     hostPath:


### PR DESCRIPTION
### Issue
Fixes #1307

### Description of changes
Optional `luaScripts` values, ConfigMap, DaemonSet mount at `/fluent-bit/scripts/`. Empty default is a no-op. Rolling update via checksum annotation when scripts are set.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

Repo `make verify` (`scripts/validate-charts.sh`, `validate-chart-versions.sh`, `lint-charts.sh`) — pass. `aws-for-fluent-bit` version 0.2.0 → 0.2.1. `make package` produced `aws-for-fluent-bit-0.2.1.tgz`.

`helm lint stable/aws-for-fluent-bit` — pass (default and with a luaScripts override).

`helm template test-fb stable/aws-for-fluent-bit --namespace kube-system` (default `luaScripts: {}`) — no luascripts ConfigMap, no `/fluent-bit/scripts/` volume or volumeMount, no `checksum/luascripts`.

`helm template` with a multiline `helpers.lua` override — ConfigMap YAML parses; script body is in `data.helpers.lua`; DaemonSet has the luascripts volume, mount at `/fluent-bit/scripts/`, and `checksum/luascripts`.

`kubeconform -strict -ignore-missing-schemas` and `kubeval --strict --ignore-missing-schemas` on default and lua override renders — pass.

Did not apply to a cluster (no EKS/kind install, no log-shipping e2e).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.